### PR TITLE
fix: hide live status on mobile

### DIFF
--- a/ui/src/app/analytics/page.module.css
+++ b/ui/src/app/analytics/page.module.css
@@ -750,7 +750,7 @@
   }
 
   .liveMeta {
-    align-items: flex-start;
+    display: none;
   }
 
   .toolbar {

--- a/ui/src/app/page.module.css
+++ b/ui/src/app/page.module.css
@@ -556,8 +556,7 @@
   }
 
   .liveMeta {
-    align-items: flex-start;
-    padding-top: 0;
+    display: none;
   }
 
   .header {


### PR DESCRIPTION
## summary
- hide the live status badge on mobile
- hide the last-updated UTC text on mobile
- keep desktop behavior unchanged

## testing
- not run (ui build unavailable locally:  in /home/ubuntu/innies/ui)
