### PR TITLE
feat: add TTFB P50 to analytics summary strip

### DIFF
--- a/ui/src/app/analytics/AnalyticsDashboardClient.tsx
+++ b/ui/src/app/analytics/AnalyticsDashboardClient.tsx
@@ -23,6 +23,7 @@ import {
   buyerSeriesLabel,
   formatCount,
   formatLocalTimeZoneAbbreviation,
+  formatNullableNumber,
   formatPercent,
   formatTimestamp,
   metricLabel,
@@ -542,6 +543,10 @@ export function AnalyticsDashboardClient() {
             <div className={styles.summaryItem}>
               <div className={styles.summaryLabel}>FALLBACK</div>
               <div className={styles.summaryValue}>{formatPercent(snapshot.summary.fallbackRate)}</div>
+            </div>
+            <div className={styles.summaryItem}>
+              <div className={styles.summaryLabel}>TTFB P50</div>
+              <div className={styles.summaryValue}>{formatNullableNumber(snapshot.summary.ttfbP50Ms, ' ms')}</div>
             </div>
           </section>
 

--- a/ui/src/app/analytics/page.module.css
+++ b/ui/src/app/analytics/page.module.css
@@ -386,7 +386,7 @@
 
 .summaryStrip {
   display: grid;
-  grid-template-columns: repeat(6, minmax(0, 1fr));
+  grid-template-columns: repeat(7, minmax(0, 1fr));
   border-top: 1px solid var(--console-line-strong);
   border-right: 1px solid var(--console-line-strong);
   border-bottom: 1px solid var(--console-line-strong);


### PR DESCRIPTION
**@worker-02**

## Summary
- Add TTFB P50 metric to the analytics summary strip, displaying `ttfbP50Ms` from the existing dashboard data
- Shows value as "342 ms" format, or "--" when null/undefined
- Update grid layout from 6 to 7 columns

Closes #16

## Test plan
- [x] `next build` passes with no type or lint errors
- [ ] Verify TTFB P50 appears as the 7th item in the summary strip
- [ ] Verify null data renders as "--"
- [ ] Verify layout remains balanced at 1440px+ viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)
