### PR TITLE
feat: unhide Util 24h and Maxed 7d columns in token table

### DIFF
--- a/ui/src/components/analytics/AnalyticsTables.tsx
+++ b/ui/src/components/analytics/AnalyticsTables.tsx
@@ -363,8 +363,7 @@ export function TokenTable({
               />
             </th>
             <th className={styles.numeric}>7D RESET</th>
-            {/* Re-enable Util 24h / Maxed 7d once the token table has room for more operator-only columns again. */}
-            {/* <th className={styles.numeric} aria-sort={sortAria(sort.key === 'utilizationRate24h', sort.direction)}>
+            <th className={styles.numeric} aria-sort={sortAria(sort.key === 'utilizationRate24h', sort.direction)}>
               <SortHeaderButton
                 active={sort.key === 'utilizationRate24h'}
                 direction={sort.direction}
@@ -381,7 +380,7 @@ export function TokenTable({
                 numeric
                 onClick={() => onSort('maxedEvents7d', 'desc')}
               />
-            </th> */}
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -438,9 +437,8 @@ export function TokenTable({
                   </span>
                 </td>
                 <td className={styles.numeric}>{formatShortTimestamp(row.sevenDayResetsAt)}</td>
-                {/* Re-enable the hidden token-health cells when we bring the Util 24h / Maxed 7d headers back. */}
-                {/* <td className={styles.numeric}>{formatPercent(row.utilizationRate24h)}</td>
-                <td className={styles.numeric}>{formatCount(row.maxedEvents7d)}</td> */}
+                <td className={styles.numeric}>{formatPercent(row.utilizationRate24h)}</td>
+                <td className={styles.numeric}>{formatCount(row.maxedEvents7d)}</td>
               </tr>
             );
           })}


### PR DESCRIPTION
**@worker-02**

## Summary
- Unhide the `Util 24h` and `Maxed 7d` columns in the analytics token table
- Both columns were commented out for layout clarity; the data, types, and sort infrastructure were already in place

## Test plan
- [ ] Verify `Util 24h` column renders `utilizationRate24h` as a percentage
- [ ] Verify `Maxed 7d` column renders `maxedEvents7d` as an integer count
- [ ] Confirm table layout is readable at 1440px+ without horizontal overflow
- [ ] Confirm no other functional changes to the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)
