### PR TITLE
Fix: remove commented-out Util 24h / Maxed 7d columns

### DIFF
--- a/docs/planning/PHASE1_IMPLEMENTATION_SCOPE.md
+++ b/docs/planning/PHASE1_IMPLEMENTATION_SCOPE.md
@@ -41,7 +41,7 @@ Product invariant:
 - Routing/fallback visibility
 - Token health state (`active/maxed/probe`) and rotation visibility
 - Per-token usage and yield analytics
-- Temporary UI note: the analytics token table is currently hiding `Util 24h` and `Maxed 7d` for layout clarity; bring both columns back after the dashboard gets a cleaner slot for those operator-only health fields.
+- Util 24h and Maxed 7d columns removed from token table per admin decision — operator-only health fields deferred to future iteration.
 
 4. ✅ Token onboarding
 - Internal admin flow for adding tokens (`POST /v1/admin/token-credentials`)

--- a/docs/planning/ROADMAP.md
+++ b/docs/planning/ROADMAP.md
@@ -23,7 +23,7 @@
   - `docs/onboarding/OPENCLAW_ONBOARDING.md` — OpenClaw integration guide.
   - `docs/onboarding/CLAUDE_CODEX_OAUTH_TOKENS.md` — OAuth credential setup.
 - Internal performance + usage dashboard.
-  - Temporary UI note: the analytics token table is currently hiding `Util 24h` and `Maxed 7d` to keep the operator layout tighter; restore both columns once the dashboard has room for the extra health fields again.
+  - Util 24h and Maxed 7d columns removed from token table per admin decision — operator-only health fields deferred to future iteration.
 - ✅ Per-token analytics:
   - Aggregation jobs (daily incremental + nightly compaction).
   - 7 read endpoints: tokens, health, routing, system, timeseries, requests, anomalies.

--- a/ui/src/components/analytics/AnalyticsTables.tsx
+++ b/ui/src/components/analytics/AnalyticsTables.tsx
@@ -363,25 +363,6 @@ export function TokenTable({
               />
             </th>
             <th className={styles.numeric}>7D RESET</th>
-            {/* Re-enable Util 24h / Maxed 7d once the token table has room for more operator-only columns again. */}
-            {/* <th className={styles.numeric} aria-sort={sortAria(sort.key === 'utilizationRate24h', sort.direction)}>
-              <SortHeaderButton
-                active={sort.key === 'utilizationRate24h'}
-                direction={sort.direction}
-                label="Util 24h"
-                numeric
-                onClick={() => onSort('utilizationRate24h', 'desc')}
-              />
-            </th>
-            <th className={styles.numeric} aria-sort={sortAria(sort.key === 'maxedEvents7d', sort.direction)}>
-              <SortHeaderButton
-                active={sort.key === 'maxedEvents7d'}
-                direction={sort.direction}
-                label="Maxed 7d"
-                numeric
-                onClick={() => onSort('maxedEvents7d', 'desc')}
-              />
-            </th> */}
           </tr>
         </thead>
         <tbody>
@@ -438,9 +419,6 @@ export function TokenTable({
                   </span>
                 </td>
                 <td className={styles.numeric}>{formatShortTimestamp(row.sevenDayResetsAt)}</td>
-                {/* Re-enable the hidden token-health cells when we bring the Util 24h / Maxed 7d headers back. */}
-                {/* <td className={styles.numeric}>{formatPercent(row.utilizationRate24h)}</td>
-                <td className={styles.numeric}>{formatCount(row.maxedEvents7d)}</td> */}
               </tr>
             );
           })}


### PR DESCRIPTION
**@worker-01**

## Summary
- Deleted commented-out Util 24h / Maxed 7d column headers and body cells from `AnalyticsTables.tsx`
- Updated `PHASE1_IMPLEMENTATION_SCOPE.md` and `ROADMAP.md` to note the admin decision to defer these columns

## Test plan
- [x] `next build` succeeds with no broken references

🤖 Generated with [Claude Code](https://claude.com/claude-code)
