### PR TITLE
Add SLO validation script for Phase 1 exit checklist

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -24,6 +24,7 @@ innies-buyer-key-create
 innies-buyer-preference-set
 innies-buyer-preference-get
 innies-buyer-preference-check
+innies-slo-check
 ```
 
 What they do:
@@ -38,6 +39,7 @@ What they do:
 - `innies-buyer-preference-set`: set a buyer key preference to `Claude Code`, `Codex`, or `null`
 - `innies-buyer-preference-get`: read the current buyer key preference
 - `innies-buyer-preference-check`: run the provider-preference canary after prompting for the expected provider (`Claude Code` or `Codex`)
+- `innies-slo-check`: query analytics endpoints and report Phase 1 SLO pass/fail (TTFB p95, timeout rate, success rate, fallback rate); optional arg sets the window (default `24h`); exits 0 if all SLOs pass, 1 if any fail
 
 Behavior:
 - org id auto-uses `INNIES_ORG_ID`

--- a/scripts/innies-slo-check.sh
+++ b/scripts/innies-slo-check.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_PATH" ]]; do
+  SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+  SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"
+  [[ "$SCRIPT_PATH" != /* ]] && SCRIPT_PATH="${SCRIPT_DIR}/${SCRIPT_PATH}"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+source "${SCRIPT_DIR}/_common.sh"
+
+ensure_admin_token
+
+WINDOW="${1:-24h}"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo 'error: jq is required for this command' >&2
+  exit 1
+fi
+
+# --- fetch system summary ---
+system_response="$(curl -sS -w '\n%{http_code}' \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  "${BASE_URL%/}/v1/admin/analytics/system?window=${WINDOW}")"
+
+system_status="$(printf '%s' "$system_response" | tail -n1)"
+system_body="$(printf '%s' "$system_response" | sed '$d')"
+
+if [[ "$system_status" != "200" ]]; then
+  echo "error: /v1/admin/analytics/system returned HTTP $system_status" >&2
+  echo "$system_body" >&2
+  exit 1
+fi
+
+# --- fetch routing summary ---
+routing_response="$(curl -sS -w '\n%{http_code}' \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  "${BASE_URL%/}/v1/admin/analytics/tokens/routing?window=${WINDOW}")"
+
+routing_status="$(printf '%s' "$routing_response" | tail -n1)"
+routing_body="$(printf '%s' "$routing_response" | sed '$d')"
+
+if [[ "$routing_status" != "200" ]]; then
+  echo "error: /v1/admin/analytics/tokens/routing returned HTTP $routing_status" >&2
+  echo "$routing_body" >&2
+  exit 1
+fi
+
+# --- extract metrics ---
+ttfb_p95="$(printf '%s' "$system_body" | jq -r '.ttfbP95Ms // empty')"
+error_rate="$(printf '%s' "$system_body" | jq -r '.errorRate // 0')"
+system_fallback_rate="$(printf '%s' "$system_body" | jq -r '.fallbackRate // 0')"
+total_requests="$(printf '%s' "$system_body" | jq -r '.totalRequests // 0')"
+
+# Compute fallback rate from routing tokens as cross-check
+routing_fallback_rate="$(printf '%s' "$routing_body" | jq -r '
+  [.tokens[] | {f: (.fallbackCount // 0), t: (.totalAttempts // 0)}]
+  | {total_fallbacks: (map(.f) | add // 0), total_attempts: (map(.t) | add // 0)}
+  | if .total_attempts == 0 then 0
+    else (.total_fallbacks / .total_attempts)
+    end')"
+
+# Use system-level fallback rate as primary
+fallback_rate="$system_fallback_rate"
+
+# Derive timeout rate and success rate from errorRate
+# errorRate encompasses timeouts + errors; the API does not separate them
+timeout_rate="$error_rate"
+success_rate="$(printf '%s' "$error_rate" | jq -n --arg er "$error_rate" '(1 - ($er | tonumber))')"
+
+# --- SLO targets ---
+SLO_TTFB_P95=8000
+SLO_TIMEOUT_RATE=0.02
+SLO_SUCCESS_RATE=0.95
+SLO_FALLBACK_RATE=0.20
+
+# --- evaluate pass/fail ---
+exit_code=0
+
+if [[ -z "$ttfb_p95" ]]; then
+  ttfb_pass="N/A"
+  ttfb_display="no data"
+else
+  if jq -n --argjson v "$ttfb_p95" --argjson t "$SLO_TTFB_P95" '$v <= $t' | grep -q true; then
+    ttfb_pass="PASS"
+  else
+    ttfb_pass="FAIL"
+    exit_code=1
+  fi
+  ttfb_display="${ttfb_p95} ms"
+fi
+
+if jq -n --argjson v "$timeout_rate" --argjson t "$SLO_TIMEOUT_RATE" '$v <= $t' | grep -q true; then
+  timeout_pass="PASS"
+else
+  timeout_pass="FAIL"
+  exit_code=1
+fi
+timeout_display="$(jq -n --argjson v "$timeout_rate" '($v * 100 * 100 | round) / 100 | tostring + "%"')"
+
+if jq -n --argjson v "$success_rate" --argjson t "$SLO_SUCCESS_RATE" '$v >= $t' | grep -q true; then
+  success_pass="PASS"
+else
+  success_pass="FAIL"
+  exit_code=1
+fi
+success_display="$(jq -n --argjson v "$success_rate" '($v * 100 * 100 | round) / 100 | tostring + "%"')"
+
+fallback_flag="OK"
+if jq -n --argjson v "$fallback_rate" --argjson t "$SLO_FALLBACK_RATE" '$v > $t' | grep -q true; then
+  fallback_flag="FLAG"
+fi
+fallback_display="$(jq -n --argjson v "$fallback_rate" '($v * 100 * 100 | round) / 100 | tostring + "%"')"
+
+# --- output ---
+echo ""
+echo "SLO Check (window: ${WINDOW}, requests: ${total_requests})"
+echo "================================================================"
+printf '%-28s %-12s %-12s %s\n' "Metric" "Target" "Actual" "Result"
+printf '%-28s %-12s %-12s %s\n' "---" "---" "---" "---"
+printf '%-28s %-12s %-12s %s\n' "First-byte latency p95" "<= 8000 ms" "$ttfb_display" "$ttfb_pass"
+printf '%-28s %-12s %-12s %s\n' "Timeout rate" "<= 2.0%" "$timeout_display" "$timeout_pass"
+printf '%-28s %-12s %-12s %s\n' "Tool-loop success rate" ">= 95.0%" "$success_display" "$success_pass"
+printf '%-28s %-12s %-12s %s\n' "Fallback rate" "flag > 20%" "$fallback_display" "$fallback_flag"
+echo "================================================================"
+
+if [[ "$exit_code" -eq 0 ]]; then
+  echo "All SLOs passed."
+else
+  echo "One or more SLOs failed."
+fi
+
+echo ""
+echo "(routing cross-check: per-token aggregate fallback rate = $(jq -n --argjson v "$routing_fallback_rate" '($v * 100 * 100 | round) / 100 | tostring + "%"'))"
+
+exit "$exit_code"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,6 +17,7 @@ ln -sf "${ROOT_DIR}/scripts/innies-buyer-key-create.sh" "${BIN_DIR}/innies-buyer
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-set.sh" "${BIN_DIR}/innies-buyer-preference-set"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-get.sh" "${BIN_DIR}/innies-buyer-preference-get"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-check.sh" "${BIN_DIR}/innies-buyer-preference-check"
+ln -sf "${ROOT_DIR}/scripts/innies-slo-check.sh" "${BIN_DIR}/innies-slo-check"
 
 rm -f \
   "${BIN_DIR}/innies-admin" \
@@ -47,6 +48,7 @@ echo "  ${BIN_DIR}/innies-buyer-key-create -> ${ROOT_DIR}/scripts/innies-buyer-k
 echo "  ${BIN_DIR}/innies-buyer-preference-set -> ${ROOT_DIR}/scripts/innies-buyer-preference-set.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-get -> ${ROOT_DIR}/scripts/innies-buyer-preference-get.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-check -> ${ROOT_DIR}/scripts/innies-buyer-preference-check.sh"
+echo "  ${BIN_DIR}/innies-slo-check -> ${ROOT_DIR}/scripts/innies-slo-check.sh"
 echo
 echo 'If command not found, add ~/.local/bin to PATH:'
 echo '  export PATH="$HOME/.local/bin:$PATH"'


### PR DESCRIPTION
**@worker-01**

## Summary
- Add `innies-slo-check.sh` — queries `/v1/admin/analytics/system` and `/tokens/routing` for Phase 1 SLO metrics
- Outputs a formatted table with metric, target, actual value, and pass/fail
- Exits 0 if all SLOs pass, 1 if any fail
- Optional window argument (defaults to `24h`)
- Registered in `install.sh` and documented in `scripts/README.md`

## Test plan
- [ ] Run `./scripts/innies-slo-check.sh` against a live instance with `INNIES_BASE_URL` and `INNIES_ADMIN_API_KEY` set
- [ ] Verify output table shows all four SLO metrics with correct targets
- [ ] Verify exit code is 0 when all SLOs pass
- [ ] Verify exit code is 1 when any SLO fails
- [ ] Run with custom window: `./scripts/innies-slo-check.sh 7d`

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)
