### PR TITLE
Fix compat 5xx credential failover for strict upstream passthrough

### DIFF
--- a/api/src/routes/proxy.ts
+++ b/api/src/routes/proxy.ts
@@ -1883,6 +1883,11 @@ async function executeTokenModeNonStreaming(input: {
   let terminalCompatError: ReturnType<typeof mapOpenAiErrorToAnthropic> | null = null;
   let terminalCompatCredentialId: string | null = null;
   let terminalCompatAttemptNo = 0;
+  let terminalStrictPassthroughStatus: number | null = null;
+  let terminalStrictPassthroughContentType: string | null = null;
+  let terminalStrictPassthroughData: unknown = null;
+  let terminalStrictPassthroughCredentialId: string | null = null;
+  let terminalStrictPassthroughAttemptNo = 0;
   for (const initialCredential of credentials) {
     attemptNo += 1;
     let credential = initialCredential;
@@ -2228,17 +2233,13 @@ async function executeTokenModeNonStreaming(input: {
             ttfbMs
           });
 
-          return {
-            requestId,
-            keyId: credential.id,
-            attemptNo,
-            upstreamStatus: status,
-            usageUnits: 0,
-            contentType,
-            data,
-            routeKind: 'token_credential',
-            alreadyRecorded: true
-          };
+          terminalStrictPassthroughStatus = status;
+          terminalStrictPassthroughContentType = contentType;
+          terminalStrictPassthroughData = data;
+          terminalStrictPassthroughCredentialId = credential.id;
+          terminalStrictPassthroughAttemptNo = attemptNo;
+          await logAttemptFailure({ kind: 'server_error', statusCode: status, message: 'upstream server error' }, ttfbMs);
+          break;
         }
 
         if (compatTranslation) {
@@ -2421,6 +2422,24 @@ async function executeTokenModeNonStreaming(input: {
     return compatTerminalResult;
   }
 
+  const strictPassthroughResult = terminalStrictPassthroughStatus != null
+    ? {
+      requestId,
+      keyId: terminalStrictPassthroughCredentialId,
+      attemptNo: terminalStrictPassthroughAttemptNo,
+      upstreamStatus: terminalStrictPassthroughStatus,
+      usageUnits: 0,
+      contentType: terminalStrictPassthroughContentType!,
+      data: terminalStrictPassthroughData,
+      routeKind: 'token_credential' as const,
+      alreadyRecorded: true
+    }
+    : null;
+
+  if (allowCompatTerminalErrorResponse && strictPassthroughResult) {
+    return strictPassthroughResult;
+  }
+
   if (sawAuthFailure) {
     if (lastAuthFailure) {
       logAuthFailureAudit({
@@ -2442,14 +2461,16 @@ async function executeTokenModeNonStreaming(input: {
         provider,
         model,
         lastAuthStatus,
-        ...(compatTerminalResult ? { compatTerminalResult } : {})
+        ...(compatTerminalResult ? { compatTerminalResult } : {}),
+        ...(strictPassthroughResult ? { compatTerminalResult: strictPassthroughResult } : {})
       });
   }
 
   throw new AppError('capacity_unavailable', 429, 'All token credential attempts exhausted', {
     provider,
     model,
-    ...(compatTerminalResult ? { compatTerminalResult } : {})
+    ...(compatTerminalResult ? { compatTerminalResult } : {}),
+    ...(strictPassthroughResult ? { compatTerminalResult: strictPassthroughResult } : {})
   });
 }
 
@@ -2523,6 +2544,11 @@ async function executeTokenModeStreaming(input: {
   let terminalCompatError: ReturnType<typeof mapOpenAiErrorToAnthropic> | null = null;
   let terminalCompatCredentialId: string | null = null;
   let terminalCompatAttemptNo = 0;
+  let terminalStrictPassthroughStatus: number | null = null;
+  let terminalStrictPassthroughContentType: string | null = null;
+  let terminalStrictPassthroughData: unknown = null;
+  let terminalStrictPassthroughCredentialId: string | null = null;
+  let terminalStrictPassthroughAttemptNo = 0;
 
   for (const initialCredential of credentials) {
     attemptNo += 1;
@@ -2851,6 +2877,20 @@ async function executeTokenModeStreaming(input: {
           terminalCompatCredentialId = credential.id;
           terminalCompatAttemptNo = attemptNo;
         }
+        await logAttemptFailure({ kind: 'server_error', statusCode: status, message: 'upstream server error' }, Math.max(0, Math.round(upstreamHeadersAt - dispatchStartedAt)));
+        break;
+      }
+
+      if (status >= 500 && strictUpstreamPassthrough) {
+        const contentType = upstreamResponse.headers.get('content-type') ?? 'application/json';
+        const data = contentType.includes('application/json')
+          ? await upstreamResponse.json().catch(() => ({}))
+          : await upstreamResponse.text();
+        terminalStrictPassthroughStatus = status;
+        terminalStrictPassthroughContentType = contentType;
+        terminalStrictPassthroughData = data;
+        terminalStrictPassthroughCredentialId = credential.id;
+        terminalStrictPassthroughAttemptNo = attemptNo;
         await logAttemptFailure({ kind: 'server_error', statusCode: status, message: 'upstream server error' }, Math.max(0, Math.round(upstreamHeadersAt - dispatchStartedAt)));
         break;
       }
@@ -3583,6 +3623,24 @@ async function executeTokenModeStreaming(input: {
     return compatTerminalResult;
   }
 
+  const strictPassthroughResult = terminalStrictPassthroughStatus != null
+    ? {
+      requestId,
+      keyId: terminalStrictPassthroughCredentialId,
+      attemptNo: terminalStrictPassthroughAttemptNo,
+      upstreamStatus: terminalStrictPassthroughStatus,
+      usageUnits: 0,
+      contentType: terminalStrictPassthroughContentType!,
+      data: terminalStrictPassthroughData,
+      routeKind: 'token_credential' as const,
+      alreadyRecorded: true
+    }
+    : null;
+
+  if (allowCompatTerminalErrorResponse && strictPassthroughResult) {
+    return strictPassthroughResult;
+  }
+
   if (sawAuthFailure) {
     if (lastAuthFailure) {
       logAuthFailureAudit({
@@ -3604,14 +3662,16 @@ async function executeTokenModeStreaming(input: {
         provider,
         model,
         lastAuthStatus,
-        ...(compatTerminalResult ? { compatTerminalResult } : {})
+        ...(compatTerminalResult ? { compatTerminalResult } : {}),
+        ...(strictPassthroughResult ? { compatTerminalResult: strictPassthroughResult } : {})
       });
   }
 
   throw new AppError('capacity_unavailable', 429, 'All token credential attempts exhausted', {
     provider,
     model,
-    ...(compatTerminalResult ? { compatTerminalResult } : {})
+    ...(compatTerminalResult ? { compatTerminalResult } : {}),
+    ...(strictPassthroughResult ? { compatTerminalResult: strictPassthroughResult } : {})
   });
 }
 

--- a/api/tests/anthropicCompat.route.test.ts
+++ b/api/tests/anthropicCompat.route.test.ts
@@ -1513,16 +1513,63 @@ describe('anthropic compat route', () => {
     upstreamSpy.mockRestore();
   });
 
-  it('passes through upstream 5xx status/body for compat route', async () => {
-    const upstreamSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({
+  it('fails over to second credential on upstream 5xx for compat route (non-streaming)', async () => {
+    const anthropicCreds = [
+      {
+        id: 'cred-a',
+        orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+        provider: 'anthropic',
+        authScheme: 'bearer',
+        accessToken: 'sk-ant-oat01-first',
+        refreshToken: null,
+        expiresAt: new Date('2026-03-02T00:00:00Z'),
+        status: 'active',
+        rotationVersion: 2,
+        createdAt: new Date('2026-03-01T00:00:00Z'),
+        updatedAt: new Date('2026-03-01T00:00:00Z'),
+        revokedAt: null,
+        monthlyContributionLimitUnits: null,
+        monthlyContributionUsedUnits: 0,
+        monthlyWindowStartAt: new Date('2026-03-01T00:00:00Z')
+      } as any,
+      {
+        id: 'cred-b',
+        orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+        provider: 'anthropic',
+        authScheme: 'bearer',
+        accessToken: 'sk-ant-oat01-second',
+        refreshToken: null,
+        expiresAt: new Date('2026-03-02T00:00:00Z'),
+        status: 'active',
+        rotationVersion: 1,
+        createdAt: new Date('2026-03-01T00:00:00Z'),
+        updatedAt: new Date('2026-03-01T00:00:00Z'),
+        revokedAt: null,
+        monthlyContributionLimitUnits: null,
+        monthlyContributionUsedUnits: 0,
+        monthlyWindowStartAt: new Date('2026-03-01T00:00:00Z')
+      } as any
+    ];
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'listActiveForRouting').mockImplementation(
+      async (_orgId: string, provider: string) => provider === 'anthropic' ? anthropicCreds : []
+    );
+    const upstreamSpy = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(JSON.stringify({
         type: 'error',
         error: { type: 'api_error', message: 'upstream outage' }
       }), {
         status: 503,
         headers: { 'content-type': 'application/json' }
-      })
-    );
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        id: 'msg_ok',
+        type: 'message',
+        usage: { input_tokens: 5, output_tokens: 5 },
+        content: [{ type: 'text', text: 'hello' }]
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' }
+      }));
 
     const req = createMockReq({
       method: 'POST',
@@ -1543,9 +1590,8 @@ describe('anthropic compat route', () => {
     await invoke(handlers[1], req, res);
     await invoke(handlers[2], req, res);
 
-    expect(upstreamSpy).toHaveBeenCalledTimes(1);
-    expect(res.statusCode).toBe(503);
-    expect((res.body as any).error?.type).toBe('api_error');
+    expect(upstreamSpy).toHaveBeenCalledTimes(2);
+    expect(res.statusCode).toBe(200);
 
     upstreamSpy.mockRestore();
   });
@@ -2155,6 +2201,279 @@ describe('anthropic compat route', () => {
     expect(body?.type).toBe('error');
     expect(typeof body?.error?.type).toBe('string');
     expect(typeof body?.error?.message).toBe('string');
+    upstreamSpy.mockRestore();
+  });
+
+  it('fails over to second credential on upstream 5xx for compat route (streaming)', async () => {
+    const anthropicCreds = [
+      {
+        id: 'cred-a',
+        orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+        provider: 'anthropic',
+        authScheme: 'bearer',
+        accessToken: 'sk-ant-oat01-first',
+        refreshToken: null,
+        expiresAt: new Date('2026-03-02T00:00:00Z'),
+        status: 'active',
+        rotationVersion: 2,
+        createdAt: new Date('2026-03-01T00:00:00Z'),
+        updatedAt: new Date('2026-03-01T00:00:00Z'),
+        revokedAt: null,
+        monthlyContributionLimitUnits: null,
+        monthlyContributionUsedUnits: 0,
+        monthlyWindowStartAt: new Date('2026-03-01T00:00:00Z')
+      } as any,
+      {
+        id: 'cred-b',
+        orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+        provider: 'anthropic',
+        authScheme: 'bearer',
+        accessToken: 'sk-ant-oat01-second',
+        refreshToken: null,
+        expiresAt: new Date('2026-03-02T00:00:00Z'),
+        status: 'active',
+        rotationVersion: 1,
+        createdAt: new Date('2026-03-01T00:00:00Z'),
+        updatedAt: new Date('2026-03-01T00:00:00Z'),
+        revokedAt: null,
+        monthlyContributionLimitUnits: null,
+        monthlyContributionUsedUnits: 0,
+        monthlyWindowStartAt: new Date('2026-03-01T00:00:00Z')
+      } as any
+    ];
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'listActiveForRouting').mockImplementation(
+      async (_orgId: string, provider: string) => provider === 'anthropic' ? anthropicCreds : []
+    );
+    const upstreamSpy = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        type: 'error',
+        error: { type: 'api_error', message: 'upstream outage' }
+      }), {
+        status: 500,
+        headers: { 'content-type': 'application/json' }
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        id: 'msg_stream_ok',
+        type: 'message',
+        usage: { input_tokens: 5, output_tokens: 5 },
+        content: [{ type: 'text', text: 'hello' }]
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' }
+      }));
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/messages',
+      headers: {
+        authorization: 'Bearer in_test_token',
+        'content-type': 'application/json'
+      },
+      body: {
+        model: 'claude-opus-4-6',
+        stream: true,
+        max_tokens: 16,
+        messages: [{ role: 'user', content: 'hi' }]
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(handlers[0], req, res);
+    await invoke(handlers[1], req, res);
+    await invoke(handlers[2], req, res);
+
+    expect(upstreamSpy).toHaveBeenCalledTimes(2);
+    expect(res.statusCode).toBe(200);
+
+    upstreamSpy.mockRestore();
+  });
+
+  it('returns terminal 5xx passthrough when all compat credentials fail (non-streaming)', async () => {
+    const anthropicCreds = [
+      {
+        id: 'cred-a',
+        orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+        provider: 'anthropic',
+        authScheme: 'bearer',
+        accessToken: 'sk-ant-oat01-first',
+        refreshToken: null,
+        expiresAt: new Date('2026-03-02T00:00:00Z'),
+        status: 'active',
+        rotationVersion: 2,
+        createdAt: new Date('2026-03-01T00:00:00Z'),
+        updatedAt: new Date('2026-03-01T00:00:00Z'),
+        revokedAt: null,
+        monthlyContributionLimitUnits: null,
+        monthlyContributionUsedUnits: 0,
+        monthlyWindowStartAt: new Date('2026-03-01T00:00:00Z')
+      } as any,
+      {
+        id: 'cred-b',
+        orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+        provider: 'anthropic',
+        authScheme: 'bearer',
+        accessToken: 'sk-ant-oat01-second',
+        refreshToken: null,
+        expiresAt: new Date('2026-03-02T00:00:00Z'),
+        status: 'active',
+        rotationVersion: 1,
+        createdAt: new Date('2026-03-01T00:00:00Z'),
+        updatedAt: new Date('2026-03-01T00:00:00Z'),
+        revokedAt: null,
+        monthlyContributionLimitUnits: null,
+        monthlyContributionUsedUnits: 0,
+        monthlyWindowStartAt: new Date('2026-03-01T00:00:00Z')
+      } as any
+    ];
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'listActiveForRouting').mockImplementation(
+      async (_orgId: string, provider: string) => provider === 'anthropic' ? anthropicCreds : []
+    );
+    const upstreamSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      new Response(JSON.stringify({
+        type: 'error',
+        error: { type: 'api_error', message: 'upstream outage' }
+      }), {
+        status: 503,
+        headers: { 'content-type': 'application/json' }
+      })
+    );
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/messages',
+      headers: {
+        authorization: 'Bearer in_test_token',
+        'content-type': 'application/json'
+      },
+      body: {
+        model: 'claude-opus-4-6',
+        max_tokens: 16,
+        messages: [{ role: 'user', content: 'hi' }]
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(handlers[0], req, res);
+    await invoke(handlers[1], req, res);
+    await invoke(handlers[2], req, res);
+
+    expect(upstreamSpy).toHaveBeenCalledTimes(2);
+    expect(res.statusCode).toBe(503);
+    expect((res.body as any).error?.type).toBe('api_error');
+
+    upstreamSpy.mockRestore();
+  });
+
+  it('returns terminal 5xx passthrough when all compat credentials fail (streaming)', async () => {
+    const anthropicCreds = [
+      {
+        id: 'cred-a',
+        orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+        provider: 'anthropic',
+        authScheme: 'bearer',
+        accessToken: 'sk-ant-oat01-first',
+        refreshToken: null,
+        expiresAt: new Date('2026-03-02T00:00:00Z'),
+        status: 'active',
+        rotationVersion: 2,
+        createdAt: new Date('2026-03-01T00:00:00Z'),
+        updatedAt: new Date('2026-03-01T00:00:00Z'),
+        revokedAt: null,
+        monthlyContributionLimitUnits: null,
+        monthlyContributionUsedUnits: 0,
+        monthlyWindowStartAt: new Date('2026-03-01T00:00:00Z')
+      } as any,
+      {
+        id: 'cred-b',
+        orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+        provider: 'anthropic',
+        authScheme: 'bearer',
+        accessToken: 'sk-ant-oat01-second',
+        refreshToken: null,
+        expiresAt: new Date('2026-03-02T00:00:00Z'),
+        status: 'active',
+        rotationVersion: 1,
+        createdAt: new Date('2026-03-01T00:00:00Z'),
+        updatedAt: new Date('2026-03-01T00:00:00Z'),
+        revokedAt: null,
+        monthlyContributionLimitUnits: null,
+        monthlyContributionUsedUnits: 0,
+        monthlyWindowStartAt: new Date('2026-03-01T00:00:00Z')
+      } as any
+    ];
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'listActiveForRouting').mockImplementation(
+      async (_orgId: string, provider: string) => provider === 'anthropic' ? anthropicCreds : []
+    );
+    const upstreamSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      new Response(JSON.stringify({
+        type: 'error',
+        error: { type: 'api_error', message: 'upstream outage' }
+      }), {
+        status: 503,
+        headers: { 'content-type': 'application/json' }
+      })
+    );
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/messages',
+      headers: {
+        authorization: 'Bearer in_test_token',
+        'content-type': 'application/json'
+      },
+      body: {
+        model: 'claude-opus-4-6',
+        stream: true,
+        max_tokens: 16,
+        messages: [{ role: 'user', content: 'hi' }]
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(handlers[0], req, res);
+    await invoke(handlers[1], req, res);
+    await invoke(handlers[2], req, res);
+
+    expect(upstreamSpy).toHaveBeenCalledTimes(2);
+    expect(res.statusCode).toBe(503);
+    expect((res.body as any)?.error?.type).toBe('api_error');
+
+    upstreamSpy.mockRestore();
+  });
+
+  it('does not change auth 401/403 retry behavior on compat route', async () => {
+    const upstreamSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({
+        type: 'error',
+        error: { type: 'authentication_error', message: 'invalid x-api-key' }
+      }), {
+        status: 401,
+        headers: { 'content-type': 'application/json' }
+      })
+    );
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/messages',
+      headers: {
+        authorization: 'Bearer in_test_token',
+        'content-type': 'application/json'
+      },
+      body: {
+        model: 'claude-opus-4-6',
+        max_tokens: 16,
+        messages: [{ role: 'user', content: 'hi' }]
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(handlers[0], req, res);
+    await invoke(handlers[1], req, res);
+    await invoke(handlers[2], req, res);
+
+    // 401 should still be handled as auth failure, not as a 5xx failover
+    expect(res.statusCode).toBe(401);
+
     upstreamSpy.mockRestore();
   });
 });


### PR DESCRIPTION
**@worker-02**

## Summary
- Fix compat 5xx credential failover in `proxy.ts` so strict upstream passthrough requests try all credentials before returning an error
- Non-streaming path: replace immediate `return` on 5xx with save-context-and-`break` to try next credential
- Streaming path: add parallel handler for `status >= 500 && strictUpstreamPassthrough` that saves context and breaks
- After credential exhaustion, terminal 5xx body is returned in Anthropic format (or passed to provider fallback via `capacity_unavailable` throw)
- Update existing buggy test that asserted only 1 fetch call; add 5 new regression tests

## Test plan
- [x] Non-streaming credential failover: first credential 503, second 200 → request succeeds, fetch called twice
- [x] Streaming credential failover: first credential 500, second 200 → request succeeds, fetch called twice
- [x] Terminal 5xx passthrough (non-streaming): all credentials 503, no alternate provider → client gets 503 with Anthropic error body
- [x] Terminal 5xx passthrough (streaming): same scenario for streaming path
- [x] Auth 401 behavior unchanged: 401 still handled as auth failure, not 5xx failover
- [x] All 46 anthropicCompat tests pass
- [x] All 45 proxy.tokenMode tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
