### PR TITLE
fix: avoid duplicate compat 5xx passthrough events

### DIFF
--- a/api/src/routes/proxy.ts
+++ b/api/src/routes/proxy.ts
@@ -2238,7 +2238,7 @@ async function executeTokenModeNonStreaming(input: {
           terminalStrictPassthroughData = data;
           terminalStrictPassthroughCredentialId = credential.id;
           terminalStrictPassthroughAttemptNo = attemptNo;
-          await logAttemptFailure({ kind: 'server_error', statusCode: status, message: 'upstream server error' }, ttfbMs);
+          // This branch already recorded the passthrough failure explicitly above.
           break;
         }
 

--- a/api/tests/anthropicCompat.route.test.ts
+++ b/api/tests/anthropicCompat.route.test.ts
@@ -1590,7 +1590,18 @@ describe('anthropic compat route', () => {
     await invoke(handlers[1], req, res);
     await invoke(handlers[2], req, res);
 
+    const routingEventCalls = (runtimeModule.runtime.repos.routingEvents.insert as any).mock.calls
+      .map(([event]: [any]) => event);
+    const firstAttemptEvents = routingEventCalls.filter((event: any) => event.attemptNo === 1);
+
     expect(upstreamSpy).toHaveBeenCalledTimes(2);
+    expect(routingEventCalls).toHaveLength(2);
+    expect(firstAttemptEvents).toHaveLength(1);
+    expect(firstAttemptEvents[0]).toMatchObject({
+      attemptNo: 1,
+      upstreamStatus: 503,
+      errorCode: 'upstream_5xx_passthrough'
+    });
     expect(res.statusCode).toBe(200);
 
     upstreamSpy.mockRestore();


### PR DESCRIPTION
## Summary
- remove the duplicate generic routing-event logger from the non-streaming strict passthrough 5xx branch
- keep the explicit `upstream_5xx_passthrough` event and existing terminal passthrough state/failover behavior
- extend compat failover coverage to assert the first failed attempt records exactly one routing event before the second credential succeeds

## Testing
- cd api && npm test -- anthropicCompat.route.test.ts -t "fails over to second credential on upstream 5xx for compat route \(non-streaming\)"
- cd api && npm test

Refs #46