### PR TITLE
fix: use routing aggregate for SLO fallback

### DIFF
--- a/scripts/innies-slo-check.sh
+++ b/scripts/innies-slo-check.sh
@@ -50,7 +50,6 @@ fi
 # --- extract metrics ---
 ttfb_p95="$(printf '%s' "$system_body" | jq -r '.ttfbP95Ms // empty')"
 error_rate="$(printf '%s' "$system_body" | jq -r '.errorRate // 0')"
-system_fallback_rate="$(printf '%s' "$system_body" | jq -r '.fallbackRate // 0')"
 total_requests="$(printf '%s' "$system_body" | jq -r '.totalRequests // 0')"
 
 # Compute fallback rate from routing tokens as cross-check
@@ -61,8 +60,8 @@ routing_fallback_rate="$(printf '%s' "$routing_body" | jq -r '
     else (.total_fallbacks / .total_attempts)
     end')"
 
-# Use system-level fallback rate as primary
-fallback_rate="$system_fallback_rate"
+# Use the routing aggregate as the fallback source of truth for Phase 1.
+fallback_rate="$routing_fallback_rate"
 
 # Derive timeout rate and success rate from errorRate
 # errorRate encompasses timeouts + errors; the API does not separate them
@@ -131,14 +130,12 @@ printf '%-28s %-12s %-12s %s\n' "Fallback rate" "flag > 20%" "$fallback_display"
 echo "================================================================"
 echo "* timeout_rate and success_rate are derived from the same errorRate metric."
 echo "  The API does not yet separate timeouts from other errors."
+echo "* Fallback source: /v1/admin/analytics/tokens/routing per-token aggregate."
 
 if [[ "$exit_code" -eq 0 ]]; then
   echo "All SLOs passed."
 else
   echo "One or more SLOs failed."
 fi
-
-echo ""
-echo "(routing cross-check: per-token aggregate fallback rate = $(jq -n --argjson v "$routing_fallback_rate" '($v * 100 * 100 | round) / 100 | tostring + "%"'))"
 
 exit "$exit_code"

--- a/scripts/tests/innies-slo-check.test.sh
+++ b/scripts/tests/innies-slo-check.test.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+cat > "${tmp_dir}/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+url="${*: -1}"
+
+case "$url" in
+  *"/v1/admin/analytics/system?window=24h")
+    cat <<'JSON'
+{"ttfbP95Ms":1000,"errorRate":0.01,"fallbackRate":0.05,"totalRequests":40}
+200
+JSON
+    ;;
+  *"/v1/admin/analytics/tokens/routing?window=24h")
+    cat <<'JSON'
+{"tokens":[
+  {"fallbackCount":3,"totalAttempts":10},
+  {"fallbackCount":2,"totalAttempts":10}
+]}
+200
+JSON
+    ;;
+  *)
+    echo "unexpected curl url: $url" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "${tmp_dir}/curl"
+
+output="$(
+  PATH="${tmp_dir}:$PATH" \
+  INNIES_ADMIN_API_KEY="admin-token" \
+  INNIES_ENV_FILE="${tmp_dir}/missing.env" \
+  bash "${ROOT_DIR}/scripts/innies-slo-check.sh"
+)"
+
+fallback_line="$(printf '%s\n' "$output" | awk '$1 == "Fallback" && $2 == "rate" { print; exit }')"
+
+if [[ "$fallback_line" != *"25%"* ]]; then
+  echo "expected fallback line to use routing-derived 25% aggregate" >&2
+  echo "$output" >&2
+  exit 1
+fi
+
+if [[ "$fallback_line" != *"FLAG"* ]]; then
+  echo "expected fallback line to remain flagged above 20%" >&2
+  echo "$output" >&2
+  exit 1
+fi
+
+if [[ "$output" != *"Fallback source: /v1/admin/analytics/tokens/routing per-token aggregate."* ]]; then
+  echo "expected output to document the routing-derived fallback source" >&2
+  echo "$output" >&2
+  exit 1
+fi
+
+echo "PASS: innies-slo-check reports routing-derived fallback rate in the main SLO table"


### PR DESCRIPTION
## Summary
- make `scripts/innies-slo-check.sh` print the fallback rate from the routing per-token aggregate instead of `system.fallbackRate`
- add a regression test that stubs both analytics endpoints and proves the main SLO table reflects the routing-derived fallback value
- repurpose the trailing note so the script output explicitly names `/v1/admin/analytics/tokens/routing` as the fallback source

## Verification
- `bash scripts/tests/innies-slo-check.test.sh`
- `bash -n scripts/innies-slo-check.sh scripts/tests/innies-slo-check.test.sh`
- `git diff --check HEAD~1 HEAD`

Refs #63