### PR TITLE
fix: use routing analytics for SLO fallback rate

### DIFF
--- a/scripts/innies-slo-check.sh
+++ b/scripts/innies-slo-check.sh
@@ -50,10 +50,10 @@ fi
 # --- extract metrics ---
 ttfb_p95="$(printf '%s' "$system_body" | jq -r '.ttfbP95Ms // empty')"
 error_rate="$(printf '%s' "$system_body" | jq -r '.errorRate // 0')"
-system_fallback_rate="$(printf '%s' "$system_body" | jq -r '.fallbackRate // 0')"
 total_requests="$(printf '%s' "$system_body" | jq -r '.totalRequests // 0')"
 
-# Compute fallback rate from routing tokens as cross-check
+# Compute fallback rate from routing tokens. Phase 1 SLO fallback tracking uses
+# the routing endpoint as the source of truth.
 routing_fallback_rate="$(printf '%s' "$routing_body" | jq -r '
   [.tokens[] | {f: (.fallbackCount // 0), t: (.totalAttempts // 0)}]
   | {total_fallbacks: (map(.f) | add // 0), total_attempts: (map(.t) | add // 0)}
@@ -61,8 +61,7 @@ routing_fallback_rate="$(printf '%s' "$routing_body" | jq -r '
     else (.total_fallbacks / .total_attempts)
     end')"
 
-# Use system-level fallback rate as primary
-fallback_rate="$system_fallback_rate"
+fallback_rate="$routing_fallback_rate"
 
 # Derive timeout rate and success rate from errorRate
 # errorRate encompasses timeouts + errors; the API does not separate them
@@ -137,8 +136,5 @@ if [[ "$exit_code" -eq 0 ]]; then
 else
   echo "One or more SLOs failed."
 fi
-
-echo ""
-echo "(routing cross-check: per-token aggregate fallback rate = $(jq -n --argjson v "$routing_fallback_rate" '($v * 100 * 100 | round) / 100 | tostring + "%"'))"
 
 exit "$exit_code"

--- a/scripts/tests/innies-slo-check.test.sh
+++ b/scripts/tests/innies-slo-check.test.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="${ROOT_DIR}/scripts/innies-slo-check.sh"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+cat >"${tmp_dir}/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+url="${@: -1}"
+
+if [[ "$url" == *"/v1/admin/analytics/system?window=24h" ]]; then
+  printf '%s\n%s\n' '{"ttfbP95Ms":5000,"errorRate":0.01,"fallbackRate":0.01,"totalRequests":100}' "200"
+  exit 0
+fi
+
+if [[ "$url" == *"/v1/admin/analytics/tokens/routing?window=24h" ]]; then
+  printf '%s\n%s\n' '{"tokens":[{"fallbackCount":30,"totalAttempts":100}]}' "200"
+  exit 0
+fi
+
+printf 'unexpected curl URL: %s\n' "$url" >&2
+exit 1
+EOF
+
+chmod +x "${tmp_dir}/curl"
+
+set +e
+output="$(
+  PATH="${tmp_dir}:$PATH" \
+  INNIES_ADMIN_API_KEY=test-admin-token \
+  INNIES_BASE_URL=http://stub.invalid \
+  bash "$SCRIPT_PATH" 2>&1
+)"
+status=$?
+set -e
+
+if [[ "$status" -ne 0 ]]; then
+  printf 'expected exit 0, got %s\n%s\n' "$status" "$output" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$output" | grep -Eq 'Fallback rate[[:space:]]+flag > 20%[[:space:]]+"?30%"?[[:space:]]+FLAG'; then
+  printf 'expected fallback row to use routing-derived 30%% and FLAG\n%s\n' "$output" >&2
+  exit 1
+fi
+
+if printf '%s\n' "$output" | grep -Eq 'Fallback rate[[:space:]]+flag > 20%[[:space:]]+"?1%"?[[:space:]]+OK'; then
+  printf 'fallback row incorrectly used system fallbackRate\n%s\n' "$output" >&2
+  exit 1
+fi
+
+printf 'PASS: fallback row uses routing-derived aggregate\n'


### PR DESCRIPTION
## Summary
- use the routing analytics aggregate as the displayed fallback-rate source in `scripts/innies-slo-check.sh`
- remove the now-redundant routing cross-check output and dead system fallback display path
- add a shell regression test that proves the fallback row ignores `system.fallbackRate` when the routing aggregate differs

## Test Plan
- bash scripts/tests/innies-slo-check.test.sh
- bash -n scripts/innies-slo-check.sh scripts/tests/innies-slo-check.test.sh

Closes #63