### PR TITLE
feat: add canonical session identity plumbing

### DIFF
--- a/api/src/routes/anthropicCompat.ts
+++ b/api/src/routes/anthropicCompat.ts
@@ -153,6 +153,7 @@ router.post(
 
       (req as any).inniesCompatMode = true;
       (req as any).inniesProxiedPath = '/v1/messages';
+      (req as any).inniesSessionIdentityBody = normalizedPayload;
       req.body = {
         // Compat requests stay Anthropic-shaped at ingress; buyer preference is
         // applied later in proxy routing so fallback can still include Anthropic.

--- a/api/src/routes/proxy.ts
+++ b/api/src/routes/proxy.ts
@@ -724,13 +724,25 @@ function logCompatAudit(input: {
   credentialId: string;
   attemptNo: number;
   upstreamStatus: number;
-  openclawRunId: string;
-  openclawSessionId?: string;
+  correlation: OpenClawCorrelation;
   errorType?: string;
   errorMessage?: string;
 }): void {
   // Keep this concise and machine-parsable for incident correlation.
-  console.info('[compat-audit] attempt', input);
+  console.info('[compat-audit] attempt', {
+    orgId: input.orgId,
+    provider: input.provider,
+    model: input.model,
+    requestId: input.requestId,
+    credentialId: input.credentialId,
+    attemptNo: input.attemptNo,
+    upstreamStatus: input.upstreamStatus,
+    openclawRunId: input.correlation.openclawRunId,
+    openclawSessionId: input.correlation.openclawSessionId,
+    ...buildCorrelationAuditFields(input.correlation),
+    errorType: input.errorType,
+    errorMessage: input.errorMessage
+  });
 }
 
 function logCompatTranslatedUpstreamError(input: {
@@ -2057,8 +2069,7 @@ async function executeTokenModeNonStreaming(input: {
             credentialId: credential.id,
             attemptNo,
             upstreamStatus: status,
-            openclawRunId: correlation.openclawRunId,
-            openclawSessionId: correlation.openclawSessionId,
+            correlation,
             errorType,
             errorMessage
           });
@@ -2177,8 +2188,7 @@ async function executeTokenModeNonStreaming(input: {
             credentialId: credential.id,
             attemptNo,
             upstreamStatus: status,
-            openclawRunId: correlation.openclawRunId,
-            openclawSessionId: correlation.openclawSessionId,
+            correlation,
             errorType: statusErrorType,
             errorMessage: statusErrorMessage
           });
@@ -2333,8 +2343,7 @@ async function executeTokenModeNonStreaming(input: {
           credentialId: credential.id,
           attemptNo,
           upstreamStatus: status,
-          openclawRunId: correlation.openclawRunId,
-          openclawSessionId: correlation.openclawSessionId,
+          correlation,
           errorType,
           errorMessage
         });
@@ -2716,8 +2725,7 @@ async function executeTokenModeStreaming(input: {
             credentialId: credential.id,
             attemptNo,
             upstreamStatus: status,
-            openclawRunId: correlation.openclawRunId,
-            openclawSessionId: correlation.openclawSessionId,
+            correlation,
             errorType,
             errorMessage
           });
@@ -2835,8 +2843,7 @@ async function executeTokenModeStreaming(input: {
             credentialId: credential.id,
             attemptNo,
             upstreamStatus: status,
-            openclawRunId: correlation.openclawRunId,
-            openclawSessionId: correlation.openclawSessionId,
+            correlation,
             errorType: statusErrorType,
             errorMessage: statusErrorMessage
           });
@@ -2968,8 +2975,7 @@ async function executeTokenModeStreaming(input: {
             credentialId: credential.id,
             attemptNo,
             upstreamStatus: status,
-            openclawRunId: correlation.openclawRunId,
-            openclawSessionId: correlation.openclawSessionId,
+            correlation,
             errorType,
             errorMessage
           });

--- a/api/src/routes/proxy.ts
+++ b/api/src/routes/proxy.ts
@@ -721,10 +721,10 @@ function logCompatAudit(input: {
   provider: string;
   model: string;
   requestId: string;
+  correlation: OpenClawCorrelation;
   credentialId: string;
   attemptNo: number;
   upstreamStatus: number;
-  correlation: OpenClawCorrelation;
   errorType?: string;
   errorMessage?: string;
 }): void {
@@ -738,7 +738,7 @@ function logCompatAudit(input: {
     attemptNo: input.attemptNo,
     upstreamStatus: input.upstreamStatus,
     openclawRunId: input.correlation.openclawRunId,
-    openclawSessionId: input.correlation.openclawSessionId,
+    openclawSessionId: input.correlation.openclawSessionId ?? null,
     ...buildCorrelationAuditFields(input.correlation),
     errorType: input.errorType,
     errorMessage: input.errorMessage
@@ -2066,10 +2066,10 @@ async function executeTokenModeNonStreaming(input: {
             provider,
             model,
             requestId,
+            correlation,
             credentialId: credential.id,
             attemptNo,
             upstreamStatus: status,
-            correlation,
             errorType,
             errorMessage
           });
@@ -2185,10 +2185,10 @@ async function executeTokenModeNonStreaming(input: {
             provider,
             model,
             requestId,
+            correlation,
             credentialId: credential.id,
             attemptNo,
             upstreamStatus: status,
-            correlation,
             errorType: statusErrorType,
             errorMessage: statusErrorMessage
           });
@@ -2340,10 +2340,10 @@ async function executeTokenModeNonStreaming(input: {
           provider,
           model,
           requestId,
+          correlation,
           credentialId: credential.id,
           attemptNo,
           upstreamStatus: status,
-          correlation,
           errorType,
           errorMessage
         });
@@ -2722,10 +2722,10 @@ async function executeTokenModeStreaming(input: {
             provider,
             model,
             requestId,
+            correlation,
             credentialId: credential.id,
             attemptNo,
             upstreamStatus: status,
-            correlation,
             errorType,
             errorMessage
           });
@@ -2840,10 +2840,10 @@ async function executeTokenModeStreaming(input: {
             provider,
             model,
             requestId,
+            correlation,
             credentialId: credential.id,
             attemptNo,
             upstreamStatus: status,
-            correlation,
             errorType: statusErrorType,
             errorMessage: statusErrorMessage
           });
@@ -2972,10 +2972,10 @@ async function executeTokenModeStreaming(input: {
             provider,
             model,
             requestId,
+            correlation,
             credentialId: credential.id,
             attemptNo,
             upstreamStatus: status,
-            correlation,
             errorType,
             errorMessage
           });

--- a/api/src/routes/proxy.ts
+++ b/api/src/routes/proxy.ts
@@ -759,13 +759,29 @@ function logCompatTranslatedUpstreamError(input: {
   });
 }
 
+function buildCorrelationAuditFields(correlation: Pick<
+  OpenClawCorrelation,
+  'openclawRunId' | 'openclawSessionId' | 'sessionId' | 'sessionSource'
+>): {
+  openclaw_run_id: string;
+  openclaw_session_id: string | null;
+  session_id: string | null;
+  session_source: SessionIdentitySource | null;
+} {
+  return {
+    openclaw_run_id: correlation.openclawRunId,
+    openclaw_session_id: correlation.openclawSessionId ?? null,
+    session_id: correlation.sessionId,
+    session_source: correlation.sessionSource
+  };
+}
+
 function logRetryAudit(input: {
   orgId: string;
   provider: string;
   model: string;
   requestId: string;
-  openclawRunId: string;
-  openclawSessionId?: string;
+  correlation: OpenClawCorrelation;
   attemptNo: number;
   credentialId: string;
   credentialLabel?: string | null;
@@ -777,8 +793,7 @@ function logRetryAudit(input: {
     provider: input.provider,
     model: input.model,
     request_id: input.requestId,
-    openclaw_run_id: input.openclawRunId,
-    openclaw_session_id: input.openclawSessionId,
+    ...buildCorrelationAuditFields(input.correlation),
     attempt_no: input.attemptNo,
     credential_id: input.credentialId,
     credential_label: input.credentialLabel ?? null,
@@ -792,8 +807,7 @@ function logAuthFailureAudit(input: {
   provider: string;
   model: string;
   requestId: string;
-  openclawRunId: string;
-  openclawSessionId?: string;
+  correlation: OpenClawCorrelation;
   attemptNo: number;
   credentialId: string;
   credentialLabel?: string | null;
@@ -806,8 +820,7 @@ function logAuthFailureAudit(input: {
     provider: input.provider,
     model: input.model,
     request_id: input.requestId,
-    openclaw_run_id: input.openclawRunId,
-    openclaw_session_id: input.openclawSessionId,
+    ...buildCorrelationAuditFields(input.correlation),
     attempt_no: input.attemptNo,
     credential_id: input.credentialId,
     credential_label: input.credentialLabel ?? null,
@@ -848,10 +861,7 @@ function buildTokenRouteDecision(
     tokenCredentialId: credential.id,
     tokenCredentialLabel: credential.debugLabel ?? null,
     tokenAuthScheme: credential.authScheme,
-    openclaw_run_id: correlation.openclawRunId,
-    openclaw_session_id: correlation.openclawSessionId ?? null,
-    session_id: correlation.sessionId,
-    session_source: correlation.sessionSource
+    ...buildCorrelationAuditFields(correlation)
   };
   if (providerPreference) {
     decision.provider_preferred = providerPreference.preferredProvider;
@@ -979,10 +989,7 @@ function buildSellerRouteDecision(input: {
       selectionReason,
       correlation: input.correlation
     }),
-    openclaw_run_id: input.correlation.openclawRunId,
-    openclaw_session_id: input.correlation.openclawSessionId ?? null,
-    session_id: input.correlation.sessionId,
-    session_source: input.correlation.sessionSource
+    ...buildCorrelationAuditFields(input.correlation)
   };
 }
 
@@ -1993,14 +2000,13 @@ async function executeTokenModeNonStreaming(input: {
             provider,
             model,
             requestId,
-            openclawRunId: correlation.openclawRunId,
-            openclawSessionId: correlation.openclawSessionId,
-          attemptNo,
-          credentialId: credential.id,
-          credentialLabel: credential.debugLabel,
-          upstreamStatus: status,
-          retryReason: 'blocked_403_compat_retry'
-        });
+            correlation,
+            attemptNo,
+            credentialId: credential.id,
+            credentialLabel: credential.debugLabel,
+            upstreamStatus: status,
+            retryReason: 'blocked_403_compat_retry'
+          });
           compat = applyCompatNormalization({
             requestId,
             attemptNo,
@@ -2113,8 +2119,7 @@ async function executeTokenModeNonStreaming(input: {
             provider,
             model,
             requestId,
-            openclawRunId: correlation.openclawRunId,
-            openclawSessionId: correlation.openclawSessionId,
+            correlation,
             attemptNo,
             credentialId: credential.id,
             credentialLabel: credential.debugLabel,
@@ -2141,8 +2146,7 @@ async function executeTokenModeNonStreaming(input: {
               provider,
               model,
               requestId,
-              openclawRunId: correlation.openclawRunId,
-              openclawSessionId: correlation.openclawSessionId,
+              correlation,
               attemptNo,
               credentialId: credential.id,
               credentialLabel: credential.debugLabel,
@@ -2203,8 +2207,7 @@ async function executeTokenModeNonStreaming(input: {
           provider,
           model,
           requestId,
-          openclawRunId: correlation.openclawRunId,
-          openclawSessionId: correlation.openclawSessionId,
+          correlation,
           attemptNo,
           credentialId: credential.id,
           credentialLabel: credential.debugLabel,
@@ -2459,8 +2462,7 @@ async function executeTokenModeNonStreaming(input: {
         provider,
         model,
         requestId,
-        openclawRunId: correlation.openclawRunId,
-        openclawSessionId: correlation.openclawSessionId,
+        correlation,
         attemptNo: lastAuthFailure.attemptNo,
         credentialId: lastAuthFailure.credentialId,
         credentialLabel: lastAuthFailure.credentialLabel,
@@ -2657,14 +2659,13 @@ async function executeTokenModeStreaming(input: {
             provider,
             model,
             requestId,
-            openclawRunId: correlation.openclawRunId,
-            openclawSessionId: correlation.openclawSessionId,
-          attemptNo,
-          credentialId: credential.id,
-          credentialLabel: credential.debugLabel,
-          upstreamStatus: status,
-          retryReason: 'blocked_403_compat_retry'
-        });
+            correlation,
+            attemptNo,
+            credentialId: credential.id,
+            credentialLabel: credential.debugLabel,
+            upstreamStatus: status,
+            retryReason: 'blocked_403_compat_retry'
+          });
           compat = applyCompatNormalization({
             requestId,
             attemptNo,
@@ -2776,8 +2777,7 @@ async function executeTokenModeStreaming(input: {
             provider,
             model,
             requestId,
-            openclawRunId: correlation.openclawRunId,
-            openclawSessionId: correlation.openclawSessionId,
+            correlation,
             attemptNo,
             credentialId: credential.id,
             credentialLabel: credential.debugLabel,
@@ -2804,8 +2804,7 @@ async function executeTokenModeStreaming(input: {
               provider,
               model,
               requestId,
-              openclawRunId: correlation.openclawRunId,
-              openclawSessionId: correlation.openclawSessionId,
+              correlation,
               attemptNo,
               credentialId: credential.id,
               credentialLabel: credential.debugLabel,
@@ -2866,8 +2865,7 @@ async function executeTokenModeStreaming(input: {
           provider,
           model,
           requestId,
-          openclawRunId: correlation.openclawRunId,
-          openclawSessionId: correlation.openclawSessionId,
+          correlation,
           attemptNo,
           credentialId: credential.id,
           credentialLabel: credential.debugLabel,
@@ -3122,8 +3120,7 @@ async function executeTokenModeStreaming(input: {
               attemptNo,
               credential_id: credential.id,
               credential_label: credential.debugLabel ?? null,
-              openclaw_run_id: correlation.openclawRunId,
-              openclaw_session_id: correlation.openclawSessionId ?? null,
+              ...buildCorrelationAuditFields(correlation),
               upstream_status: status,
               upstream_content_type: contentType,
               stream_mode: 'buffered_passthrough',
@@ -3253,8 +3250,7 @@ async function executeTokenModeStreaming(input: {
             attemptNo,
             credential_id: credential.id,
             credential_label: credential.debugLabel ?? null,
-            openclaw_run_id: correlation.openclawRunId,
-            openclaw_session_id: correlation.openclawSessionId ?? null,
+            ...buildCorrelationAuditFields(correlation),
             upstream_status: status,
             upstream_content_type: contentType,
             stream_mode: streamMode,
@@ -3591,8 +3587,7 @@ async function executeTokenModeStreaming(input: {
         attemptNo,
         credential_id: credential.id,
         credential_label: credential.debugLabel ?? null,
-        openclaw_run_id: correlation.openclawRunId,
-        openclaw_session_id: correlation.openclawSessionId ?? null,
+        ...buildCorrelationAuditFields(correlation),
         upstream_status: status,
         upstream_content_type: contentType,
         stream_mode: compatTranslation ? 'translated_passthrough' : 'passthrough',
@@ -3660,8 +3655,7 @@ async function executeTokenModeStreaming(input: {
         provider,
         model,
         requestId,
-        openclawRunId: correlation.openclawRunId,
-        openclawSessionId: correlation.openclawSessionId,
+        correlation,
         attemptNo: lastAuthFailure.attemptNo,
         credentialId: lastAuthFailure.credentialId,
         credentialLabel: lastAuthFailure.credentialLabel,

--- a/api/src/routes/proxy.ts
+++ b/api/src/routes/proxy.ts
@@ -9,6 +9,12 @@ import type { IdempotencySession } from '../services/idempotencyService.js';
 import { AppError } from '../utils/errors.js';
 import { sha256Hex, stableJson } from '../utils/hash.js';
 import { readAndValidateIdempotencyKey } from '../utils/idempotencyKey.js';
+import {
+  resolveOpenClawSessionIdentity,
+  resolveSessionIdentity,
+  type SessionIdentity,
+  type SessionIdentitySource
+} from '../utils/sessionIdentity.js';
 import { anthropicToOpenAi } from '../utils/anthropicToOpenai.js';
 import { mapOpenAiErrorToAnthropic, translateOpenAiToAnthropic } from '../utils/openaiToAnthropic.js';
 import { OpenAiToAnthropicStreamTransform } from '../utils/openaiToAnthropicStream.js';
@@ -84,6 +90,8 @@ type OpenClawCorrelation = {
   openclawRunId: string;
   openclawSessionId?: string;
   sourceExplicit: boolean;
+  sessionId: string | null;
+  sessionSource: SessionIdentitySource | null;
 };
 type RetryReason =
   | 'blocked_403_compat_retry'
@@ -171,7 +179,7 @@ function readHeader(req: any, ...names: string[]): string | undefined {
   return undefined;
 }
 
-function resolveOpenClawCorrelation(req: any, requestId: string): OpenClawCorrelation {
+function resolveOpenClawCorrelation(req: any, requestId: string, sessionIdentity: SessionIdentity): OpenClawCorrelation {
   const bodyObject = req.body && typeof req.body === 'object'
     ? (req.body as any)
     : undefined;
@@ -179,17 +187,17 @@ function resolveOpenClawCorrelation(req: any, requestId: string): OpenClawCorrel
   const metadataRunId = typeof metadata?.openclaw_run_id === 'string'
     ? metadata.openclaw_run_id.trim()
     : undefined;
-  const metadataSessionId = typeof metadata?.openclaw_session_id === 'string'
-    ? metadata.openclaw_session_id.trim()
-    : undefined;
   const explicitRunId = readHeader(req, 'x-openclaw-run-id', 'openclaw-run-id', 'x-run-id')
     ?? (metadataRunId && metadataRunId.length > 0 ? metadataRunId : undefined);
-  const explicitSessionId = readHeader(req, 'x-openclaw-session-id', 'openclaw-session-id', 'x-session-id')
-    ?? (metadataSessionId && metadataSessionId.length > 0 ? metadataSessionId : undefined);
+  const openClawSessionIdentity = sessionIdentity.source === 'x-innies-session-id'
+    ? resolveOpenClawSessionIdentity(req)
+    : sessionIdentity;
   return {
     openclawRunId: explicitRunId ?? `run_${requestId}`,
-    openclawSessionId: explicitSessionId,
-    sourceExplicit: Boolean(explicitRunId || explicitSessionId)
+    openclawSessionId: openClawSessionIdentity.sessionId ?? undefined,
+    sourceExplicit: Boolean(explicitRunId || openClawSessionIdentity.sessionId),
+    sessionId: sessionIdentity.sessionId,
+    sessionSource: sessionIdentity.source
   };
 }
 
@@ -841,7 +849,9 @@ function buildTokenRouteDecision(
     tokenCredentialLabel: credential.debugLabel ?? null,
     tokenAuthScheme: credential.authScheme,
     openclaw_run_id: correlation.openclawRunId,
-    openclaw_session_id: correlation.openclawSessionId ?? null
+    openclaw_session_id: correlation.openclawSessionId ?? null,
+    session_id: correlation.sessionId,
+    session_source: correlation.sessionSource
   };
   if (providerPreference) {
     decision.provider_preferred = providerPreference.preferredProvider;
@@ -970,7 +980,9 @@ function buildSellerRouteDecision(input: {
       correlation: input.correlation
     }),
     openclaw_run_id: input.correlation.openclawRunId,
-    openclaw_session_id: input.correlation.openclawSessionId ?? null
+    openclaw_session_id: input.correlation.openclawSessionId ?? null,
+    session_id: input.correlation.sessionId,
+    session_source: input.correlation.sessionSource
   };
 }
 
@@ -3691,7 +3703,12 @@ export async function proxyPostHandler(req: any, res: Response, next: any): Prom
     const parsed = parseProxyRequestBody(req.body, proxiedPath);
     const requestProvider = canonicalizeProvider(parsed.provider);
     const requestId = buildRequestId(req.header('x-request-id') ?? undefined);
-    const correlation = resolveOpenClawCorrelation(req, requestId);
+    const sessionIdentityRequest = {
+      header: req.header.bind(req),
+      body: req.inniesSessionIdentityBody ?? req.body
+    };
+    const sessionIdentity = resolveSessionIdentity(sessionIdentityRequest);
+    const correlation = resolveOpenClawCorrelation(sessionIdentityRequest, requestId, sessionIdentity);
     const rawIdempotencyKey = req.header('idempotency-key') ?? undefined;
     const shouldPersistIdempotency = Boolean(rawIdempotencyKey);
     const idempotencyKey = shouldPersistIdempotency

--- a/api/src/utils/sessionIdentity.ts
+++ b/api/src/utils/sessionIdentity.ts
@@ -1,0 +1,88 @@
+export type SessionIdentitySource =
+  | 'x-innies-session-id'
+  | 'x-openclaw-session-id'
+  | 'openclaw-session-id'
+  | 'x-session-id'
+  | 'metadata.openclaw_session_id'
+  | 'payload.metadata.openclaw_session_id';
+
+export type SessionIdentity = {
+  sessionId: string | null;
+  source: SessionIdentitySource | null;
+};
+
+type RequestLike = {
+  header: (name: string) => string | undefined;
+  body?: unknown;
+};
+
+const MAX_SESSION_ID_LENGTH = 256;
+
+function normalizeSessionCandidate(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (trimmed.length === 0 || trimmed.length > MAX_SESSION_ID_LENGTH) return null;
+  return trimmed;
+}
+
+function readHeader(req: RequestLike, ...names: string[]): string | undefined {
+  for (const name of names) {
+    const raw = req.header(name);
+    if (typeof raw !== 'string') continue;
+    return raw;
+  }
+  return undefined;
+}
+
+function readBody(req: RequestLike): Record<string, unknown> | undefined {
+  if (!req.body || typeof req.body !== 'object' || Array.isArray(req.body)) {
+    return undefined;
+  }
+  return req.body as Record<string, unknown>;
+}
+
+function readMetadataSession(body: Record<string, unknown> | undefined, source: SessionIdentitySource): unknown {
+  const metadata = source === 'metadata.openclaw_session_id'
+    ? body?.metadata
+    : (body?.payload as Record<string, unknown> | undefined)?.metadata;
+
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    return undefined;
+  }
+
+  return (metadata as Record<string, unknown>).openclaw_session_id;
+}
+
+function resolveFromCandidates(candidates: ReadonlyArray<readonly [SessionIdentitySource, unknown]>): SessionIdentity {
+  for (const [source, candidate] of candidates) {
+    const sessionId = normalizeSessionCandidate(candidate);
+    if (sessionId) {
+      return { sessionId, source };
+    }
+  }
+
+  return { sessionId: null, source: null };
+}
+
+export function resolveSessionIdentity(req: RequestLike): SessionIdentity {
+  const body = readBody(req);
+  return resolveFromCandidates([
+    ['x-innies-session-id', readHeader(req, 'x-innies-session-id')],
+    ['x-openclaw-session-id', readHeader(req, 'x-openclaw-session-id')],
+    ['openclaw-session-id', readHeader(req, 'openclaw-session-id')],
+    ['x-session-id', readHeader(req, 'x-session-id')],
+    ['metadata.openclaw_session_id', readMetadataSession(body, 'metadata.openclaw_session_id')],
+    ['payload.metadata.openclaw_session_id', readMetadataSession(body, 'payload.metadata.openclaw_session_id')]
+  ]);
+}
+
+export function resolveOpenClawSessionIdentity(req: RequestLike): SessionIdentity {
+  const body = readBody(req);
+  return resolveFromCandidates([
+    ['x-openclaw-session-id', readHeader(req, 'x-openclaw-session-id')],
+    ['openclaw-session-id', readHeader(req, 'openclaw-session-id')],
+    ['x-session-id', readHeader(req, 'x-session-id')],
+    ['metadata.openclaw_session_id', readMetadataSession(body, 'metadata.openclaw_session_id')],
+    ['payload.metadata.openclaw_session_id', readMetadataSession(body, 'payload.metadata.openclaw_session_id')]
+  ]);
+}

--- a/api/tests/anthropicCompat.route.test.ts
+++ b/api/tests/anthropicCompat.route.test.ts
@@ -2131,6 +2131,7 @@ describe('anthropic compat route', () => {
   });
 
   it('passes through blocked 403 when compat retry is still blocked', async () => {
+    const compatAuditSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
     const upstreamSpy = vi.spyOn(globalThis, 'fetch')
       .mockResolvedValueOnce(new Response(JSON.stringify({
         type: 'error',
@@ -2153,7 +2154,9 @@ describe('anthropic compat route', () => {
       headers: {
         authorization: 'Bearer in_test_token',
         'content-type': 'application/json',
-        'anthropic-beta': 'oauth-2025-04-20,claude-code-20250219'
+        'anthropic-beta': 'oauth-2025-04-20,claude-code-20250219',
+        'x-openclaw-session-id': 'oc_blocked_session_1',
+        'x-innies-session-id': 'sess_blocked_canonical_1'
       },
       body: {
         model: 'claude-opus-4-6',
@@ -2170,7 +2173,15 @@ describe('anthropic compat route', () => {
     expect(upstreamSpy).toHaveBeenCalledTimes(2);
     expect(res.statusCode).toBe(403);
     expect((res.body as any).error?.message).toContain('blocked');
+    const compatAuditCalls = compatAuditSpy.mock.calls.filter((call) => call[0] === '[compat-audit] attempt');
+    expect(compatAuditCalls.length).toBeGreaterThan(0);
+    const compatAudit = compatAuditCalls[compatAuditCalls.length - 1]?.[1] as any;
+    expect(String(compatAudit?.openclaw_run_id ?? '')).toMatch(/^run_req_/);
+    expect(compatAudit?.openclaw_session_id).toBe('oc_blocked_session_1');
+    expect(compatAudit?.session_id).toBe('sess_blocked_canonical_1');
+    expect(compatAudit?.session_source).toBe('x-innies-session-id');
 
+    compatAuditSpy.mockRestore();
     upstreamSpy.mockRestore();
   });
 
@@ -2728,6 +2739,7 @@ describe('anthropic compat route', () => {
   });
 
   it('does not change auth 401/403 retry behavior on compat route', async () => {
+    const compatAuditSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
     const upstreamSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(JSON.stringify({
         type: 'error',
@@ -2743,7 +2755,9 @@ describe('anthropic compat route', () => {
       path: '/v1/messages',
       headers: {
         authorization: 'Bearer in_test_token',
-        'content-type': 'application/json'
+        'content-type': 'application/json',
+        'x-openclaw-session-id': 'oc_auth_session_1',
+        'x-innies-session-id': 'sess_auth_canonical_compat_1'
       },
       body: {
         model: 'claude-opus-4-6',
@@ -2759,7 +2773,15 @@ describe('anthropic compat route', () => {
 
     // 401 should still be handled as auth failure, not as a 5xx failover
     expect(res.statusCode).toBe(401);
+    const compatAuditCalls = compatAuditSpy.mock.calls.filter((call) => call[0] === '[compat-audit] attempt');
+    expect(compatAuditCalls.length).toBeGreaterThan(0);
+    const compatAudit = compatAuditCalls[compatAuditCalls.length - 1]?.[1] as any;
+    expect(String(compatAudit?.openclaw_run_id ?? '')).toMatch(/^run_req_/);
+    expect(compatAudit?.openclaw_session_id).toBe('oc_auth_session_1');
+    expect(compatAudit?.session_id).toBe('sess_auth_canonical_compat_1');
+    expect(compatAudit?.session_source).toBe('x-innies-session-id');
 
+    compatAuditSpy.mockRestore();
     upstreamSpy.mockRestore();
   });
 });

--- a/api/tests/anthropicCompat.route.test.ts
+++ b/api/tests/anthropicCompat.route.test.ts
@@ -788,7 +788,8 @@ describe('anthropic compat route', () => {
         authorization: 'Bearer in_test_token',
         'content-type': 'application/json',
         'x-openclaw-run-id': 'oc_run_123',
-        'x-openclaw-session-id': 'oc_sess_456'
+        'x-openclaw-session-id': 'oc_sess_456',
+        'x-innies-session-id': 'sess_canonical_123'
       },
       body: { model: 'claude-opus-4-6', stream: true, max_tokens: 8, messages: [{ role: 'user', content: 'hi' }] }
     });
@@ -819,6 +820,8 @@ describe('anthropic compat route', () => {
     const routingArgs = routingSpy.mock.calls[0]?.[0] as any;
     expect(routingArgs?.routeDecision?.openclaw_run_id).toBe('oc_run_123');
     expect(routingArgs?.routeDecision?.openclaw_session_id).toBe('oc_sess_456');
+    expect(routingArgs?.routeDecision?.session_id).toBe('sess_canonical_123');
+    expect(routingArgs?.routeDecision?.session_source).toBe('x-innies-session-id');
     upstreamSpy.mockRestore();
     streamLatencySpy.mockRestore();
   });
@@ -1162,6 +1165,271 @@ describe('anthropic compat route', () => {
     const routingArgs = routingSpy.mock.calls[0]?.[0] as any;
     expect(routingArgs?.routeDecision?.openclaw_run_id).toBe('meta_run_1');
     expect(routingArgs?.routeDecision?.openclaw_session_id).toBe('meta_sess_1');
+    expect(routingArgs?.routeDecision?.session_id).toBe('meta_sess_1');
+    expect(routingArgs?.routeDecision?.session_source).toBe('metadata.openclaw_session_id');
+    upstreamSpy.mockRestore();
+  });
+
+  it('falls back through documented session identity sources and ignores unusable values', async () => {
+    const routingSpy = vi.spyOn(runtimeModule.runtime.repos.routingEvents, 'insert');
+    const upstreamSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ id: 'msg_session_identity', usage: { input_tokens: 5, output_tokens: 2 } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' }
+      })
+    );
+
+    const cases = [
+      {
+        name: 'x-openclaw-session-id',
+        headers: { 'x-openclaw-session-id': ' oc_hdr_1 ' },
+        body: { model: 'claude-opus-4-6', max_tokens: 8, messages: [{ role: 'user', content: 'hi' }] },
+        expectedSessionId: 'oc_hdr_1',
+        expectedSource: 'x-openclaw-session-id',
+        expectedOpenClawSessionId: 'oc_hdr_1'
+      },
+      {
+        name: 'openclaw-session-id',
+        headers: { 'openclaw-session-id': ' oc_hdr_2 ' },
+        body: { model: 'claude-opus-4-6', max_tokens: 8, messages: [{ role: 'user', content: 'hi' }] },
+        expectedSessionId: 'oc_hdr_2',
+        expectedSource: 'openclaw-session-id',
+        expectedOpenClawSessionId: 'oc_hdr_2'
+      },
+      {
+        name: 'x-session-id',
+        headers: { 'x-session-id': ' legacy_sess_3 ' },
+        body: { model: 'claude-opus-4-6', max_tokens: 8, messages: [{ role: 'user', content: 'hi' }] },
+        expectedSessionId: 'legacy_sess_3',
+        expectedSource: 'x-session-id',
+        expectedOpenClawSessionId: 'legacy_sess_3'
+      },
+      {
+        name: 'ignores blank and oversized values before later fallback',
+        headers: {
+          'x-openclaw-session-id': '   ',
+          'openclaw-session-id': 'x'.repeat(257),
+          'x-session-id': ' trimmed_sess_5 '
+        },
+        body: { model: 'claude-opus-4-6', max_tokens: 8, messages: [{ role: 'user', content: 'hi' }] },
+        expectedSessionId: 'trimmed_sess_5',
+        expectedSource: 'x-session-id',
+        expectedOpenClawSessionId: 'trimmed_sess_5'
+      }
+    ] as const;
+
+    for (const testCase of cases) {
+      routingSpy.mockClear();
+      const req = createMockReq({
+        method: 'POST',
+        path: '/v1/messages',
+        headers: {
+          authorization: 'Bearer in_test_token',
+          'content-type': 'application/json',
+          ...testCase.headers
+        },
+        body: testCase.body
+      });
+      const res = createMockRes();
+
+      await invoke(handlers[0], req, res);
+      await invoke(handlers[1], req, res);
+      await invoke(handlers[2], req, res);
+
+      expect(res.statusCode, testCase.name).toBe(200);
+      const routingArgs = routingSpy.mock.calls.at(-1)?.[0] as any;
+      expect(routingArgs?.routeDecision?.session_id, testCase.name).toBe(testCase.expectedSessionId);
+      expect(routingArgs?.routeDecision?.session_source, testCase.name).toBe(testCase.expectedSource);
+      expect(routingArgs?.routeDecision?.openclaw_session_id, testCase.name).toBe(testCase.expectedOpenClawSessionId);
+    }
+
+    upstreamSpy.mockRestore();
+  });
+
+  it('prefers x-innies-session-id over OpenClaw session fallbacks', async () => {
+    const routingSpy = vi.spyOn(runtimeModule.runtime.repos.routingEvents, 'insert');
+    const upstreamSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ id: 'msg_canonical_session', usage: { input_tokens: 5, output_tokens: 2 } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' }
+      })
+    );
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/messages',
+      headers: {
+        authorization: 'Bearer in_test_token',
+        'content-type': 'application/json',
+        'x-innies-session-id': 'sess_canonical_1',
+        'x-openclaw-session-id': 'oc_sess_preserved'
+      },
+      body: {
+        model: 'claude-opus-4-6',
+        max_tokens: 8,
+        messages: [{ role: 'user', content: 'hi' }],
+        metadata: {
+          openclaw_session_id: 'meta_sess_ignored'
+        }
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(handlers[0], req, res);
+    await invoke(handlers[1], req, res);
+    await invoke(handlers[2], req, res);
+
+    expect(res.statusCode).toBe(200);
+    const routingArgs = routingSpy.mock.calls[0]?.[0] as any;
+    expect(routingArgs?.routeDecision?.session_id).toBe('sess_canonical_1');
+    expect(routingArgs?.routeDecision?.session_source).toBe('x-innies-session-id');
+    expect(routingArgs?.routeDecision?.openclaw_session_id).toBe('oc_sess_preserved');
+    upstreamSpy.mockRestore();
+  });
+
+  it('falls back through OpenClaw session fields in documented order', async () => {
+    const routingSpy = vi.spyOn(runtimeModule.runtime.repos.routingEvents, 'insert');
+    const upstreamSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ id: 'msg_session_fallback', usage: { input_tokens: 5, output_tokens: 2 } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' }
+      })
+    );
+
+    const cases = [
+      {
+        headers: { 'x-openclaw-session-id': 'oc_header_session' },
+        body: {
+          model: 'claude-opus-4-6',
+          max_tokens: 8,
+          messages: [{ role: 'user', content: 'hi' }]
+        },
+        expectedSessionId: 'oc_header_session',
+        expectedSource: 'x-openclaw-session-id'
+      },
+      {
+        headers: { 'openclaw-session-id': 'oc_legacy_header_session' },
+        body: {
+          model: 'claude-opus-4-6',
+          max_tokens: 8,
+          messages: [{ role: 'user', content: 'hi' }]
+        },
+        expectedSessionId: 'oc_legacy_header_session',
+        expectedSource: 'openclaw-session-id'
+      },
+      {
+        headers: { 'x-session-id': 'oc_generic_header_session' },
+        body: {
+          model: 'claude-opus-4-6',
+          max_tokens: 8,
+          messages: [{ role: 'user', content: 'hi' }]
+        },
+        expectedSessionId: 'oc_generic_header_session',
+        expectedSource: 'x-session-id'
+      },
+      {
+        headers: {},
+        body: {
+          model: 'claude-opus-4-6',
+          max_tokens: 8,
+          messages: [{ role: 'user', content: 'hi' }],
+          metadata: {
+            openclaw_session_id: 'meta_session_fallback'
+          }
+        },
+        expectedSessionId: 'meta_session_fallback',
+        expectedSource: 'metadata.openclaw_session_id'
+      },
+      {
+        headers: {},
+        body: {
+          model: 'claude-opus-4-6',
+          max_tokens: 8,
+          messages: [{ role: 'user', content: 'hi' }],
+          payload: {
+            metadata: {
+              openclaw_session_id: 'payload_meta_session_fallback'
+            }
+          }
+        },
+        expectedSessionId: 'payload_meta_session_fallback',
+        expectedSource: 'payload.metadata.openclaw_session_id'
+      }
+    ] as const;
+
+    for (const testCase of cases) {
+      routingSpy.mockClear();
+      const req = createMockReq({
+        method: 'POST',
+        path: '/v1/messages',
+        headers: {
+          authorization: 'Bearer in_test_token',
+          'content-type': 'application/json',
+          ...testCase.headers
+        },
+        body: testCase.body
+      });
+      const res = createMockRes();
+
+      await invoke(handlers[0], req, res);
+      await invoke(handlers[1], req, res);
+      await invoke(handlers[2], req, res);
+
+      expect(res.statusCode).toBe(200);
+      const routingArgs = routingSpy.mock.calls[0]?.[0] as any;
+      expect(routingArgs?.routeDecision?.session_id).toBe(testCase.expectedSessionId);
+      expect(routingArgs?.routeDecision?.session_source).toBe(testCase.expectedSource);
+      expect(routingArgs?.routeDecision?.openclaw_session_id).toBe(testCase.expectedSessionId);
+    }
+
+    upstreamSpy.mockRestore();
+  });
+
+  it('ignores blank or oversized session ids and stays request-by-request when none are usable', async () => {
+    const routingSpy = vi.spyOn(runtimeModule.runtime.repos.routingEvents, 'insert');
+    const upstreamSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ id: 'msg_invalid_session', usage: { input_tokens: 5, output_tokens: 2 } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' }
+      })
+    );
+    const oversizedSessionId = 'x'.repeat(257);
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/messages',
+      headers: {
+        authorization: 'Bearer in_test_token',
+        'content-type': 'application/json',
+        'x-innies-session-id': '   ',
+        'x-openclaw-session-id': oversizedSessionId,
+        'x-session-id': ' \n\t '
+      },
+      body: {
+        model: 'claude-opus-4-6',
+        max_tokens: 8,
+        messages: [{ role: 'user', content: 'hi' }],
+        metadata: {
+          openclaw_session_id: ' '
+        },
+        payload: {
+          metadata: {
+            openclaw_session_id: oversizedSessionId
+          }
+        }
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(handlers[0], req, res);
+    await invoke(handlers[1], req, res);
+    await invoke(handlers[2], req, res);
+
+    expect(res.statusCode).toBe(200);
+    const routingArgs = routingSpy.mock.calls[0]?.[0] as any;
+    expect(routingArgs?.routeDecision?.session_id).toBeNull();
+    expect(routingArgs?.routeDecision?.session_source).toBeNull();
+    expect(routingArgs?.routeDecision?.openclaw_session_id).toBeNull();
     upstreamSpy.mockRestore();
   });
 

--- a/api/tests/anthropicCompat.route.test.ts
+++ b/api/tests/anthropicCompat.route.test.ts
@@ -1708,6 +1708,7 @@ describe('anthropic compat route', () => {
   });
 
   it('passes through upstream 4xx status/body for compat route', async () => {
+    const compatAuditSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
     const upstreamSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(JSON.stringify({
         type: 'error',
@@ -1723,7 +1724,10 @@ describe('anthropic compat route', () => {
       path: '/v1/messages',
       headers: {
         authorization: 'Bearer in_test_token',
-        'content-type': 'application/json'
+        'content-type': 'application/json',
+        'x-openclaw-run-id': 'oc_run_passthrough_1',
+        'x-openclaw-session-id': 'oc_passthrough_session_1',
+        'x-innies-session-id': 'sess_passthrough_canonical_1'
       },
       body: {
         model: 'claude-opus-4-6',
@@ -1740,7 +1744,21 @@ describe('anthropic compat route', () => {
     expect(upstreamSpy).toHaveBeenCalledTimes(1);
     expect(res.statusCode).toBe(400);
     expect((res.body as any).error?.type).toBe('invalid_request_error');
+    const compatCalls = compatAuditSpy.mock.calls.filter((call) => call[0] === '[compat-audit] attempt');
+    expect(compatCalls.length).toBeGreaterThan(0);
+    const compatAudit = compatCalls[0]?.[1] as any;
+    expect(compatAudit?.upstreamStatus).toBe(400);
+    expect(compatAudit?.provider).toBe('anthropic');
+    expect(compatAudit?.model).toBe('claude-opus-4-6');
+    expect(compatAudit?.openclawRunId).toBe('oc_run_passthrough_1');
+    expect(compatAudit?.openclaw_run_id).toBe('oc_run_passthrough_1');
+    expect(compatAudit?.openclaw_session_id).toBe('oc_passthrough_session_1');
+    expect(compatAudit?.session_id).toBe('sess_passthrough_canonical_1');
+    expect(compatAudit?.session_source).toBe('x-innies-session-id');
+    expect(compatAudit?.errorType).toBe('invalid_request_error');
+    expect(compatAudit?.errorMessage).toContain('bad model');
 
+    compatAuditSpy.mockRestore();
     upstreamSpy.mockRestore();
   });
 
@@ -2155,6 +2173,7 @@ describe('anthropic compat route', () => {
         authorization: 'Bearer in_test_token',
         'content-type': 'application/json',
         'anthropic-beta': 'oauth-2025-04-20,claude-code-20250219',
+        'x-openclaw-run-id': 'oc_run_blocked_1',
         'x-openclaw-session-id': 'oc_blocked_session_1',
         'x-innies-session-id': 'sess_blocked_canonical_1'
       },
@@ -2173,13 +2192,19 @@ describe('anthropic compat route', () => {
     expect(upstreamSpy).toHaveBeenCalledTimes(2);
     expect(res.statusCode).toBe(403);
     expect((res.body as any).error?.message).toContain('blocked');
-    const compatAuditCalls = compatAuditSpy.mock.calls.filter((call) => call[0] === '[compat-audit] attempt');
-    expect(compatAuditCalls.length).toBeGreaterThan(0);
-    const compatAudit = compatAuditCalls[compatAuditCalls.length - 1]?.[1] as any;
-    expect(String(compatAudit?.openclaw_run_id ?? '')).toMatch(/^run_req_/);
+    const compatCalls = compatAuditSpy.mock.calls.filter((call) => call[0] === '[compat-audit] attempt');
+    expect(compatCalls.length).toBeGreaterThan(0);
+    const compatAudit = compatCalls.at(-1)?.[1] as any;
+    expect(compatAudit?.upstreamStatus).toBe(403);
+    expect(compatAudit?.provider).toBe('anthropic');
+    expect(compatAudit?.model).toBe('claude-opus-4-6');
+    expect(compatAudit?.openclawRunId).toBe('oc_run_blocked_1');
+    expect(compatAudit?.openclaw_run_id).toBe('oc_run_blocked_1');
     expect(compatAudit?.openclaw_session_id).toBe('oc_blocked_session_1');
     expect(compatAudit?.session_id).toBe('sess_blocked_canonical_1');
     expect(compatAudit?.session_source).toBe('x-innies-session-id');
+    expect(compatAudit?.errorType).toBe('invalid_request_error');
+    expect(compatAudit?.errorMessage).toContain('blocked');
 
     compatAuditSpy.mockRestore();
     upstreamSpy.mockRestore();
@@ -2756,6 +2781,7 @@ describe('anthropic compat route', () => {
       headers: {
         authorization: 'Bearer in_test_token',
         'content-type': 'application/json',
+        'x-openclaw-run-id': 'oc_run_auth_1',
         'x-openclaw-session-id': 'oc_auth_session_1',
         'x-innies-session-id': 'sess_auth_canonical_compat_1'
       },
@@ -2773,13 +2799,82 @@ describe('anthropic compat route', () => {
 
     // 401 should still be handled as auth failure, not as a 5xx failover
     expect(res.statusCode).toBe(401);
-    const compatAuditCalls = compatAuditSpy.mock.calls.filter((call) => call[0] === '[compat-audit] attempt');
-    expect(compatAuditCalls.length).toBeGreaterThan(0);
-    const compatAudit = compatAuditCalls[compatAuditCalls.length - 1]?.[1] as any;
-    expect(String(compatAudit?.openclaw_run_id ?? '')).toMatch(/^run_req_/);
+    const compatCalls = compatAuditSpy.mock.calls.filter((call) => call[0] === '[compat-audit] attempt');
+    expect(compatCalls.length).toBeGreaterThan(0);
+    const compatAudit = compatCalls[0]?.[1] as any;
+    expect(compatAudit?.upstreamStatus).toBe(401);
+    expect(compatAudit?.provider).toBe('anthropic');
+    expect(compatAudit?.model).toBe('claude-opus-4-6');
+    expect(compatAudit?.openclawRunId).toBe('oc_run_auth_1');
+    expect(compatAudit?.openclaw_run_id).toBe('oc_run_auth_1');
     expect(compatAudit?.openclaw_session_id).toBe('oc_auth_session_1');
     expect(compatAudit?.session_id).toBe('sess_auth_canonical_compat_1');
     expect(compatAudit?.session_source).toBe('x-innies-session-id');
+    expect(compatAudit?.errorType).toBe('authentication_error');
+    expect(compatAudit?.errorMessage).toContain('invalid x-api-key');
+
+    compatAuditSpy.mockRestore();
+    upstreamSpy.mockRestore();
+  });
+
+  it('passes through blocked 403 in compat stream mode with canonical session audit fields', async () => {
+    const compatAuditSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    const upstreamSpy = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        type: 'error',
+        error: { type: 'invalid_request_error', message: 'Your request was blocked.' }
+      }), {
+        status: 403,
+        headers: { 'content-type': 'application/json' }
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        type: 'error',
+        error: { type: 'invalid_request_error', message: 'Your request was blocked.' }
+      }), {
+        status: 403,
+        headers: { 'content-type': 'application/json' }
+      }));
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/messages',
+      headers: {
+        authorization: 'Bearer in_test_token',
+        'content-type': 'application/json',
+        'anthropic-beta': 'oauth-2025-04-20,claude-code-20250219',
+        'x-openclaw-run-id': 'oc_run_stream_blocked_1',
+        'x-openclaw-session-id': 'oc_stream_blocked_session_1',
+        'x-innies-session-id': 'sess_stream_blocked_canonical_1'
+      },
+      body: {
+        model: 'claude-opus-4-6',
+        stream: true,
+        max_tokens: 16,
+        messages: [{ role: 'user', content: 'hi' }]
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(handlers[0], req, res);
+    await invoke(handlers[1], req, res);
+    await invoke(handlers[2], req, res);
+
+    expect(upstreamSpy).toHaveBeenCalledTimes(2);
+    expect(res.statusCode).toBe(403);
+    expect((res.body as any).error?.message).toContain('blocked');
+    const compatCalls = compatAuditSpy.mock.calls.filter((call) => call[0] === '[compat-audit] attempt');
+    expect(compatCalls.length).toBeGreaterThan(0);
+    const compatAudit = compatCalls.at(-1)?.[1] as any;
+    expect(compatAudit?.upstreamStatus).toBe(403);
+    expect(compatAudit?.provider).toBe('anthropic');
+    expect(compatAudit?.model).toBe('claude-opus-4-6');
+    expect(compatAudit?.openclawRunId).toBe('oc_run_stream_blocked_1');
+    expect(compatAudit?.openclaw_run_id).toBe('oc_run_stream_blocked_1');
+    expect(compatAudit?.openclaw_session_id).toBe('oc_stream_blocked_session_1');
+    expect(compatAudit?.session_id).toBe('sess_stream_blocked_canonical_1');
+    expect(compatAudit?.session_source).toBe('x-innies-session-id');
+    expect(compatAudit?.errorType).toBe('invalid_request_error');
+    expect(compatAudit?.errorMessage).toContain('blocked');
 
     compatAuditSpy.mockRestore();
     upstreamSpy.mockRestore();

--- a/api/tests/anthropicCompat.route.test.ts
+++ b/api/tests/anthropicCompat.route.test.ts
@@ -817,6 +817,8 @@ describe('anthropic compat route', () => {
     expect(lastLatency?.bridge_build_ms).toBeNull();
     expect(lastLatency?.openclaw_run_id).toBe('oc_run_123');
     expect(lastLatency?.openclaw_session_id).toBe('oc_sess_456');
+    expect(lastLatency?.session_id).toBe('sess_canonical_123');
+    expect(lastLatency?.session_source).toBe('x-innies-session-id');
     const routingArgs = routingSpy.mock.calls[0]?.[0] as any;
     expect(routingArgs?.routeDecision?.openclaw_run_id).toBe('oc_run_123');
     expect(routingArgs?.routeDecision?.openclaw_session_id).toBe('oc_sess_456');
@@ -2245,7 +2247,9 @@ describe('anthropic compat route', () => {
       headers: {
         authorization: 'Bearer in_test_token',
         'content-type': 'application/json',
-        'anthropic-beta': 'fine-grained-tool-streaming-2025-05-14'
+        'anthropic-beta': 'fine-grained-tool-streaming-2025-05-14',
+        'x-openclaw-session-id': 'oc_retry_session_1',
+        'x-innies-session-id': 'sess_retry_canonical_1'
       },
       body: {
         model: 'claude-opus-4-6',
@@ -2292,6 +2296,9 @@ describe('anthropic compat route', () => {
     expect(retryAudit?.org_id).toBe('818d0cc7-7ed2-469f-b690-a977e72a921d');
     expect(retryAudit?.model).toBe('claude-opus-4-6');
     expect(String(retryAudit?.openclaw_run_id ?? '')).toMatch(/^run_req_/);
+    expect(retryAudit?.openclaw_session_id).toBe('oc_retry_session_1');
+    expect(retryAudit?.session_id).toBe('sess_retry_canonical_1');
+    expect(retryAudit?.session_source).toBe('x-innies-session-id');
 
     retryAuditSpy.mockRestore();
     upstreamSpy.mockRestore();

--- a/api/tests/proxy.tokenMode.route.test.ts
+++ b/api/tests/proxy.tokenMode.route.test.ts
@@ -2124,7 +2124,8 @@ describe('proxy token-mode route behavior', () => {
         'content-type': 'application/json',
         'idempotency-key': 'abcdefghijklmnopqrstuvwxyz123456',
         'x-request-id': 'req_native_codex',
-        'x-innies-provider-pin': 'true'
+        'x-innies-provider-pin': 'true',
+        'x-innies-session-id': 'sess_proxy_native_1'
       },
       body: {
         model: 'gpt-5.4',
@@ -2155,9 +2156,184 @@ describe('proxy token-mode route behavior', () => {
         reason: 'cli_provider_pinned',
         provider_selection_reason: 'cli_provider_pinned',
         provider_effective: 'openai',
-        provider_plan: ['openai']
+        provider_plan: ['openai'],
+        session_id: 'sess_proxy_native_1',
+        session_source: 'x-innies-session-id'
       })
     }));
+    upstreamSpy.mockRestore();
+  });
+
+  it('uses x-innies-session-id on the direct token-mode proxy path', async () => {
+    process.env.TOKEN_MODE_ENABLED_ORGS = '818d0cc7-7ed2-469f-b690-a977e72a921d';
+    process.env.OPENAI_UPSTREAM_BASE_URL = 'https://openai.internal.test';
+    vi.spyOn(runtimeModule.runtime.repos.apiKeys, 'findActiveByHash').mockResolvedValue({
+      id: '11111111-1111-4111-8111-111111111111',
+      org_id: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      scope: 'buyer_proxy',
+      is_active: true,
+      expires_at: null,
+      preferred_provider: null
+    } as any);
+    vi.spyOn(runtimeModule.runtime.repos.modelCompatibility, 'findActive').mockResolvedValue({
+      provider: 'openai',
+      model: 'gpt-5.4',
+      supports_streaming: false
+    } as any);
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'listActiveForRouting').mockResolvedValue([{
+      id: 'dddd0002-0000-4000-8000-000000000000',
+      orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      provider: 'openai',
+      authScheme: 'x_api_key',
+      accessToken: 'openai-key-session',
+      refreshToken: null,
+      expiresAt: new Date('2026-03-02T00:00:00Z'),
+      status: 'active',
+      rotationVersion: 1,
+      createdAt: new Date('2026-03-01T00:00:00Z'),
+      updatedAt: new Date('2026-03-01T00:00:00Z'),
+      revokedAt: null,
+      monthlyContributionLimitUnits: null,
+      monthlyContributionUsedUnits: 0,
+      monthlyWindowStartAt: new Date('2026-03-01T00:00:00Z')
+    } as any]);
+    const upstreamSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ id: 'resp_native_session_ok' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' }
+      })
+    );
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/proxy/v1/responses',
+      headers: {
+        authorization: 'Bearer in_test_token',
+        'content-type': 'application/json',
+        'idempotency-key': 'abcdefghijklmnopqrstuvwxyz123456',
+        'x-request-id': 'req_native_codex_session',
+        'x-innies-provider-pin': 'true',
+        'x-innies-session-id': 'sess_cli_123'
+      },
+      body: {
+        model: 'gpt-5.4',
+        input: 'hello from stable session',
+        stream: false
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(handlers[0], req, res);
+    await invoke(handlers[1], req, res);
+
+    expect(res.statusCode).toBe(200);
+    const routeDecision = (runtimeModule.runtime.repos.routingEvents.insert as any).mock.calls[0]?.[0]?.routeDecision;
+    expect(routeDecision?.session_id).toBe('sess_cli_123');
+    expect(routeDecision?.session_source).toBe('x-innies-session-id');
+    expect(routeDecision?.openclaw_session_id).toBeNull();
+    upstreamSpy.mockRestore();
+  });
+
+  it('falls back to metadata session ids on direct proxy requests', async () => {
+    process.env.TOKEN_MODE_ENABLED_ORGS = '818d0cc7-7ed2-469f-b690-a977e72a921d';
+    process.env.ANTHROPIC_UPSTREAM_BASE_URL = 'https://anthropic.internal.test';
+    vi.spyOn(runtimeModule.runtime.repos.apiKeys, 'findActiveByHash').mockResolvedValue({
+      id: '11111111-1111-4111-8111-111111111111',
+      org_id: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      scope: 'buyer_proxy',
+      is_active: true,
+      expires_at: null,
+      preferred_provider: null
+    } as any);
+    vi.spyOn(runtimeModule.runtime.repos.modelCompatibility, 'findActive').mockResolvedValue({
+      provider: 'anthropic',
+      model: 'claude-opus-4-6',
+      supports_streaming: false
+    } as any);
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'listActiveForRouting').mockResolvedValue([{
+      id: 'dddd0002-0000-4000-8000-000000000000',
+      orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      provider: 'anthropic',
+      authScheme: 'bearer',
+      accessToken: 'anthropic-key-native',
+      refreshToken: null,
+      expiresAt: new Date('2026-03-02T00:00:00Z'),
+      status: 'active',
+      rotationVersion: 1,
+      createdAt: new Date('2026-03-01T00:00:00Z'),
+      updatedAt: new Date('2026-03-01T00:00:00Z'),
+      revokedAt: null,
+      monthlyContributionLimitUnits: null,
+      monthlyContributionUsedUnits: 0,
+      monthlyWindowStartAt: new Date('2026-03-01T00:00:00Z')
+    } as any]);
+    const upstreamSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ id: 'msg_direct_metadata_ok', usage: { input_tokens: 5, output_tokens: 2 } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' }
+      })
+    );
+
+    const cases = [
+      {
+        name: 'metadata.openclaw_session_id',
+        body: {
+          model: 'claude-opus-4-6',
+          max_tokens: 8,
+          messages: [{ role: 'user', content: 'hi' }],
+          stream: false,
+          metadata: {
+            openclaw_session_id: 'meta_direct_1'
+          }
+        },
+        expectedSessionId: 'meta_direct_1',
+        expectedSource: 'metadata.openclaw_session_id'
+      },
+      {
+        name: 'payload.metadata.openclaw_session_id',
+        body: {
+          provider: 'anthropic',
+          model: 'claude-opus-4-6',
+          streaming: false,
+          payload: {
+            model: 'claude-opus-4-6',
+            max_tokens: 8,
+            messages: [{ role: 'user', content: 'hi' }],
+            metadata: {
+              openclaw_session_id: 'payload_direct_2'
+            }
+          }
+        },
+        expectedSessionId: 'payload_direct_2',
+        expectedSource: 'payload.metadata.openclaw_session_id'
+      }
+    ] as const;
+
+    for (const testCase of cases) {
+      const req = createMockReq({
+        method: 'POST',
+        path: '/v1/proxy/v1/messages',
+        headers: {
+          authorization: 'Bearer in_test_token',
+          'content-type': 'application/json',
+          'idempotency-key': 'abcdefghijklmnopqrstuvwxyz123456',
+          'x-request-id': `req_${testCase.name}`,
+          'x-innies-provider-pin': 'true'
+        },
+        body: testCase.body
+      });
+      const res = createMockRes();
+
+      await invoke(handlers[0], req, res);
+      await invoke(handlers[1], req, res);
+
+      expect(res.statusCode, testCase.name).toBe(200);
+      const routeDecision = (runtimeModule.runtime.repos.routingEvents.insert as any).mock.calls.at(-1)?.[0]?.routeDecision;
+      expect(routeDecision?.session_id, testCase.name).toBe(testCase.expectedSessionId);
+      expect(routeDecision?.session_source, testCase.name).toBe(testCase.expectedSource);
+      expect(routeDecision?.openclaw_session_id, testCase.name).toBe(testCase.expectedSessionId);
+    }
+
     upstreamSpy.mockRestore();
   });
 

--- a/api/tests/proxy.tokenMode.route.test.ts
+++ b/api/tests/proxy.tokenMode.route.test.ts
@@ -553,7 +553,8 @@ describe('proxy token-mode route behavior', () => {
         'content-type': 'application/json',
         'idempotency-key': 'abcdefghijklmnopqrstuvwxyz123456',
         'anthropic-version': '2023-06-01',
-        'x-innies-provider-pin': 'true'
+        'x-innies-provider-pin': 'true',
+        'x-innies-session-id': 'sess_auth_canonical_1'
       },
       body: {
         provider: 'anthropic',
@@ -1011,7 +1012,8 @@ describe('proxy token-mode route behavior', () => {
         'content-type': 'application/json',
         'idempotency-key': 'abcdefghijklmnopqrstuvwxyz123456',
         'anthropic-version': '2023-06-01',
-        'x-innies-provider-pin': 'true'
+        'x-innies-provider-pin': 'true',
+        'x-innies-session-id': 'sess_auth_canonical_1'
       },
       body: {
         provider: 'anthropic',
@@ -1043,6 +1045,9 @@ describe('proxy token-mode route behavior', () => {
     expect(authAudit?.provider).toBe('anthropic');
     expect(authAudit?.model).toBe('claude-3-5-sonnet-latest');
     expect(String(authAudit?.openclaw_run_id ?? '')).toMatch(/^run_req_/);
+    expect(authAudit?.openclaw_session_id).toBeNull();
+    expect(authAudit?.session_id).toBe('sess_auth_canonical_1');
+    expect(authAudit?.session_source).toBe('x-innies-session-id');
 
     authFailureSpy.mockRestore();
     upstreamSpy.mockRestore();
@@ -2749,7 +2754,9 @@ describe('proxy token-mode route behavior', () => {
         authorization: 'Bearer in_test_token',
         'content-type': 'application/json',
         'idempotency-key': 'abcdefghijklmnopqrstuvwxyz123456',
-        'anthropic-version': '2023-06-01'
+        'anthropic-version': '2023-06-01',
+        'x-openclaw-session-id': 'oc_stream_session_1',
+        'x-innies-session-id': 'sess_stream_canonical_1'
       },
       body: {
         provider: 'anthropic',
@@ -2789,6 +2796,9 @@ describe('proxy token-mode route behavior', () => {
     expect(lastLatency?.stream_mode).toBe('synthetic_bridge');
     expect(lastLatency?.synthetic_content_block_count).toBe(2);
     expect(lastLatency?.synthetic_content_block_types).toBe('text,tool_use');
+    expect(lastLatency?.openclaw_session_id).toBe('oc_stream_session_1');
+    expect(lastLatency?.session_id).toBe('sess_stream_canonical_1');
+    expect(lastLatency?.session_source).toBe('x-innies-session-id');
 
     upstreamSpy.mockRestore();
     streamLatencySpy.mockRestore();

--- a/cli/scripts/smoke.sh
+++ b/cli/scripts/smoke.sh
@@ -78,6 +78,7 @@ set -euo pipefail
   echo "INNIES_PROXY_URL:${INNIES_PROXY_URL:-}"
   echo "INNIES_TOKEN:${INNIES_TOKEN:-}"
   echo "INNIES_CORRELATION_ID:${INNIES_CORRELATION_ID:-}"
+  echo "INNIES_SESSION_ID:${INNIES_SESSION_ID:-}"
   echo "INNIES_PROVIDER_PIN:${INNIES_PROVIDER_PIN:-}"
   echo "OPENAI_API_KEY:${OPENAI_API_KEY:-}"
   echo "OPENAI_BASE_URL:${OPENAI_BASE_URL:-}"
@@ -218,6 +219,11 @@ if ! grep -q 'arg:model_providers.innies.env_http_headers."x-request-id"="INNIES
   exit 1
 fi
 
+if ! grep -q 'arg:model_providers.innies.env_http_headers."x-innies-session-id"="INNIES_SESSION_ID"' "$FAKE_CODEX_LOG"; then
+  echo "smoke: missing codex session header wiring"
+  exit 1
+fi
+
 if ! grep -q 'arg:model_providers.innies.env_http_headers."x-innies-provider-pin"="INNIES_PROVIDER_PIN"' "$FAKE_CODEX_LOG"; then
   echo "smoke: missing codex pin header wiring"
   exit 1
@@ -245,6 +251,11 @@ fi
 
 if ! grep -q 'INNIES_PROVIDER_PIN:true' "$FAKE_CODEX_LOG"; then
   echo "smoke: missing codex provider pin env wiring"
+  exit 1
+fi
+
+if ! grep -Eq 'INNIES_SESSION_ID:sess_[[:alnum:]-]+' "$FAKE_CODEX_LOG"; then
+  echo "smoke: missing codex session env wiring"
   exit 1
 fi
 

--- a/cli/src/commands/codex.js
+++ b/cli/src/commands/codex.js
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { spawn } from 'node:child_process';
 import { loadConfig, resolveProviderDefaultModel } from '../config.js';
 import { buildCorrelationId, fail } from '../utils.js';
@@ -37,6 +38,7 @@ export function buildCodexArgs(input) {
     '--config', `${providerPath}.supports_websockets=false`,
     '--config', 'responses_websockets_v2=false',
     '--config', `${providerPath}.env_http_headers."x-request-id"="INNIES_CORRELATION_ID"`,
+    '--config', `${providerPath}.env_http_headers."x-innies-session-id"="INNIES_SESSION_ID"`,
     '--config', `${providerPath}.env_http_headers."x-innies-provider-pin"="INNIES_PROVIDER_PIN"`
   ];
 
@@ -45,6 +47,24 @@ export function buildCodexArgs(input) {
   }
 
   return [...forcedArgs, ...args];
+}
+
+export function buildCodexEnv(input) {
+  return {
+    ...input.baseEnv,
+    MallocStackLogging: '',
+    INNIES_CODEX_WRAPPED: '1',
+    INNIES_TOKEN: input.token,
+    INNIES_API_BASE_URL: input.apiBaseUrl,
+    INNIES_PROXY_URL: input.proxyUrl,
+    INNIES_MODEL: input.model,
+    INNIES_ROUTE_MODE: 'token',
+    INNIES_CORRELATION_ID: input.correlationId,
+    INNIES_SESSION_ID: input.sessionId,
+    INNIES_PROVIDER_PIN: 'true',
+    OPENAI_API_KEY: input.token,
+    OPENAI_BASE_URL: input.proxyUrl
+  };
 }
 
 export async function runCodex(args) {
@@ -74,6 +94,7 @@ export async function runCodex(args) {
   const model = resolveProviderDefaultModel(config, 'openai');
   const proxyUrl = proxyBase(config.apiBaseUrl);
   const correlationId = buildCorrelationId();
+  const sessionId = `sess_${randomUUID()}`;
   const codexBinary = resolveWrappedBinary({
     binaryName: 'codex',
     displayName: 'Codex',
@@ -82,20 +103,15 @@ export async function runCodex(args) {
 
   printConnectionStatus({ model, proxyUrl, correlationId });
 
-  const env = {
-    ...process.env,
-    MallocStackLogging: '',
-    INNIES_CODEX_WRAPPED: '1',
-    INNIES_TOKEN: config.token,
-    INNIES_API_BASE_URL: config.apiBaseUrl,
-    INNIES_PROXY_URL: proxyUrl,
-    INNIES_MODEL: model,
-    INNIES_ROUTE_MODE: 'token',
-    INNIES_CORRELATION_ID: correlationId,
-    INNIES_PROVIDER_PIN: 'true',
-    OPENAI_API_KEY: config.token,
-    OPENAI_BASE_URL: proxyUrl
-  };
+  const env = buildCodexEnv({
+    baseEnv: process.env,
+    token: config.token,
+    apiBaseUrl: config.apiBaseUrl,
+    proxyUrl,
+    model,
+    correlationId,
+    sessionId
+  });
 
   const captureOutput = shouldCaptureCommandOutput('INNIES_CAPTURE_CODEX_OUTPUT');
   let combinedOutput = '';

--- a/cli/tests/codexArgs.test.js
+++ b/cli/tests/codexArgs.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { buildCodexArgs, hasExplicitModelArg } from '../src/commands/codex.js';
+import { buildCodexArgs, buildCodexEnv, hasExplicitModelArg } from '../src/commands/codex.js';
 
 test('detects explicit codex model override forms', () => {
   assert.equal(hasExplicitModelArg(['--model', 'gpt-5.5']), true);
@@ -29,4 +29,24 @@ test('injects a custom codex provider config that points at the innies proxy', (
   assert.ok(args.includes('model_providers.innies.requires_openai_auth=false'));
   assert.ok(args.includes('model_providers.innies.supports_websockets=false'));
   assert.ok(args.includes('responses_websockets_v2=false'));
+  assert.ok(args.includes('model_providers.innies.env_http_headers."x-innies-session-id"="INNIES_SESSION_ID"'));
+});
+
+test('exports one session id per codex invocation environment', () => {
+  const env = buildCodexEnv({
+    baseEnv: { PATH: '/tmp/bin' },
+    token: 'in_live_test',
+    apiBaseUrl: 'https://api.innies.computer',
+    proxyUrl: 'https://api.innies.computer/v1/proxy/v1',
+    model: 'gpt-5.4',
+    correlationId: 'req_123',
+    sessionId: 'sess_abc123'
+  });
+
+  assert.equal(env.PATH, '/tmp/bin');
+  assert.equal(env.INNIES_SESSION_ID, 'sess_abc123');
+  assert.equal(env.INNIES_CORRELATION_ID, 'req_123');
+  assert.equal(env.INNIES_PROVIDER_PIN, 'true');
+  assert.equal(env.OPENAI_API_KEY, 'in_live_test');
+  assert.equal(env.OPENAI_BASE_URL, 'https://api.innies.computer/v1/proxy/v1');
 });

--- a/docs/API_CONTRACT.md
+++ b/docs/API_CONTRACT.md
@@ -94,6 +94,8 @@ Notes:
   - `provider_fallback_reason`
   - `openclaw_run_id`
   - `openclaw_session_id`
+  - `session_id`
+  - `session_source`
 - Current reason values:
   - `preferred_provider_selected`
   - `fallback_provider_selected`


### PR DESCRIPTION
## Summary
- add a shared session-identity helper for canonical `x-innies-session-id` resolution with the documented OpenClaw fallback order
- thread `session_id` and `session_source` into proxy routing metadata while preserving existing OpenClaw correlation fields and compat-mode semantics
- make `innies codex` generate one per-process session id, forward it via `x-innies-session-id`, and cover the wiring in unit and smoke tests

## Test Plan
- cd api && npx vitest run tests/anthropicCompat.route.test.ts tests/proxy.tokenMode.route.test.ts
- cd cli && node --test tests/codexArgs.test.js
- cd cli && npm run test:smoke

Fixes #70