### PR TITLE
feat: add token affinity persistence

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -18,6 +18,7 @@
         "@types/express": "^4.17.23",
         "@types/node": "^20.19.13",
         "@types/pg": "^8.11.11",
+        "pg-mem": "^3.0.14",
         "tsx": "^4.20.5",
         "typescript": "^5.9.2",
         "vitest": "^3.2.4"
@@ -1164,6 +1165,25 @@
         "node": ">=8"
       }
     },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -1220,6 +1240,13 @@
         "node": ">= 16"
       }
     },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -1275,6 +1302,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -1293,6 +1338,13 @@
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
       }
+    },
+    "node_modules/discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dotenv": {
       "version": "17.2.3",
@@ -1579,6 +1631,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -1641,6 +1700,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -1697,6 +1769,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/immutable": {
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
+      "integrity": "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -1712,6 +1791,13 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
@@ -1719,12 +1805,55 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
       "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -1805,6 +1934,23 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moo": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.3.tgz",
+      "integrity": "sha512-m2fmM2dDm7GZQsY7KK2cme8agi+AAljILjQnof7p1ZMDe6dQ4bdnSMx0cPppudoeNv5hEFQirN6u+O4fDE0IWA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -1830,6 +1976,29 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/nearley": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.19.0",
+        "moo": "^0.5.0",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6"
+      },
+      "bin": {
+        "nearley-railroad": "bin/nearley-railroad.js",
+        "nearley-test": "bin/nearley-test.js",
+        "nearley-unparse": "bin/nearley-unparse.js",
+        "nearleyc": "bin/nearleyc.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://nearley.js.org/#give-to-nearley"
+      }
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -1837,6 +2006,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
@@ -1849,6 +2028,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/on-finished": {
@@ -1972,6 +2161,65 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/pg-mem": {
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/pg-mem/-/pg-mem-3.0.14.tgz",
+      "integrity": "sha512-G9m8OD0A+YS083smidSUJddTX2dEDPT8mRMG3sQGNiGfS/mkvAgd9Kf1/onD5633bFN7HcQK/Tn2x7qjBMFRUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "functional-red-black-tree": "^1.0.1",
+        "immutable": "^4.3.4",
+        "json-stable-stringify": "^1.0.1",
+        "lru-cache": "^6.0.0",
+        "moment": "^2.27.0",
+        "object-hash": "^2.0.3",
+        "pgsql-ast-parser": "^12.0.2"
+      },
+      "peerDependencies": {
+        "@mikro-orm/core": ">=4.5.3",
+        "@mikro-orm/postgresql": ">=4.5.3",
+        "knex": ">=0.20",
+        "kysely": ">=0.26",
+        "pg-promise": ">=10.8.7",
+        "pg-server": "^0.1.5",
+        "postgres": "^3.4.4",
+        "slonik": ">=23.0.1",
+        "typeorm": ">=0.2.29"
+      },
+      "peerDependenciesMeta": {
+        "@mikro-orm/core": {
+          "optional": true
+        },
+        "@mikro-orm/postgresql": {
+          "optional": true
+        },
+        "knex": {
+          "optional": true
+        },
+        "kysely": {
+          "optional": true
+        },
+        "mikro-orm": {
+          "optional": true
+        },
+        "pg-promise": {
+          "optional": true
+        },
+        "pg-server": {
+          "optional": true
+        },
+        "postgres": {
+          "optional": true
+        },
+        "slonik": {
+          "optional": true
+        },
+        "typeorm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/pg-pool": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.12.0.tgz",
@@ -2010,6 +2258,17 @@
       "license": "MIT",
       "dependencies": {
         "split2": "^4.1.0"
+      }
+    },
+    "node_modules/pgsql-ast-parser": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/pgsql-ast-parser/-/pgsql-ast-parser-12.0.2.tgz",
+      "integrity": "sha512-1WWa96Sw6h4uv9GLw98EzH/+xoBTC8j2TwV/AMW3E+Ir/fHOu/jLLbj6kPiz3y2bGISTKNYvKWwHoqvQ5FLuAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "moo": "^0.5.1",
+        "nearley": "^2.19.5"
       }
     },
     "node_modules/picocolors": {
@@ -2128,6 +2387,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -2160,6 +2440,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12"
       }
     },
     "node_modules/rollup": {
@@ -2276,6 +2566,24 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/setprototypeof": {
@@ -2815,6 +3123,13 @@
       "engines": {
         "node": ">=0.4"
       }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/zod": {
       "version": "4.3.6",

--- a/api/package.json
+++ b/api/package.json
@@ -21,6 +21,7 @@
     "@types/express": "^4.17.23",
     "@types/node": "^20.19.13",
     "@types/pg": "^8.11.11",
+    "pg-mem": "^3.0.14",
     "tsx": "^4.20.5",
     "typescript": "^5.9.2",
     "vitest": "^3.2.4"

--- a/api/src/repos/tableNames.ts
+++ b/api/src/repos/tableNames.ts
@@ -5,6 +5,8 @@ export const TABLES = {
   orgs: 'in_orgs',
   requestLog: 'in_request_log',
   sellerKeys: 'in_seller_keys',
+  tokenAffinityActiveStreams: 'in_token_affinity_active_streams',
+  tokenAffinityAssignments: 'in_token_affinity_assignments',
   tokenCredentialProviderUsage: 'in_token_credential_provider_usage',
   tokenCredentials: 'in_token_credentials',
   tokenCredentialEvents: 'in_token_credential_events',

--- a/api/src/repos/tokenAffinityRepository.ts
+++ b/api/src/repos/tokenAffinityRepository.ts
@@ -55,6 +55,14 @@ export type GetPreferredAssignmentInput = {
   sessionId: string;
 };
 
+type ActiveStreamOwnerInput = {
+  requestId: string;
+  orgId: string;
+  provider: string;
+  credentialId: string;
+  sessionId: string;
+};
+
 export type ClaimPreferredAssignmentInput = GetPreferredAssignmentInput & {
   credentialId: string;
 };
@@ -74,22 +82,13 @@ export type TouchPreferredAssignmentInput = GetPreferredAssignmentInput & {
   graceExpiresAt: Date | null;
 };
 
-export type UpsertActiveStreamInput = {
-  requestId: string;
-  orgId: string;
-  provider: string;
-  credentialId: string;
-  sessionId: string;
-};
+export type UpsertActiveStreamInput = ActiveStreamOwnerInput;
 
-export type TouchActiveStreamInput = {
-  requestId: string;
+export type TouchActiveStreamInput = ActiveStreamOwnerInput & {
   touchedAt: Date;
 };
 
-export type ClearActiveStreamInput = {
-  requestId: string;
-};
+export type ClearActiveStreamInput = ActiveStreamOwnerInput;
 
 export type ListBusyCredentialIdsInput = {
   orgId: string;
@@ -127,9 +126,9 @@ function mapActiveStreamRow(row: TokenAffinityActiveStreamRow): TokenAffinityAct
   };
 }
 
-async function selectActiveStreamByRequestId(
+async function selectActiveStreamByOwner(
   db: Pick<SqlClient, 'query'> | TransactionContext,
-  requestId: string
+  input: ActiveStreamOwnerInput
 ): Promise<TokenAffinityActiveStream | null> {
   const result = await db.query<TokenAffinityActiveStreamRow>(
     `
@@ -143,10 +142,15 @@ async function selectActiveStreamByRequestId(
         last_touched_at,
         ended_at
       from ${TABLES.tokenAffinityActiveStreams}
-      where request_id = $1
+      where
+        org_id = $1::uuid
+        and provider = $2
+        and credential_id = $3::uuid
+        and session_id = $4
+        and request_id = $5
       limit 1
     `,
-    [requestId]
+    [input.orgId, input.provider, input.credentialId, input.sessionId, input.requestId]
   );
 
   return result.rowCount === 1 ? mapActiveStreamRow(result.rows[0]) : null;
@@ -333,15 +337,10 @@ export class TokenAffinityRepository {
             last_touched_at,
             ended_at
           ) values ($1, $2::uuid, $3, $4::uuid, $5, now(), now(), null)
-          on conflict (request_id)
+          on conflict (org_id, provider, credential_id, session_id, request_id)
           do update set
             last_touched_at = excluded.last_touched_at,
             ended_at = null
-          where
-            ${TABLES.tokenAffinityActiveStreams}.org_id = excluded.org_id
-            and ${TABLES.tokenAffinityActiveStreams}.provider = excluded.provider
-            and ${TABLES.tokenAffinityActiveStreams}.credential_id = excluded.credential_id
-            and ${TABLES.tokenAffinityActiveStreams}.session_id = excluded.session_id
           returning
             request_id,
             org_id,
@@ -365,7 +364,7 @@ export class TokenAffinityRepository {
         return mapActiveStreamRow(result.rows[0]);
       }
 
-      const existing = await selectActiveStreamByRequestId(tx, input.requestId);
+      const existing = await selectActiveStreamByOwner(tx, input);
       if (existing) {
         return existing;
       }
@@ -379,11 +378,17 @@ export class TokenAffinityRepository {
       `
         update ${TABLES.tokenAffinityActiveStreams}
         set
-          last_touched_at = $2,
+          last_touched_at = $6,
           ended_at = null
-        where request_id = $1 and ended_at is null
+        where
+          org_id = $1::uuid
+          and provider = $2
+          and credential_id = $3::uuid
+          and session_id = $4
+          and request_id = $5
+          and ended_at is null
       `,
-      [input.requestId, input.touchedAt]
+      [input.orgId, input.provider, input.credentialId, input.sessionId, input.requestId, input.touchedAt]
     );
 
     return result.rowCount > 0;
@@ -393,7 +398,12 @@ export class TokenAffinityRepository {
     const result = await this.db.query<TokenAffinityActiveStreamRow>(
       `
         delete from ${TABLES.tokenAffinityActiveStreams}
-        where request_id = $1
+        where
+          org_id = $1::uuid
+          and provider = $2
+          and credential_id = $3::uuid
+          and session_id = $4
+          and request_id = $5
         returning
           request_id,
           org_id,
@@ -404,7 +414,7 @@ export class TokenAffinityRepository {
           last_touched_at,
           ended_at
       `,
-      [input.requestId]
+      [input.orgId, input.provider, input.credentialId, input.sessionId, input.requestId]
     );
 
     return result.rowCount === 1 ? mapActiveStreamRow(result.rows[0]) : null;

--- a/api/src/repos/tokenAffinityRepository.ts
+++ b/api/src/repos/tokenAffinityRepository.ts
@@ -127,6 +127,31 @@ function mapActiveStreamRow(row: TokenAffinityActiveStreamRow): TokenAffinityAct
   };
 }
 
+async function selectActiveStreamByRequestId(
+  db: Pick<SqlClient, 'query'> | TransactionContext,
+  requestId: string
+): Promise<TokenAffinityActiveStream | null> {
+  const result = await db.query<TokenAffinityActiveStreamRow>(
+    `
+      select
+        request_id,
+        org_id,
+        provider,
+        credential_id,
+        session_id,
+        started_at,
+        last_touched_at,
+        ended_at
+      from ${TABLES.tokenAffinityActiveStreams}
+      where request_id = $1
+      limit 1
+    `,
+    [requestId]
+  );
+
+  return result.rowCount === 1 ? mapActiveStreamRow(result.rows[0]) : null;
+}
+
 async function selectAssignmentBySession(
   tx: TransactionContext,
   input: GetPreferredAssignmentInput
@@ -295,50 +320,58 @@ export class TokenAffinityRepository {
   }
 
   async upsertActiveStream(input: UpsertActiveStreamInput): Promise<TokenAffinityActiveStream> {
-    const result = await this.db.query<TokenAffinityActiveStreamRow>(
-      `
-        insert into ${TABLES.tokenAffinityActiveStreams} (
-          request_id,
-          org_id,
-          provider,
-          credential_id,
-          session_id,
-          started_at,
-          last_touched_at,
-          ended_at
-        ) values ($1, $2::uuid, $3, $4::uuid, $5, now(), now(), null)
-        on conflict (request_id)
-        do update set
-          org_id = excluded.org_id,
-          provider = excluded.provider,
-          credential_id = excluded.credential_id,
-          session_id = excluded.session_id,
-          last_touched_at = excluded.last_touched_at,
-          ended_at = null
-        returning
-          request_id,
-          org_id,
-          provider,
-          credential_id,
-          session_id,
-          started_at,
-          last_touched_at,
-          ended_at
-      `,
-      [
-        input.requestId,
-        input.orgId,
-        input.provider,
-        input.credentialId,
-        input.sessionId
-      ]
-    );
+    return this.db.transaction(async (tx) => {
+      const result = await tx.query<TokenAffinityActiveStreamRow>(
+        `
+          insert into ${TABLES.tokenAffinityActiveStreams} (
+            request_id,
+            org_id,
+            provider,
+            credential_id,
+            session_id,
+            started_at,
+            last_touched_at,
+            ended_at
+          ) values ($1, $2::uuid, $3, $4::uuid, $5, now(), now(), null)
+          on conflict (request_id)
+          do update set
+            last_touched_at = excluded.last_touched_at,
+            ended_at = null
+          where
+            ${TABLES.tokenAffinityActiveStreams}.org_id = excluded.org_id
+            and ${TABLES.tokenAffinityActiveStreams}.provider = excluded.provider
+            and ${TABLES.tokenAffinityActiveStreams}.credential_id = excluded.credential_id
+            and ${TABLES.tokenAffinityActiveStreams}.session_id = excluded.session_id
+          returning
+            request_id,
+            org_id,
+            provider,
+            credential_id,
+            session_id,
+            started_at,
+            last_touched_at,
+            ended_at
+        `,
+        [
+          input.requestId,
+          input.orgId,
+          input.provider,
+          input.credentialId,
+          input.sessionId
+        ]
+      );
 
-    if (result.rowCount !== 1) {
+      if (result.rowCount === 1) {
+        return mapActiveStreamRow(result.rows[0]);
+      }
+
+      const existing = await selectActiveStreamByRequestId(tx, input.requestId);
+      if (existing) {
+        return existing;
+      }
+
       throw new Error('expected active stream upsert');
-    }
-
-    return mapActiveStreamRow(result.rows[0]);
+    });
   }
 
   async touchActiveStream(input: TouchActiveStreamInput): Promise<boolean> {

--- a/api/src/repos/tokenAffinityRepository.ts
+++ b/api/src/repos/tokenAffinityRepository.ts
@@ -1,0 +1,414 @@
+import type { SqlClient, SqlValue, TransactionContext } from './sqlClient.js';
+import { TABLES } from './tableNames.js';
+
+type TokenAffinityAssignmentRow = {
+  org_id: string;
+  provider: string;
+  credential_id: string;
+  session_id: string;
+  last_activity_at: string | Date;
+  grace_expires_at: string | Date | null;
+  created_at: string | Date;
+  updated_at: string | Date;
+};
+
+type TokenAffinityActiveStreamRow = {
+  request_id: string;
+  org_id: string;
+  provider: string;
+  credential_id: string;
+  session_id: string;
+  started_at: string | Date;
+  last_touched_at: string | Date;
+  ended_at: string | Date | null;
+};
+
+type CredentialIdRow = {
+  credential_id: string;
+};
+
+export type TokenAffinityAssignment = {
+  orgId: string;
+  provider: string;
+  credentialId: string;
+  sessionId: string;
+  lastActivityAt: Date;
+  graceExpiresAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type TokenAffinityActiveStream = {
+  requestId: string;
+  orgId: string;
+  provider: string;
+  credentialId: string;
+  sessionId: string;
+  startedAt: Date;
+  lastTouchedAt: Date;
+  endedAt: Date | null;
+};
+
+export type GetPreferredAssignmentInput = {
+  orgId: string;
+  provider: string;
+  sessionId: string;
+};
+
+export type ClaimPreferredAssignmentInput = GetPreferredAssignmentInput & {
+  credentialId: string;
+};
+
+export type ClaimPreferredAssignmentResult =
+  | { outcome: 'claimed'; assignment: TokenAffinityAssignment }
+  | { outcome: 'already_owned_by_session'; assignment: TokenAffinityAssignment }
+  | { outcome: 'credential_unavailable' }
+  | { outcome: 'session_already_bound'; assignment: TokenAffinityAssignment };
+
+export type ClearPreferredAssignmentInput = GetPreferredAssignmentInput & {
+  credentialId?: string;
+};
+
+export type TouchPreferredAssignmentInput = GetPreferredAssignmentInput & {
+  credentialId: string;
+  graceExpiresAt: Date | null;
+};
+
+export type UpsertActiveStreamInput = {
+  requestId: string;
+  orgId: string;
+  provider: string;
+  credentialId: string;
+  sessionId: string;
+};
+
+export type TouchActiveStreamInput = {
+  requestId: string;
+  touchedAt: Date;
+};
+
+export type ClearActiveStreamInput = {
+  requestId: string;
+};
+
+export type ListBusyCredentialIdsInput = {
+  orgId: string;
+  provider: string;
+  staleBefore: Date;
+};
+
+export type ClearStaleActiveStreamsInput = {
+  staleBefore: Date;
+};
+
+function mapAssignmentRow(row: TokenAffinityAssignmentRow): TokenAffinityAssignment {
+  return {
+    orgId: row.org_id,
+    provider: row.provider,
+    credentialId: row.credential_id,
+    sessionId: row.session_id,
+    lastActivityAt: new Date(row.last_activity_at),
+    graceExpiresAt: row.grace_expires_at ? new Date(row.grace_expires_at) : null,
+    createdAt: new Date(row.created_at),
+    updatedAt: new Date(row.updated_at)
+  };
+}
+
+function mapActiveStreamRow(row: TokenAffinityActiveStreamRow): TokenAffinityActiveStream {
+  return {
+    requestId: row.request_id,
+    orgId: row.org_id,
+    provider: row.provider,
+    credentialId: row.credential_id,
+    sessionId: row.session_id,
+    startedAt: new Date(row.started_at),
+    lastTouchedAt: new Date(row.last_touched_at),
+    endedAt: row.ended_at ? new Date(row.ended_at) : null
+  };
+}
+
+async function selectAssignmentBySession(
+  tx: TransactionContext,
+  input: GetPreferredAssignmentInput
+): Promise<TokenAffinityAssignment | null> {
+  const result = await tx.query<TokenAffinityAssignmentRow>(
+    `
+      select
+        org_id,
+        provider,
+        credential_id,
+        session_id,
+        last_activity_at,
+        grace_expires_at,
+        created_at,
+        updated_at
+      from ${TABLES.tokenAffinityAssignments}
+      where org_id = $1::uuid and provider = $2 and session_id = $3
+      limit 1
+    `,
+    [input.orgId, input.provider, input.sessionId]
+  );
+
+  return result.rowCount === 1 ? mapAssignmentRow(result.rows[0]) : null;
+}
+
+async function selectAssignmentByCredential(
+  tx: TransactionContext,
+  input: { orgId: string; provider: string; credentialId: string }
+): Promise<TokenAffinityAssignment | null> {
+  const result = await tx.query<TokenAffinityAssignmentRow>(
+    `
+      select
+        org_id,
+        provider,
+        credential_id,
+        session_id,
+        last_activity_at,
+        grace_expires_at,
+        created_at,
+        updated_at
+      from ${TABLES.tokenAffinityAssignments}
+      where org_id = $1::uuid and provider = $2 and credential_id = $3::uuid
+      limit 1
+    `,
+    [input.orgId, input.provider, input.credentialId]
+  );
+
+  return result.rowCount === 1 ? mapAssignmentRow(result.rows[0]) : null;
+}
+
+export class TokenAffinityRepository {
+  constructor(private readonly db: SqlClient) {}
+
+  async getPreferredAssignment(input: GetPreferredAssignmentInput): Promise<TokenAffinityAssignment | null> {
+    return selectAssignmentBySession(this.db, input);
+  }
+
+  async claimPreferredAssignment(input: ClaimPreferredAssignmentInput): Promise<ClaimPreferredAssignmentResult> {
+    return this.db.transaction(async (tx) => {
+      const existingBySession = await selectAssignmentBySession(tx, input);
+      if (existingBySession) {
+        return existingBySession.credentialId === input.credentialId
+          ? { outcome: 'already_owned_by_session', assignment: existingBySession }
+          : { outcome: 'session_already_bound', assignment: existingBySession };
+      }
+
+      const params: SqlValue[] = [
+        input.orgId,
+        input.provider,
+        input.credentialId,
+        input.sessionId
+      ];
+
+      const inserted = await tx.query<TokenAffinityAssignmentRow>(
+        `
+          insert into ${TABLES.tokenAffinityAssignments} (
+            org_id,
+            provider,
+            credential_id,
+            session_id,
+            last_activity_at,
+            grace_expires_at,
+            created_at,
+            updated_at
+          ) values ($1::uuid, $2, $3::uuid, $4, now(), null, now(), now())
+          on conflict do nothing
+          returning
+            org_id,
+            provider,
+            credential_id,
+            session_id,
+            last_activity_at,
+            grace_expires_at,
+            created_at,
+            updated_at
+        `,
+        params
+      );
+
+      if (inserted.rowCount === 1) {
+        return { outcome: 'claimed', assignment: mapAssignmentRow(inserted.rows[0]) };
+      }
+
+      const reboundBySession = await selectAssignmentBySession(tx, input);
+      if (reboundBySession) {
+        return reboundBySession.credentialId === input.credentialId
+          ? { outcome: 'already_owned_by_session', assignment: reboundBySession }
+          : { outcome: 'session_already_bound', assignment: reboundBySession };
+      }
+
+      const reboundByCredential = await selectAssignmentByCredential(tx, input);
+      if (reboundByCredential && reboundByCredential.sessionId === input.sessionId) {
+        return { outcome: 'already_owned_by_session', assignment: reboundByCredential };
+      }
+
+      return { outcome: 'credential_unavailable' };
+    });
+  }
+
+  async clearPreferredAssignment(input: ClearPreferredAssignmentInput): Promise<boolean> {
+    const params: SqlValue[] = [input.orgId, input.provider, input.sessionId];
+    const where = [
+      'org_id = $1::uuid',
+      'provider = $2',
+      'session_id = $3'
+    ];
+
+    if (input.credentialId) {
+      params.push(input.credentialId);
+      where.push(`credential_id = $${params.length}::uuid`);
+    }
+
+    const result = await this.db.query(
+      `
+        delete from ${TABLES.tokenAffinityAssignments}
+        where ${where.join(' and ')}
+      `,
+      params
+    );
+
+    return result.rowCount > 0;
+  }
+
+  async touchPreferredAssignment(input: TouchPreferredAssignmentInput): Promise<boolean> {
+    const params: SqlValue[] = [
+      input.orgId,
+      input.provider,
+      input.sessionId,
+      input.credentialId,
+      input.graceExpiresAt
+    ];
+
+    const result = await this.db.query(
+      `
+        update ${TABLES.tokenAffinityAssignments}
+        set
+          last_activity_at = now(),
+          grace_expires_at = $5,
+          updated_at = now()
+        where org_id = $1::uuid and provider = $2 and session_id = $3 and credential_id = $4::uuid
+      `,
+      params
+    );
+
+    return result.rowCount > 0;
+  }
+
+  async upsertActiveStream(input: UpsertActiveStreamInput): Promise<TokenAffinityActiveStream> {
+    const result = await this.db.query<TokenAffinityActiveStreamRow>(
+      `
+        insert into ${TABLES.tokenAffinityActiveStreams} (
+          request_id,
+          org_id,
+          provider,
+          credential_id,
+          session_id,
+          started_at,
+          last_touched_at,
+          ended_at
+        ) values ($1, $2::uuid, $3, $4::uuid, $5, now(), now(), null)
+        on conflict (request_id)
+        do update set
+          org_id = excluded.org_id,
+          provider = excluded.provider,
+          credential_id = excluded.credential_id,
+          session_id = excluded.session_id,
+          last_touched_at = excluded.last_touched_at,
+          ended_at = null
+        returning
+          request_id,
+          org_id,
+          provider,
+          credential_id,
+          session_id,
+          started_at,
+          last_touched_at,
+          ended_at
+      `,
+      [
+        input.requestId,
+        input.orgId,
+        input.provider,
+        input.credentialId,
+        input.sessionId
+      ]
+    );
+
+    if (result.rowCount !== 1) {
+      throw new Error('expected active stream upsert');
+    }
+
+    return mapActiveStreamRow(result.rows[0]);
+  }
+
+  async touchActiveStream(input: TouchActiveStreamInput): Promise<boolean> {
+    const result = await this.db.query(
+      `
+        update ${TABLES.tokenAffinityActiveStreams}
+        set
+          last_touched_at = $2,
+          ended_at = null
+        where request_id = $1 and ended_at is null
+      `,
+      [input.requestId, input.touchedAt]
+    );
+
+    return result.rowCount > 0;
+  }
+
+  async clearActiveStream(input: ClearActiveStreamInput): Promise<TokenAffinityActiveStream | null> {
+    const result = await this.db.query<TokenAffinityActiveStreamRow>(
+      `
+        delete from ${TABLES.tokenAffinityActiveStreams}
+        where request_id = $1
+        returning
+          request_id,
+          org_id,
+          provider,
+          credential_id,
+          session_id,
+          started_at,
+          last_touched_at,
+          ended_at
+      `,
+      [input.requestId]
+    );
+
+    return result.rowCount === 1 ? mapActiveStreamRow(result.rows[0]) : null;
+  }
+
+  async listBusyCredentialIds(input: ListBusyCredentialIdsInput): Promise<string[]> {
+    const result = await this.db.query<CredentialIdRow>(
+      `
+        select distinct credential_id
+        from ${TABLES.tokenAffinityActiveStreams}
+        where org_id = $1::uuid and provider = $2 and last_touched_at >= $3 and ended_at is null
+        order by credential_id asc
+      `,
+      [input.orgId, input.provider, input.staleBefore]
+    );
+
+    return result.rows.map((row) => row.credential_id);
+  }
+
+  async clearStaleActiveStreams(input: ClearStaleActiveStreamsInput): Promise<TokenAffinityActiveStream[]> {
+    const result = await this.db.query<TokenAffinityActiveStreamRow>(
+      `
+        delete from ${TABLES.tokenAffinityActiveStreams}
+        where last_touched_at < $1 and ended_at is null
+        returning
+          request_id,
+          org_id,
+          provider,
+          credential_id,
+          session_id,
+          started_at,
+          last_touched_at,
+          ended_at
+      `,
+      [input.staleBefore]
+    );
+
+    return result.rows.map(mapActiveStreamRow);
+  }
+}

--- a/api/tests/tokenAffinityRepository.test.ts
+++ b/api/tests/tokenAffinityRepository.test.ts
@@ -272,6 +272,12 @@ describe('tokenAffinityRepository', () => {
     expect(stream.requestId).toBe('req_123');
     expect(db.queries[0]?.sql).toContain('insert into in_token_affinity_active_streams');
     expect(db.queries[0]?.sql).toContain('on conflict (request_id)');
+    expect(db.queries[0]?.sql).toContain('last_touched_at = excluded.last_touched_at');
+    expect(db.queries[0]?.sql).toContain('ended_at = null');
+    expect(db.queries[0]?.sql).not.toContain('org_id = excluded.org_id');
+    expect(db.queries[0]?.sql).not.toContain('provider = excluded.provider');
+    expect(db.queries[0]?.sql).not.toContain('credential_id = excluded.credential_id');
+    expect(db.queries[0]?.sql).not.toContain('session_id = excluded.session_id');
   });
 
   it('refreshes last_touched_at for a live stream heartbeat', async () => {
@@ -416,7 +422,7 @@ describe('tokenAffinityRepository contract', () => {
     });
   });
 
-  it('preserves the original started_at when the same request id is upserted again', async () => {
+  it('preserves the original owner and started_at when the same request id is upserted again for the same stream', async () => {
     await withContractRepository(async ({ repo, pool }) => {
       await repo.upsertActiveStream({
         requestId: 'req_123',
@@ -439,14 +445,226 @@ describe('tokenAffinityRepository contract', () => {
         requestId: 'req_123',
         orgId: '00000000-0000-0000-0000-000000000001',
         provider: 'openai',
+        credentialId: '00000000-0000-0000-0000-000000000010',
+        sessionId: 'sess_123'
+      });
+
+      expect(upserted.startedAt.toISOString()).toBe('2026-03-15T00:00:00.000Z');
+      expect(upserted.credentialId).toBe('00000000-0000-0000-0000-000000000010');
+      expect(upserted.sessionId).toBe('sess_123');
+      expect(upserted.lastTouchedAt.getTime()).toBeGreaterThan(new Date('2026-03-15T00:00:05.000Z').getTime());
+    });
+  });
+
+  it('does not silently rebind an active stream when the same request id is reused by a different owner', async () => {
+    await withContractRepository(async ({ repo, pool }) => {
+      await repo.upsertActiveStream({
+        requestId: 'req_123',
+        orgId: '00000000-0000-0000-0000-000000000001',
+        provider: 'openai',
+        credentialId: '00000000-0000-0000-0000-000000000010',
+        sessionId: 'sess_123'
+      });
+
+      await pool.query(
+        `
+          update in_token_affinity_active_streams
+          set started_at = $2::timestamptz, last_touched_at = $3::timestamptz
+          where request_id = $1
+        `,
+        ['req_123', '2026-03-15T00:00:00.000Z', '2026-03-15T00:00:05.000Z']
+      );
+
+      const upserted = await repo.upsertActiveStream({
+        requestId: 'req_123',
+        orgId: '00000000-0000-0000-0000-000000000099',
+        provider: 'anthropic',
         credentialId: '00000000-0000-0000-0000-000000000011',
         sessionId: 'sess_456'
       });
 
+      expect(upserted.orgId).toBe('00000000-0000-0000-0000-000000000001');
+      expect(upserted.provider).toBe('openai');
+      expect(upserted.credentialId).toBe('00000000-0000-0000-0000-000000000010');
+      expect(upserted.sessionId).toBe('sess_123');
       expect(upserted.startedAt.toISOString()).toBe('2026-03-15T00:00:00.000Z');
-      expect(upserted.credentialId).toBe('00000000-0000-0000-0000-000000000011');
-      expect(upserted.sessionId).toBe('sess_456');
-      expect(upserted.lastTouchedAt.getTime()).toBeGreaterThan(new Date('2026-03-15T00:00:05.000Z').getTime());
+      expect(upserted.lastTouchedAt.toISOString()).toBe('2026-03-15T00:00:05.000Z');
+
+      const persisted = await pool.query(
+        `
+          select org_id, provider, credential_id, session_id, started_at, last_touched_at
+          from in_token_affinity_active_streams
+          where request_id = $1
+        `,
+        ['req_123']
+      );
+
+      const persistedRow = (persisted as {
+        rows: Array<{
+          org_id: string;
+          provider: string;
+          credential_id: string;
+          session_id: string;
+          started_at: Date | string;
+          last_touched_at: Date | string;
+        }>;
+      }).rows[0];
+
+      expect({
+        ...persistedRow,
+        started_at: new Date(persistedRow.started_at).toISOString(),
+        last_touched_at: new Date(persistedRow.last_touched_at).toISOString()
+      }).toMatchObject({
+        org_id: '00000000-0000-0000-0000-000000000001',
+        provider: 'openai',
+        credential_id: '00000000-0000-0000-0000-000000000010',
+        session_id: 'sess_123',
+        started_at: '2026-03-15T00:00:00.000Z',
+        last_touched_at: '2026-03-15T00:00:05.000Z'
+      });
+    });
+  });
+
+  it('lists busy credential ids through the live SQL contract and excludes stale rows', async () => {
+    await withContractRepository(async ({ repo, pool }) => {
+      await repo.upsertActiveStream({
+        requestId: 'req_busy',
+        orgId: '00000000-0000-0000-0000-000000000001',
+        provider: 'openai',
+        credentialId: '00000000-0000-0000-0000-000000000010',
+        sessionId: 'sess_busy'
+      });
+
+      await repo.upsertActiveStream({
+        requestId: 'req_stale',
+        orgId: '00000000-0000-0000-0000-000000000001',
+        provider: 'openai',
+        credentialId: '00000000-0000-0000-0000-000000000011',
+        sessionId: 'sess_stale'
+      });
+
+      await repo.upsertActiveStream({
+        requestId: 'req_other_provider',
+        orgId: '00000000-0000-0000-0000-000000000001',
+        provider: 'anthropic',
+        credentialId: '00000000-0000-0000-0000-000000000012',
+        sessionId: 'sess_other'
+      });
+
+      await pool.query(
+        `
+          update in_token_affinity_active_streams
+          set last_touched_at = $2::timestamptz
+          where request_id = $1
+        `,
+        ['req_stale', '2026-03-15T00:00:00.000Z']
+      );
+
+      const busyCredentialIds = await repo.listBusyCredentialIds({
+        orgId: '00000000-0000-0000-0000-000000000001',
+        provider: 'openai',
+        staleBefore: new Date('2026-03-15T00:00:01.000Z')
+      });
+
+      expect(busyCredentialIds).toEqual(['00000000-0000-0000-0000-000000000010']);
+    });
+  });
+
+  it('touches and clears active streams through the live SQL contract', async () => {
+    await withContractRepository(async ({ repo }) => {
+      await repo.upsertActiveStream({
+        requestId: 'req_123',
+        orgId: '00000000-0000-0000-0000-000000000001',
+        provider: 'openai',
+        credentialId: '00000000-0000-0000-0000-000000000010',
+        sessionId: 'sess_123'
+      });
+
+      const touchResult = await repo.touchActiveStream({
+        requestId: 'req_123',
+        touchedAt: new Date('2026-03-16T00:05:00.000Z')
+      });
+
+      expect(touchResult).toBe(true);
+
+      const busyCredentialIds = await repo.listBusyCredentialIds({
+        orgId: '00000000-0000-0000-0000-000000000001',
+        provider: 'openai',
+        staleBefore: new Date('2026-03-16T00:04:59.000Z')
+      });
+
+      expect(busyCredentialIds).toEqual(['00000000-0000-0000-0000-000000000010']);
+
+      const cleared = await repo.clearActiveStream({
+        requestId: 'req_123'
+      });
+
+      expect(cleared).toMatchObject({
+        requestId: 'req_123',
+        credentialId: '00000000-0000-0000-0000-000000000010',
+        sessionId: 'sess_123'
+      });
+
+      const busyAfterClear = await repo.listBusyCredentialIds({
+        orgId: '00000000-0000-0000-0000-000000000001',
+        provider: 'openai',
+        staleBefore: new Date('2026-03-16T00:00:00.000Z')
+      });
+
+      expect(busyAfterClear).toEqual([]);
+      expect(await repo.touchActiveStream({
+        requestId: 'req_123',
+        touchedAt: new Date('2026-03-16T00:06:00.000Z')
+      })).toBe(false);
+      expect(await repo.clearActiveStream({ requestId: 'req_123' })).toBeNull();
+    });
+  });
+
+  it('clears stale active streams through the live SQL contract and returns the removed rows', async () => {
+    await withContractRepository(async ({ repo, pool }) => {
+      await repo.upsertActiveStream({
+        requestId: 'req_stale',
+        orgId: '00000000-0000-0000-0000-000000000001',
+        provider: 'openai',
+        credentialId: '00000000-0000-0000-0000-000000000010',
+        sessionId: 'sess_stale'
+      });
+
+      await repo.upsertActiveStream({
+        requestId: 'req_fresh',
+        orgId: '00000000-0000-0000-0000-000000000001',
+        provider: 'openai',
+        credentialId: '00000000-0000-0000-0000-000000000011',
+        sessionId: 'sess_fresh'
+      });
+
+      await pool.query(
+        `
+          update in_token_affinity_active_streams
+          set last_touched_at = $2::timestamptz
+          where request_id = $1
+        `,
+        ['req_stale', '2026-03-15T00:00:00.000Z']
+      );
+
+      const cleared = await repo.clearStaleActiveStreams({
+        staleBefore: new Date('2026-03-15T00:00:01.000Z')
+      });
+
+      expect(cleared).toHaveLength(1);
+      expect(cleared[0]).toMatchObject({
+        requestId: 'req_stale',
+        credentialId: '00000000-0000-0000-0000-000000000010',
+        sessionId: 'sess_stale'
+      });
+
+      const remainingBusy = await repo.listBusyCredentialIds({
+        orgId: '00000000-0000-0000-0000-000000000001',
+        provider: 'openai',
+        staleBefore: new Date('2026-03-15T00:00:01.000Z')
+      });
+
+      expect(remainingBusy).toEqual(['00000000-0000-0000-0000-000000000011']);
     });
   });
 });

--- a/api/tests/tokenAffinityRepository.test.ts
+++ b/api/tests/tokenAffinityRepository.test.ts
@@ -498,7 +498,7 @@ describe('tokenAffinityRepository contract', () => {
       expect(upserted.credentialId).toBe('00000000-0000-0000-0000-000000000010');
       expect(upserted.sessionId).toBe('sess_123');
       expect(upserted.startedAt.toISOString()).toBe('2026-03-15T00:00:00.000Z');
-      expect(upserted.lastTouchedAt.getTime()).toBeGreaterThan(new Date('2026-03-15T00:00:05.000Z').getTime());
+      expect(upserted.lastTouchedAt.toISOString()).toBe('2026-03-15T00:00:05.000Z');
 
       const persisted = await pool.query(
         `
@@ -523,18 +523,15 @@ describe('tokenAffinityRepository contract', () => {
       expect({
         ...persistedRow,
         started_at: new Date(persistedRow.started_at).toISOString(),
-        last_touched_at: new Date(persistedRow.last_touched_at).getTime()
+        last_touched_at: new Date(persistedRow.last_touched_at).toISOString()
       }).toMatchObject({
         org_id: '00000000-0000-0000-0000-000000000001',
         provider: 'openai',
         credential_id: '00000000-0000-0000-0000-000000000010',
         session_id: 'sess_123',
         started_at: '2026-03-15T00:00:00.000Z',
-        last_touched_at: expect.any(Number)
+        last_touched_at: '2026-03-15T00:00:05.000Z'
       });
-      expect(new Date(persistedRow.last_touched_at).getTime()).toBeGreaterThan(
-        new Date('2026-03-15T00:00:05.000Z').getTime()
-      );
     });
   });
 

--- a/api/tests/tokenAffinityRepository.test.ts
+++ b/api/tests/tokenAffinityRepository.test.ts
@@ -488,7 +488,7 @@ describe('tokenAffinityRepository contract', () => {
       expect(upserted.credentialId).toBe('00000000-0000-0000-0000-000000000010');
       expect(upserted.sessionId).toBe('sess_123');
       expect(upserted.startedAt.toISOString()).toBe('2026-03-15T00:00:00.000Z');
-      expect(upserted.lastTouchedAt.toISOString()).toBe('2026-03-15T00:00:05.000Z');
+      expect(upserted.lastTouchedAt.getTime()).toBeGreaterThan(new Date('2026-03-15T00:00:05.000Z').getTime());
 
       const persisted = await pool.query(
         `
@@ -513,15 +513,18 @@ describe('tokenAffinityRepository contract', () => {
       expect({
         ...persistedRow,
         started_at: new Date(persistedRow.started_at).toISOString(),
-        last_touched_at: new Date(persistedRow.last_touched_at).toISOString()
+        last_touched_at: new Date(persistedRow.last_touched_at).getTime()
       }).toMatchObject({
         org_id: '00000000-0000-0000-0000-000000000001',
         provider: 'openai',
         credential_id: '00000000-0000-0000-0000-000000000010',
         session_id: 'sess_123',
         started_at: '2026-03-15T00:00:00.000Z',
-        last_touched_at: '2026-03-15T00:00:05.000Z'
+        last_touched_at: expect.any(Number)
       });
+      expect(new Date(persistedRow.last_touched_at).getTime()).toBeGreaterThan(
+        new Date('2026-03-15T00:00:05.000Z').getTime()
+      );
     });
   });
 

--- a/api/tests/tokenAffinityRepository.test.ts
+++ b/api/tests/tokenAffinityRepository.test.ts
@@ -1,0 +1,452 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { newDb } from 'pg-mem';
+import { PgSqlClient } from '../src/repos/pgClient.js';
+import type { SqlClient, SqlQueryResult, SqlValue, TransactionContext } from '../src/repos/sqlClient.js';
+import { TokenAffinityRepository } from '../src/repos/tokenAffinityRepository.js';
+
+type AssignmentRow = {
+  org_id: string;
+  provider: string;
+  credential_id: string;
+  session_id: string;
+  last_activity_at: string;
+  grace_expires_at: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+type ActiveStreamRow = {
+  request_id: string;
+  org_id: string;
+  provider: string;
+  credential_id: string;
+  session_id: string;
+  started_at: string;
+  last_touched_at: string;
+  ended_at: string | null;
+};
+
+const tokenAffinityMigrationSql = readFileSync(
+  new URL('../../docs/migrations/017_token_affinity.sql', import.meta.url),
+  'utf8'
+);
+
+class SequenceSqlClient implements SqlClient {
+  readonly queries: Array<{ sql: string; params?: SqlValue[] }> = [];
+
+  constructor(private readonly results: Array<SqlQueryResult | Error>) {}
+
+  async query<T = Record<string, unknown>>(sql: string, params?: SqlValue[]): Promise<SqlQueryResult<T>> {
+    this.queries.push({ sql, params });
+    const next = this.results.shift() ?? { rows: [], rowCount: 0 };
+    if (next instanceof Error) {
+      throw next;
+    }
+    return next as SqlQueryResult<T>;
+  }
+
+  async transaction<T>(run: (tx: TransactionContext) => Promise<T>): Promise<T> {
+    return run(this);
+  }
+}
+
+function assignmentRow(overrides: Partial<AssignmentRow> = {}): AssignmentRow {
+  return {
+    org_id: '00000000-0000-0000-0000-000000000001',
+    provider: 'openai',
+    credential_id: '00000000-0000-0000-0000-000000000010',
+    session_id: 'sess_123',
+    last_activity_at: '2026-03-16T00:00:00.000Z',
+    grace_expires_at: null,
+    created_at: '2026-03-16T00:00:00.000Z',
+    updated_at: '2026-03-16T00:00:00.000Z',
+    ...overrides
+  };
+}
+
+function activeStreamRow(overrides: Partial<ActiveStreamRow> = {}): ActiveStreamRow {
+  return {
+    request_id: 'req_123',
+    org_id: '00000000-0000-0000-0000-000000000001',
+    provider: 'openai',
+    credential_id: '00000000-0000-0000-0000-000000000010',
+    session_id: 'sess_123',
+    started_at: '2026-03-16T00:00:00.000Z',
+    last_touched_at: '2026-03-16T00:00:05.000Z',
+    ended_at: null,
+    ...overrides
+  };
+}
+
+async function withContractRepository(
+  run: (ctx: {
+    repo: TokenAffinityRepository;
+    pool: {
+      query: (sql: string, params?: unknown[]) => Promise<unknown>;
+      end: () => Promise<void>;
+    };
+  }) => Promise<void>
+): Promise<void> {
+  const memoryDb = newDb();
+  memoryDb.public.none(tokenAffinityMigrationSql);
+
+  const { Pool } = memoryDb.adapters.createPg();
+  const pool = new Pool();
+  const repo = new TokenAffinityRepository(new PgSqlClient(pool));
+
+  try {
+    await run({ repo, pool });
+  } finally {
+    await pool.end();
+  }
+}
+
+describe('tokenAffinityRepository', () => {
+  it('gets a preferred assignment by session', async () => {
+    const db = new SequenceSqlClient([{ rows: [assignmentRow()], rowCount: 1 }]);
+    const repo = new TokenAffinityRepository(db);
+
+    const assignment = await repo.getPreferredAssignment({
+      orgId: '00000000-0000-0000-0000-000000000001',
+      provider: 'openai',
+      sessionId: 'sess_123'
+    });
+
+    expect(assignment?.credentialId).toBe('00000000-0000-0000-0000-000000000010');
+    expect(assignment?.sessionId).toBe('sess_123');
+    expect(db.queries[0]?.sql).toContain('from in_token_affinity_assignments');
+    expect(db.queries[0]?.sql).toContain('session_id = $3');
+  });
+
+  it('claims one preferred credential per (org_id, provider, session_id)', async () => {
+    const db = new SequenceSqlClient([
+      { rows: [], rowCount: 0 },
+      { rows: [assignmentRow()], rowCount: 1 }
+    ]);
+    const repo = new TokenAffinityRepository(db);
+
+    const result = await repo.claimPreferredAssignment({
+      orgId: '00000000-0000-0000-0000-000000000001',
+      provider: 'openai',
+      sessionId: 'sess_123',
+      credentialId: '00000000-0000-0000-0000-000000000010'
+    });
+
+    expect(result).toMatchObject({
+      outcome: 'claimed',
+      assignment: {
+        credentialId: '00000000-0000-0000-0000-000000000010',
+        sessionId: 'sess_123'
+      }
+    });
+    expect(db.queries).toHaveLength(2);
+    expect(db.queries[1]?.sql).toContain('insert into in_token_affinity_assignments');
+    expect(db.queries[1]?.sql).toContain('on conflict do nothing');
+  });
+
+  it('returns already_owned_by_session when the same session already owns the credential', async () => {
+    const db = new SequenceSqlClient([{ rows: [assignmentRow()], rowCount: 1 }]);
+    const repo = new TokenAffinityRepository(db);
+
+    const result = await repo.claimPreferredAssignment({
+      orgId: '00000000-0000-0000-0000-000000000001',
+      provider: 'openai',
+      sessionId: 'sess_123',
+      credentialId: '00000000-0000-0000-0000-000000000010'
+    });
+
+    expect(result).toMatchObject({
+      outcome: 'already_owned_by_session',
+      assignment: {
+        credentialId: '00000000-0000-0000-0000-000000000010',
+        sessionId: 'sess_123'
+      }
+    });
+    expect(db.queries).toHaveLength(1);
+  });
+
+  it('returns session_already_bound when the session already owns another credential', async () => {
+    const db = new SequenceSqlClient([
+      {
+        rows: [
+          assignmentRow({
+            credential_id: '00000000-0000-0000-0000-000000000011'
+          })
+        ],
+        rowCount: 1
+      }
+    ]);
+    const repo = new TokenAffinityRepository(db);
+
+    const result = await repo.claimPreferredAssignment({
+      orgId: '00000000-0000-0000-0000-000000000001',
+      provider: 'openai',
+      sessionId: 'sess_123',
+      credentialId: '00000000-0000-0000-0000-000000000010'
+    });
+
+    expect(result).toMatchObject({
+      outcome: 'session_already_bound',
+      assignment: {
+        credentialId: '00000000-0000-0000-0000-000000000011',
+        sessionId: 'sess_123'
+      }
+    });
+  });
+
+  it('rejects competing claims for the same credential', async () => {
+    const db = new SequenceSqlClient([
+      { rows: [], rowCount: 0 },
+      { rows: [], rowCount: 0 },
+      { rows: [], rowCount: 0 },
+      {
+        rows: [
+          assignmentRow({
+            session_id: 'sess_other'
+          })
+        ],
+        rowCount: 1
+      }
+    ]);
+    const repo = new TokenAffinityRepository(db);
+
+    const result = await repo.claimPreferredAssignment({
+      orgId: '00000000-0000-0000-0000-000000000001',
+      provider: 'openai',
+      sessionId: 'sess_123',
+      credentialId: '00000000-0000-0000-0000-000000000010'
+    });
+
+    expect(result).toEqual({ outcome: 'credential_unavailable' });
+    expect(db.queries).toHaveLength(4);
+    expect(db.queries[3]?.sql).toContain('credential_id = $3');
+  });
+
+  it('touches a preferred assignment grace window', async () => {
+    const db = new SequenceSqlClient([{ rows: [], rowCount: 1 }]);
+    const repo = new TokenAffinityRepository(db);
+    const graceExpiresAt = new Date('2026-03-16T00:00:10.000Z');
+
+    const updated = await repo.touchPreferredAssignment({
+      orgId: '00000000-0000-0000-0000-000000000001',
+      provider: 'openai',
+      sessionId: 'sess_123',
+      credentialId: '00000000-0000-0000-0000-000000000010',
+      graceExpiresAt
+    });
+
+    expect(updated).toBe(true);
+    expect(db.queries[0]?.sql).toContain('update in_token_affinity_assignments');
+    expect(db.queries[0]?.params?.[4]).toBe(graceExpiresAt);
+  });
+
+  it('clears a preferred assignment', async () => {
+    const db = new SequenceSqlClient([{ rows: [], rowCount: 1 }]);
+    const repo = new TokenAffinityRepository(db);
+
+    const cleared = await repo.clearPreferredAssignment({
+      orgId: '00000000-0000-0000-0000-000000000001',
+      provider: 'openai',
+      sessionId: 'sess_123',
+      credentialId: '00000000-0000-0000-0000-000000000010'
+    });
+
+    expect(cleared).toBe(true);
+    expect(db.queries[0]?.sql).toContain('delete from in_token_affinity_assignments');
+    expect(db.queries[0]?.sql).toContain('credential_id = $4');
+  });
+
+  it('upserts an active stream by request id', async () => {
+    const db = new SequenceSqlClient([{ rows: [activeStreamRow()], rowCount: 1 }]);
+    const repo = new TokenAffinityRepository(db);
+
+    const stream = await repo.upsertActiveStream({
+      requestId: 'req_123',
+      orgId: '00000000-0000-0000-0000-000000000001',
+      provider: 'openai',
+      credentialId: '00000000-0000-0000-0000-000000000010',
+      sessionId: 'sess_123'
+    });
+
+    expect(stream.requestId).toBe('req_123');
+    expect(db.queries[0]?.sql).toContain('insert into in_token_affinity_active_streams');
+    expect(db.queries[0]?.sql).toContain('on conflict (request_id)');
+  });
+
+  it('refreshes last_touched_at for a live stream heartbeat', async () => {
+    const db = new SequenceSqlClient([{ rows: [], rowCount: 1 }]);
+    const repo = new TokenAffinityRepository(db);
+    const touchedAt = new Date('2026-03-16T00:00:20.000Z');
+
+    const touched = await repo.touchActiveStream({
+      requestId: 'req_123',
+      touchedAt
+    });
+
+    expect(touched).toBe(true);
+    expect(db.queries[0]?.sql).toContain('update in_token_affinity_active_streams');
+    expect(db.queries[0]?.sql).toContain('last_touched_at = $2');
+    expect(db.queries[0]?.params).toEqual(['req_123', touchedAt]);
+  });
+
+  it('returns cleared stream context by request id', async () => {
+    const db = new SequenceSqlClient([{ rows: [activeStreamRow()], rowCount: 1 }]);
+    const repo = new TokenAffinityRepository(db);
+
+    const cleared = await repo.clearActiveStream({
+      requestId: 'req_123'
+    });
+
+    expect(cleared).toMatchObject({
+      requestId: 'req_123',
+      credentialId: '00000000-0000-0000-0000-000000000010',
+      sessionId: 'sess_123'
+    });
+    expect(db.queries[0]?.sql).toContain('delete from in_token_affinity_active_streams');
+    expect(db.queries[0]?.sql).toContain('returning');
+  });
+
+  it('lists busy credential ids for a partition', async () => {
+    const db = new SequenceSqlClient([{
+      rows: [
+        { credential_id: '00000000-0000-0000-0000-000000000010' },
+        { credential_id: '00000000-0000-0000-0000-000000000011' }
+      ],
+      rowCount: 2
+    }]);
+    const repo = new TokenAffinityRepository(db);
+
+    const busyCredentialIds = await repo.listBusyCredentialIds({
+      orgId: '00000000-0000-0000-0000-000000000001',
+      provider: 'openai',
+      staleBefore: new Date('2026-03-16T00:00:00.000Z')
+    });
+
+    expect(busyCredentialIds).toEqual([
+      '00000000-0000-0000-0000-000000000010',
+      '00000000-0000-0000-0000-000000000011'
+    ]);
+    expect(db.queries[0]?.sql).toContain('select distinct credential_id');
+    expect(db.queries[0]?.sql).toContain('last_touched_at >= $3');
+  });
+
+  it('clears stale active streams and returns the cleared rows for higher-layer cleanup', async () => {
+    const db = new SequenceSqlClient([{
+      rows: [
+        activeStreamRow(),
+        activeStreamRow({
+          request_id: 'req_456',
+          credential_id: '00000000-0000-0000-0000-000000000011',
+          session_id: 'sess_456'
+        })
+      ],
+      rowCount: 2
+    }]);
+    const repo = new TokenAffinityRepository(db);
+
+    const cleared = await repo.clearStaleActiveStreams({
+      staleBefore: new Date('2026-03-16T00:00:00.000Z')
+    });
+
+    expect(cleared).toHaveLength(2);
+    expect(cleared[0]?.requestId).toBe('req_123');
+    expect(cleared[1]?.sessionId).toBe('sess_456');
+    expect(db.queries[0]?.sql).toContain('delete from in_token_affinity_active_streams');
+    expect(db.queries[0]?.sql).toContain('last_touched_at < $1');
+  });
+});
+
+describe('tokenAffinityRepository contract', () => {
+  it('enforces preferred-assignment uniqueness through the live SQL contract', async () => {
+    await withContractRepository(async ({ repo }) => {
+      const firstClaim = await repo.claimPreferredAssignment({
+        orgId: '00000000-0000-0000-0000-000000000001',
+        provider: 'openai',
+        sessionId: 'sess_123',
+        credentialId: '00000000-0000-0000-0000-000000000010'
+      });
+
+      expect(firstClaim).toMatchObject({
+        outcome: 'claimed',
+        assignment: {
+          credentialId: '00000000-0000-0000-0000-000000000010',
+          sessionId: 'sess_123'
+        }
+      });
+
+      const competingClaim = await repo.claimPreferredAssignment({
+        orgId: '00000000-0000-0000-0000-000000000001',
+        provider: 'openai',
+        sessionId: 'sess_other',
+        credentialId: '00000000-0000-0000-0000-000000000010'
+      });
+
+      expect(competingClaim).toEqual({ outcome: 'credential_unavailable' });
+
+      const reboundSession = await repo.claimPreferredAssignment({
+        orgId: '00000000-0000-0000-0000-000000000001',
+        provider: 'openai',
+        sessionId: 'sess_123',
+        credentialId: '00000000-0000-0000-0000-000000000011'
+      });
+
+      expect(reboundSession).toMatchObject({
+        outcome: 'session_already_bound',
+        assignment: {
+          credentialId: '00000000-0000-0000-0000-000000000010',
+          sessionId: 'sess_123'
+        }
+      });
+
+      const repeatedClaim = await repo.claimPreferredAssignment({
+        orgId: '00000000-0000-0000-0000-000000000001',
+        provider: 'openai',
+        sessionId: 'sess_123',
+        credentialId: '00000000-0000-0000-0000-000000000010'
+      });
+
+      expect(repeatedClaim).toMatchObject({
+        outcome: 'already_owned_by_session',
+        assignment: {
+          credentialId: '00000000-0000-0000-0000-000000000010',
+          sessionId: 'sess_123'
+        }
+      });
+    });
+  });
+
+  it('preserves the original started_at when the same request id is upserted again', async () => {
+    await withContractRepository(async ({ repo, pool }) => {
+      await repo.upsertActiveStream({
+        requestId: 'req_123',
+        orgId: '00000000-0000-0000-0000-000000000001',
+        provider: 'openai',
+        credentialId: '00000000-0000-0000-0000-000000000010',
+        sessionId: 'sess_123'
+      });
+
+      await pool.query(
+        `
+          update in_token_affinity_active_streams
+          set started_at = $2::timestamptz, last_touched_at = $3::timestamptz
+          where request_id = $1
+        `,
+        ['req_123', '2026-03-15T00:00:00.000Z', '2026-03-15T00:00:05.000Z']
+      );
+
+      const upserted = await repo.upsertActiveStream({
+        requestId: 'req_123',
+        orgId: '00000000-0000-0000-0000-000000000001',
+        provider: 'openai',
+        credentialId: '00000000-0000-0000-0000-000000000011',
+        sessionId: 'sess_456'
+      });
+
+      expect(upserted.startedAt.toISOString()).toBe('2026-03-15T00:00:00.000Z');
+      expect(upserted.credentialId).toBe('00000000-0000-0000-0000-000000000011');
+      expect(upserted.sessionId).toBe('sess_456');
+      expect(upserted.lastTouchedAt.getTime()).toBeGreaterThan(new Date('2026-03-15T00:00:05.000Z').getTime());
+    });
+  });
+});

--- a/api/tests/tokenAffinityRepository.test.ts
+++ b/api/tests/tokenAffinityRepository.test.ts
@@ -257,7 +257,7 @@ describe('tokenAffinityRepository', () => {
     expect(db.queries[0]?.sql).toContain('credential_id = $4');
   });
 
-  it('upserts an active stream by request id', async () => {
+  it('upserts an active stream by owner-scoped request id', async () => {
     const db = new SequenceSqlClient([{ rows: [activeStreamRow()], rowCount: 1 }]);
     const repo = new TokenAffinityRepository(db);
 
@@ -273,21 +273,15 @@ describe('tokenAffinityRepository', () => {
     const upsertSql = db.queries[0]?.sql ?? '';
 
     expect(upsertSql).toContain('insert into in_token_affinity_active_streams');
-    expect(upsertSql).toContain('on conflict (request_id)');
+    expect(upsertSql).toContain(
+      'on conflict (org_id, provider, credential_id, session_id, request_id)'
+    );
 
     const updateClause = upsertSql.split('do update set')[1]?.split('returning')[0] ?? '';
 
     expect(updateClause).toContain('last_touched_at = excluded.last_touched_at');
     expect(updateClause).toContain('ended_at = null');
-    expect(updateClause).toContain('where');
-    expect(updateClause).not.toContain('org_id = excluded.org_id,');
-    expect(updateClause).not.toContain('provider = excluded.provider,');
-    expect(updateClause).not.toContain('credential_id = excluded.credential_id,');
-    expect(updateClause).not.toContain('session_id = excluded.session_id,');
-    expect(updateClause).toContain('in_token_affinity_active_streams.org_id = excluded.org_id');
-    expect(updateClause).toContain('in_token_affinity_active_streams.provider = excluded.provider');
-    expect(updateClause).toContain('in_token_affinity_active_streams.credential_id = excluded.credential_id');
-    expect(updateClause).toContain('in_token_affinity_active_streams.session_id = excluded.session_id');
+    expect(updateClause).not.toContain('where');
   });
 
   it('refreshes last_touched_at for a live stream heartbeat', async () => {
@@ -296,21 +290,41 @@ describe('tokenAffinityRepository', () => {
     const touchedAt = new Date('2026-03-16T00:00:20.000Z');
 
     const touched = await repo.touchActiveStream({
+      orgId: '00000000-0000-0000-0000-000000000001',
+      provider: 'openai',
+      credentialId: '00000000-0000-0000-0000-000000000010',
+      sessionId: 'sess_123',
       requestId: 'req_123',
       touchedAt
     });
 
     expect(touched).toBe(true);
     expect(db.queries[0]?.sql).toContain('update in_token_affinity_active_streams');
-    expect(db.queries[0]?.sql).toContain('last_touched_at = $2');
-    expect(db.queries[0]?.params).toEqual(['req_123', touchedAt]);
+    expect(db.queries[0]?.sql).toContain('last_touched_at = $6');
+    expect(db.queries[0]?.sql).toContain('org_id = $1::uuid');
+    expect(db.queries[0]?.sql).toContain('provider = $2');
+    expect(db.queries[0]?.sql).toContain('credential_id = $3::uuid');
+    expect(db.queries[0]?.sql).toContain('session_id = $4');
+    expect(db.queries[0]?.sql).toContain('request_id = $5');
+    expect(db.queries[0]?.params).toEqual([
+      '00000000-0000-0000-0000-000000000001',
+      'openai',
+      '00000000-0000-0000-0000-000000000010',
+      'sess_123',
+      'req_123',
+      touchedAt
+    ]);
   });
 
-  it('returns cleared stream context by request id', async () => {
+  it('returns cleared stream context by owner-scoped request id', async () => {
     const db = new SequenceSqlClient([{ rows: [activeStreamRow()], rowCount: 1 }]);
     const repo = new TokenAffinityRepository(db);
 
     const cleared = await repo.clearActiveStream({
+      orgId: '00000000-0000-0000-0000-000000000001',
+      provider: 'openai',
+      credentialId: '00000000-0000-0000-0000-000000000010',
+      sessionId: 'sess_123',
       requestId: 'req_123'
     });
 
@@ -320,6 +334,18 @@ describe('tokenAffinityRepository', () => {
       sessionId: 'sess_123'
     });
     expect(db.queries[0]?.sql).toContain('delete from in_token_affinity_active_streams');
+    expect(db.queries[0]?.sql).toContain('org_id = $1::uuid');
+    expect(db.queries[0]?.sql).toContain('provider = $2');
+    expect(db.queries[0]?.sql).toContain('credential_id = $3::uuid');
+    expect(db.queries[0]?.sql).toContain('session_id = $4');
+    expect(db.queries[0]?.sql).toContain('request_id = $5');
+    expect(db.queries[0]?.params).toEqual([
+      '00000000-0000-0000-0000-000000000001',
+      'openai',
+      '00000000-0000-0000-0000-000000000010',
+      'sess_123',
+      'req_123'
+    ]);
     expect(db.queries[0]?.sql).toContain('returning');
   });
 
@@ -466,7 +492,7 @@ describe('tokenAffinityRepository contract', () => {
     });
   });
 
-  it('does not silently rebind an active stream when the same request id is reused by a different owner', async () => {
+  it('stores separate active-stream rows when the same request id is reused by a different owner', async () => {
     await withContractRepository(async ({ repo, pool }) => {
       await repo.upsertActiveStream({
         requestId: 'req_123',
@@ -493,23 +519,22 @@ describe('tokenAffinityRepository contract', () => {
         sessionId: 'sess_456'
       });
 
-      expect(upserted.orgId).toBe('00000000-0000-0000-0000-000000000001');
-      expect(upserted.provider).toBe('openai');
-      expect(upserted.credentialId).toBe('00000000-0000-0000-0000-000000000010');
-      expect(upserted.sessionId).toBe('sess_123');
-      expect(upserted.startedAt.toISOString()).toBe('2026-03-15T00:00:00.000Z');
-      expect(upserted.lastTouchedAt.toISOString()).toBe('2026-03-15T00:00:05.000Z');
+      expect(upserted.orgId).toBe('00000000-0000-0000-0000-000000000099');
+      expect(upserted.provider).toBe('anthropic');
+      expect(upserted.credentialId).toBe('00000000-0000-0000-0000-000000000011');
+      expect(upserted.sessionId).toBe('sess_456');
 
       const persisted = await pool.query(
         `
           select org_id, provider, credential_id, session_id, started_at, last_touched_at
           from in_token_affinity_active_streams
           where request_id = $1
+          order by org_id asc, provider asc, credential_id asc, session_id asc
         `,
         ['req_123']
       );
 
-      const persistedRow = (persisted as {
+      const persistedRows = (persisted as {
         rows: Array<{
           org_id: string;
           provider: string;
@@ -518,20 +543,29 @@ describe('tokenAffinityRepository contract', () => {
           started_at: Date | string;
           last_touched_at: Date | string;
         }>;
-      }).rows[0];
+      }).rows.map((row) => ({
+        ...row,
+        started_at: new Date(row.started_at).toISOString(),
+        last_touched_at: new Date(row.last_touched_at).toISOString()
+      }));
 
-      expect({
-        ...persistedRow,
-        started_at: new Date(persistedRow.started_at).toISOString(),
-        last_touched_at: new Date(persistedRow.last_touched_at).toISOString()
-      }).toMatchObject({
-        org_id: '00000000-0000-0000-0000-000000000001',
-        provider: 'openai',
-        credential_id: '00000000-0000-0000-0000-000000000010',
-        session_id: 'sess_123',
-        started_at: '2026-03-15T00:00:00.000Z',
-        last_touched_at: '2026-03-15T00:00:05.000Z'
-      });
+      expect(persistedRows).toHaveLength(2);
+      expect(persistedRows).toMatchObject([
+        {
+          org_id: '00000000-0000-0000-0000-000000000001',
+          provider: 'openai',
+          credential_id: '00000000-0000-0000-0000-000000000010',
+          session_id: 'sess_123',
+          started_at: '2026-03-15T00:00:00.000Z',
+          last_touched_at: '2026-03-15T00:00:05.000Z'
+        },
+        {
+          org_id: '00000000-0000-0000-0000-000000000099',
+          provider: 'anthropic',
+          credential_id: '00000000-0000-0000-0000-000000000011',
+          session_id: 'sess_456'
+        }
+      ]);
     });
   });
 
@@ -591,6 +625,10 @@ describe('tokenAffinityRepository contract', () => {
       });
 
       const touchResult = await repo.touchActiveStream({
+        orgId: '00000000-0000-0000-0000-000000000001',
+        provider: 'openai',
+        credentialId: '00000000-0000-0000-0000-000000000010',
+        sessionId: 'sess_123',
         requestId: 'req_123',
         touchedAt: new Date('2026-03-16T00:05:00.000Z')
       });
@@ -606,6 +644,10 @@ describe('tokenAffinityRepository contract', () => {
       expect(busyCredentialIds).toEqual(['00000000-0000-0000-0000-000000000010']);
 
       const cleared = await repo.clearActiveStream({
+        orgId: '00000000-0000-0000-0000-000000000001',
+        provider: 'openai',
+        credentialId: '00000000-0000-0000-0000-000000000010',
+        sessionId: 'sess_123',
         requestId: 'req_123'
       });
 
@@ -623,10 +665,55 @@ describe('tokenAffinityRepository contract', () => {
 
       expect(busyAfterClear).toEqual([]);
       expect(await repo.touchActiveStream({
+        orgId: '00000000-0000-0000-0000-000000000001',
+        provider: 'openai',
+        credentialId: '00000000-0000-0000-0000-000000000010',
+        sessionId: 'sess_123',
         requestId: 'req_123',
         touchedAt: new Date('2026-03-16T00:06:00.000Z')
       })).toBe(false);
-      expect(await repo.clearActiveStream({ requestId: 'req_123' })).toBeNull();
+      expect(await repo.clearActiveStream({
+        orgId: '00000000-0000-0000-0000-000000000001',
+        provider: 'openai',
+        credentialId: '00000000-0000-0000-0000-000000000010',
+        sessionId: 'sess_123',
+        requestId: 'req_123'
+      })).toBeNull();
+    });
+  });
+
+  it('refuses to touch or clear another owner using the same raw request id', async () => {
+    await withContractRepository(async ({ repo }) => {
+      await repo.upsertActiveStream({
+        requestId: 'req_123',
+        orgId: '00000000-0000-0000-0000-000000000001',
+        provider: 'openai',
+        credentialId: '00000000-0000-0000-0000-000000000010',
+        sessionId: 'sess_123'
+      });
+
+      expect(await repo.touchActiveStream({
+        orgId: '00000000-0000-0000-0000-000000000099',
+        provider: 'anthropic',
+        credentialId: '00000000-0000-0000-0000-000000000011',
+        sessionId: 'sess_456',
+        requestId: 'req_123',
+        touchedAt: new Date('2026-03-16T00:05:00.000Z')
+      })).toBe(false);
+
+      expect(await repo.clearActiveStream({
+        orgId: '00000000-0000-0000-0000-000000000099',
+        provider: 'anthropic',
+        credentialId: '00000000-0000-0000-0000-000000000011',
+        sessionId: 'sess_456',
+        requestId: 'req_123'
+      })).toBeNull();
+
+      expect(await repo.listBusyCredentialIds({
+        orgId: '00000000-0000-0000-0000-000000000001',
+        provider: 'openai',
+        staleBefore: new Date('2026-03-16T00:00:00.000Z')
+      })).toEqual(['00000000-0000-0000-0000-000000000010']);
     });
   });
 

--- a/api/tests/tokenAffinityRepository.test.ts
+++ b/api/tests/tokenAffinityRepository.test.ts
@@ -270,14 +270,24 @@ describe('tokenAffinityRepository', () => {
     });
 
     expect(stream.requestId).toBe('req_123');
-    expect(db.queries[0]?.sql).toContain('insert into in_token_affinity_active_streams');
-    expect(db.queries[0]?.sql).toContain('on conflict (request_id)');
-    expect(db.queries[0]?.sql).toContain('last_touched_at = excluded.last_touched_at');
-    expect(db.queries[0]?.sql).toContain('ended_at = null');
-    expect(db.queries[0]?.sql).not.toContain('org_id = excluded.org_id');
-    expect(db.queries[0]?.sql).not.toContain('provider = excluded.provider');
-    expect(db.queries[0]?.sql).not.toContain('credential_id = excluded.credential_id');
-    expect(db.queries[0]?.sql).not.toContain('session_id = excluded.session_id');
+    const upsertSql = db.queries[0]?.sql ?? '';
+
+    expect(upsertSql).toContain('insert into in_token_affinity_active_streams');
+    expect(upsertSql).toContain('on conflict (request_id)');
+
+    const updateClause = upsertSql.split('do update set')[1]?.split('returning')[0] ?? '';
+
+    expect(updateClause).toContain('last_touched_at = excluded.last_touched_at');
+    expect(updateClause).toContain('ended_at = null');
+    expect(updateClause).toContain('where');
+    expect(updateClause).not.toContain('org_id = excluded.org_id,');
+    expect(updateClause).not.toContain('provider = excluded.provider,');
+    expect(updateClause).not.toContain('credential_id = excluded.credential_id,');
+    expect(updateClause).not.toContain('session_id = excluded.session_id,');
+    expect(updateClause).toContain('in_token_affinity_active_streams.org_id = excluded.org_id');
+    expect(updateClause).toContain('in_token_affinity_active_streams.provider = excluded.provider');
+    expect(updateClause).toContain('in_token_affinity_active_streams.credential_id = excluded.credential_id');
+    expect(updateClause).toContain('in_token_affinity_active_streams.session_id = excluded.session_id');
   });
 
   it('refreshes last_touched_at for a live stream heartbeat', async () => {

--- a/docs/migrations/017_token_affinity.sql
+++ b/docs/migrations/017_token_affinity.sql
@@ -12,14 +12,15 @@ CREATE TABLE IF NOT EXISTS in_token_affinity_assignments (
 );
 
 CREATE TABLE IF NOT EXISTS in_token_affinity_active_streams (
-  request_id text PRIMARY KEY,
   org_id uuid NOT NULL,
   provider text NOT NULL,
   credential_id uuid NOT NULL,
   session_id text NOT NULL,
+  request_id text NOT NULL,
   started_at timestamptz NOT NULL DEFAULT now(),
   last_touched_at timestamptz NOT NULL DEFAULT now(),
-  ended_at timestamptz
+  ended_at timestamptz,
+  PRIMARY KEY (org_id, provider, credential_id, session_id, request_id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_in_token_affinity_assignments_session

--- a/docs/migrations/017_token_affinity.sql
+++ b/docs/migrations/017_token_affinity.sql
@@ -1,0 +1,36 @@
+CREATE TABLE IF NOT EXISTS in_token_affinity_assignments (
+  org_id uuid NOT NULL,
+  provider text NOT NULL,
+  credential_id uuid NOT NULL,
+  session_id text NOT NULL,
+  last_activity_at timestamptz NOT NULL DEFAULT now(),
+  grace_expires_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (org_id, provider, credential_id),
+  UNIQUE (org_id, provider, session_id)
+);
+
+CREATE TABLE IF NOT EXISTS in_token_affinity_active_streams (
+  request_id text PRIMARY KEY,
+  org_id uuid NOT NULL,
+  provider text NOT NULL,
+  credential_id uuid NOT NULL,
+  session_id text NOT NULL,
+  started_at timestamptz NOT NULL DEFAULT now(),
+  last_touched_at timestamptz NOT NULL DEFAULT now(),
+  ended_at timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS idx_in_token_affinity_assignments_session
+  ON in_token_affinity_assignments (org_id, provider, session_id);
+
+CREATE INDEX IF NOT EXISTS idx_in_token_affinity_assignments_grace
+  ON in_token_affinity_assignments (org_id, provider, grace_expires_at);
+
+CREATE INDEX IF NOT EXISTS idx_in_token_affinity_active_streams_partition
+  ON in_token_affinity_active_streams (org_id, provider, credential_id);
+
+CREATE INDEX IF NOT EXISTS idx_in_token_affinity_active_streams_stale
+  ON in_token_affinity_active_streams (last_touched_at)
+  WHERE ended_at IS NULL;

--- a/docs/migrations/017_token_affinity_no_extensions.sql
+++ b/docs/migrations/017_token_affinity_no_extensions.sql
@@ -12,14 +12,15 @@ CREATE TABLE IF NOT EXISTS in_token_affinity_assignments (
 );
 
 CREATE TABLE IF NOT EXISTS in_token_affinity_active_streams (
-  request_id text PRIMARY KEY,
   org_id uuid NOT NULL,
   provider text NOT NULL,
   credential_id uuid NOT NULL,
   session_id text NOT NULL,
+  request_id text NOT NULL,
   started_at timestamptz NOT NULL DEFAULT now(),
   last_touched_at timestamptz NOT NULL DEFAULT now(),
-  ended_at timestamptz
+  ended_at timestamptz,
+  PRIMARY KEY (org_id, provider, credential_id, session_id, request_id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_in_token_affinity_assignments_session

--- a/docs/migrations/017_token_affinity_no_extensions.sql
+++ b/docs/migrations/017_token_affinity_no_extensions.sql
@@ -1,0 +1,36 @@
+CREATE TABLE IF NOT EXISTS in_token_affinity_assignments (
+  org_id uuid NOT NULL,
+  provider text NOT NULL,
+  credential_id uuid NOT NULL,
+  session_id text NOT NULL,
+  last_activity_at timestamptz NOT NULL DEFAULT now(),
+  grace_expires_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (org_id, provider, credential_id),
+  UNIQUE (org_id, provider, session_id)
+);
+
+CREATE TABLE IF NOT EXISTS in_token_affinity_active_streams (
+  request_id text PRIMARY KEY,
+  org_id uuid NOT NULL,
+  provider text NOT NULL,
+  credential_id uuid NOT NULL,
+  session_id text NOT NULL,
+  started_at timestamptz NOT NULL DEFAULT now(),
+  last_touched_at timestamptz NOT NULL DEFAULT now(),
+  ended_at timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS idx_in_token_affinity_assignments_session
+  ON in_token_affinity_assignments (org_id, provider, session_id);
+
+CREATE INDEX IF NOT EXISTS idx_in_token_affinity_assignments_grace
+  ON in_token_affinity_assignments (org_id, provider, grace_expires_at);
+
+CREATE INDEX IF NOT EXISTS idx_in_token_affinity_active_streams_partition
+  ON in_token_affinity_active_streams (org_id, provider, credential_id);
+
+CREATE INDEX IF NOT EXISTS idx_in_token_affinity_active_streams_stale
+  ON in_token_affinity_active_streams (last_touched_at)
+  WHERE ended_at IS NULL;


### PR DESCRIPTION
## Summary
- add token affinity assignment and active-stream migrations plus table-name wiring
- add TokenAffinityRepository with claim/get/clear/touch/list/cleanup operations
- add repository contract coverage, including live SQL checks via pg-mem

## Verification
- `cd api && npx vitest run tests/tokenAffinityRepository.test.ts`
- verified `docs/migrations/017_token_affinity.sql` and `docs/migrations/017_token_affinity_no_extensions.sql` are identical

## Notes
- `DATABASE_URL` was not available in this environment, so I could not apply `docs/migrations/017_token_affinity.sql` locally

Closes #69