### PR TITLE
feat: add token affinity persistence

### DIFF
--- a/api/src/repos/tableNames.ts
+++ b/api/src/repos/tableNames.ts
@@ -5,6 +5,8 @@ export const TABLES = {
   orgs: 'in_orgs',
   requestLog: 'in_request_log',
   sellerKeys: 'in_seller_keys',
+  tokenAffinityAssignments: 'in_token_affinity_assignments',
+  tokenAffinityActiveStreams: 'in_token_affinity_active_streams',
   tokenCredentialProviderUsage: 'in_token_credential_provider_usage',
   tokenCredentials: 'in_token_credentials',
   tokenCredentialEvents: 'in_token_credential_events',

--- a/api/src/repos/tokenAffinityRepository.ts
+++ b/api/src/repos/tokenAffinityRepository.ts
@@ -1,0 +1,437 @@
+import type { SqlClient, SqlQueryResult, SqlValue, TransactionContext } from './sqlClient.js';
+import { TABLES } from './tableNames.js';
+
+type TokenAffinityAssignmentRow = {
+  org_id: string;
+  provider: string;
+  credential_id: string;
+  session_id: string;
+  last_activity_at: string | Date;
+  grace_expires_at: string | Date | null;
+  created_at: string | Date;
+  updated_at: string | Date;
+};
+
+type TokenAffinityActiveStreamRow = {
+  request_id: string;
+  org_id: string;
+  provider: string;
+  credential_id: string;
+  session_id: string;
+  started_at: string | Date;
+  last_touched_at: string | Date;
+  ended_at: string | Date | null;
+};
+
+export type TokenAffinityAssignment = {
+  orgId: string;
+  provider: string;
+  credentialId: string;
+  sessionId: string;
+  lastActivityAt: Date;
+  graceExpiresAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type TokenAffinityActiveStream = {
+  requestId: string;
+  orgId: string;
+  provider: string;
+  credentialId: string;
+  sessionId: string;
+  startedAt: Date;
+  lastTouchedAt: Date;
+  endedAt: Date | null;
+};
+
+export type ClaimPreferredAssignmentResult =
+  | { outcome: 'claimed'; assignment: TokenAffinityAssignment }
+  | { outcome: 'already_owned_by_session'; assignment: TokenAffinityAssignment }
+  | { outcome: 'credential_unavailable' }
+  | { outcome: 'session_already_bound'; assignment: TokenAffinityAssignment };
+
+export type GetPreferredAssignmentInput = {
+  orgId: string;
+  provider: string;
+  sessionId: string;
+};
+
+export type ClaimPreferredAssignmentInput = GetPreferredAssignmentInput & {
+  credentialId: string;
+};
+
+export type ClearPreferredAssignmentInput = GetPreferredAssignmentInput & {
+  credentialId?: string;
+};
+
+export type TouchPreferredAssignmentInput = ClaimPreferredAssignmentInput & {
+  graceExpiresAt: Date | null;
+};
+
+export type UpsertActiveStreamInput = {
+  requestId: string;
+  orgId: string;
+  provider: string;
+  credentialId: string;
+  sessionId: string;
+};
+
+export type TouchActiveStreamInput = {
+  requestId: string;
+  touchedAt: Date;
+};
+
+export type ClearActiveStreamInput = {
+  requestId: string;
+};
+
+export type ListBusyCredentialIdsInput = {
+  orgId: string;
+  provider: string;
+  staleBefore: Date;
+};
+
+export type ClearStaleActiveStreamsInput = {
+  staleBefore: Date;
+};
+
+function mapAssignment(row: TokenAffinityAssignmentRow): TokenAffinityAssignment {
+  return {
+    orgId: row.org_id,
+    provider: row.provider,
+    credentialId: row.credential_id,
+    sessionId: row.session_id,
+    lastActivityAt: new Date(row.last_activity_at),
+    graceExpiresAt: row.grace_expires_at ? new Date(row.grace_expires_at) : null,
+    createdAt: new Date(row.created_at),
+    updatedAt: new Date(row.updated_at)
+  };
+}
+
+function mapActiveStream(row: TokenAffinityActiveStreamRow): TokenAffinityActiveStream {
+  return {
+    requestId: row.request_id,
+    orgId: row.org_id,
+    provider: row.provider,
+    credentialId: row.credential_id,
+    sessionId: row.session_id,
+    startedAt: new Date(row.started_at),
+    lastTouchedAt: new Date(row.last_touched_at),
+    endedAt: row.ended_at ? new Date(row.ended_at) : null
+  };
+}
+
+async function loadClaimConflict(
+  tx: TransactionContext,
+  input: ClaimPreferredAssignmentInput
+): Promise<TokenAffinityAssignment> {
+  const result = await tx.query<TokenAffinityAssignmentRow>(
+    `
+      select
+        org_id,
+        provider,
+        credential_id,
+        session_id,
+        last_activity_at,
+        grace_expires_at,
+        created_at,
+        updated_at
+      from ${TABLES.tokenAffinityAssignments}
+      where org_id = $1::uuid
+        and provider = $2
+        and (session_id = $3 or credential_id = $4::uuid)
+      order by
+        case when session_id = $3 then 0 else 1 end,
+        case when credential_id = $4::uuid then 0 else 1 end
+      limit 1
+    `,
+    [input.orgId, input.provider, input.sessionId, input.credentialId]
+  );
+
+  if (result.rowCount !== 1) {
+    throw new Error('expected conflicting token affinity assignment after failed claim');
+  }
+
+  return mapAssignment(result.rows[0]);
+}
+
+export class TokenAffinityRepository {
+  constructor(private readonly db: SqlClient) {}
+
+  async getPreferredAssignment(input: GetPreferredAssignmentInput): Promise<TokenAffinityAssignment | null> {
+    const result = await this.db.query<TokenAffinityAssignmentRow>(
+      `
+        select
+          org_id,
+          provider,
+          credential_id,
+          session_id,
+          last_activity_at,
+          grace_expires_at,
+          created_at,
+          updated_at
+        from ${TABLES.tokenAffinityAssignments}
+        where org_id = $1::uuid
+          and provider = $2
+          and session_id = $3
+        limit 1
+      `,
+      [input.orgId, input.provider, input.sessionId]
+    );
+
+    if (result.rowCount !== 1) {
+      return null;
+    }
+
+    return mapAssignment(result.rows[0]);
+  }
+
+  async claimPreferredAssignment(input: ClaimPreferredAssignmentInput): Promise<ClaimPreferredAssignmentResult> {
+    return this.db.transaction(async (tx) => {
+      const result = await tx.query<TokenAffinityAssignmentRow>(
+        `
+          insert into ${TABLES.tokenAffinityAssignments} (
+            org_id,
+            provider,
+            credential_id,
+            session_id,
+            last_activity_at,
+            grace_expires_at,
+            created_at,
+            updated_at
+          ) values ($1::uuid, $2, $3::uuid, $4, now(), null, now(), now())
+          on conflict do nothing
+          returning
+            org_id,
+            provider,
+            credential_id,
+            session_id,
+            last_activity_at,
+            grace_expires_at,
+            created_at,
+            updated_at
+        `,
+        [input.orgId, input.provider, input.credentialId, input.sessionId]
+      );
+
+      if (result.rowCount === 1) {
+        return {
+          outcome: 'claimed',
+          assignment: mapAssignment(result.rows[0])
+        };
+      }
+
+      const assignment = await loadClaimConflict(tx, input);
+      const sameSession = assignment.sessionId === input.sessionId;
+      const sameCredential = assignment.credentialId === input.credentialId;
+
+      if (sameSession && sameCredential) {
+        return { outcome: 'already_owned_by_session', assignment };
+      }
+
+      if (sameSession) {
+        return { outcome: 'session_already_bound', assignment };
+      }
+
+      if (sameCredential) {
+        return { outcome: 'credential_unavailable' };
+      }
+
+      throw new Error('unexpected token affinity claim conflict');
+    });
+  }
+
+  async clearPreferredAssignment(input: ClearPreferredAssignmentInput): Promise<boolean> {
+    const params: SqlValue[] = [input.orgId, input.provider, input.sessionId];
+    const credentialFilter = input.credentialId
+      ? 'and credential_id = $4::uuid'
+      : '';
+
+    if (input.credentialId) {
+      params.push(input.credentialId);
+    }
+
+    const result = await this.db.query(
+      `
+        delete from ${TABLES.tokenAffinityAssignments}
+        where org_id = $1::uuid
+          and provider = $2
+          and session_id = $3
+          ${credentialFilter}
+      `,
+      params
+    );
+
+    return result.rowCount > 0;
+  }
+
+  async touchPreferredAssignment(input: TouchPreferredAssignmentInput): Promise<boolean> {
+    const result = await this.db.query(
+      `
+        update ${TABLES.tokenAffinityAssignments}
+        set
+          last_activity_at = now(),
+          grace_expires_at = $5,
+          updated_at = now()
+        where org_id = $1::uuid
+          and provider = $2
+          and session_id = $3
+          and credential_id = $4::uuid
+      `,
+      [input.orgId, input.provider, input.sessionId, input.credentialId, input.graceExpiresAt]
+    );
+
+    return result.rowCount > 0;
+  }
+
+  async upsertActiveStream(input: UpsertActiveStreamInput): Promise<TokenAffinityActiveStream> {
+    const result = await this.db.query<TokenAffinityActiveStreamRow>(
+      `
+        insert into ${TABLES.tokenAffinityActiveStreams} (
+          request_id,
+          org_id,
+          provider,
+          credential_id,
+          session_id,
+          started_at,
+          last_touched_at,
+          ended_at
+        ) values ($1, $2::uuid, $3, $4::uuid, $5, now(), now(), null)
+        on conflict (request_id)
+        do update set
+          org_id = excluded.org_id,
+          provider = excluded.provider,
+          credential_id = excluded.credential_id,
+          session_id = excluded.session_id,
+          last_touched_at = now(),
+          ended_at = null
+        returning
+          request_id,
+          org_id,
+          provider,
+          credential_id,
+          session_id,
+          started_at,
+          last_touched_at,
+          ended_at
+      `,
+      [input.requestId, input.orgId, input.provider, input.credentialId, input.sessionId]
+    );
+
+    if (result.rowCount !== 1) {
+      throw new Error('expected active stream upsert');
+    }
+
+    return mapActiveStream(result.rows[0]);
+  }
+
+  async touchActiveStream(input: TouchActiveStreamInput): Promise<boolean> {
+    const result = await this.db.query(
+      `
+        update ${TABLES.tokenAffinityActiveStreams}
+        set
+          last_touched_at = $2,
+          ended_at = null
+        where request_id = $1
+          and ended_at is null
+      `,
+      [input.requestId, input.touchedAt]
+    );
+
+    return result.rowCount > 0;
+  }
+
+  async clearActiveStream(input: ClearActiveStreamInput): Promise<TokenAffinityActiveStream | null> {
+    const result = await this.db.query<TokenAffinityActiveStreamRow>(
+      `
+        delete from ${TABLES.tokenAffinityActiveStreams}
+        where request_id = $1
+        returning
+          request_id,
+          org_id,
+          provider,
+          credential_id,
+          session_id,
+          started_at,
+          last_touched_at,
+          ended_at
+      `,
+      [input.requestId]
+    );
+
+    if (result.rowCount !== 1) {
+      return null;
+    }
+
+    return mapActiveStream(result.rows[0]);
+  }
+
+  async listBusyCredentialIds(input: ListBusyCredentialIdsInput): Promise<string[]> {
+    const result = await this.db.query<{ credential_id: string }>(
+      `
+        select distinct credential_id
+        from ${TABLES.tokenAffinityActiveStreams}
+        where org_id = $1::uuid
+          and provider = $2
+          and ended_at is null
+          and last_touched_at >= $3
+        order by credential_id asc
+      `,
+      [input.orgId, input.provider, input.staleBefore]
+    );
+
+    return result.rows.map((row) => row.credential_id);
+  }
+
+  async clearStaleActiveStreams(input: ClearStaleActiveStreamsInput): Promise<TokenAffinityActiveStream[]> {
+    const result = await this.db.query<TokenAffinityActiveStreamRow>(
+      `
+        with cleared_streams as (
+          delete from ${TABLES.tokenAffinityActiveStreams}
+          where ended_at is null
+            and last_touched_at < $1
+          returning
+            request_id,
+            org_id,
+            provider,
+            credential_id,
+            session_id,
+            started_at,
+            last_touched_at,
+            ended_at
+        ), cleared_assignments as (
+          delete from ${TABLES.tokenAffinityAssignments} assignment
+          using cleared_streams stream
+          where assignment.org_id = stream.org_id
+            and assignment.provider = stream.provider
+            and assignment.credential_id = stream.credential_id
+            and assignment.session_id = stream.session_id
+            and not exists (
+              select 1
+              from ${TABLES.tokenAffinityActiveStreams} live
+              where live.org_id = stream.org_id
+                and live.provider = stream.provider
+                and live.credential_id = stream.credential_id
+                and live.session_id = stream.session_id
+                and live.ended_at is null
+            )
+        )
+        select
+          request_id,
+          org_id,
+          provider,
+          credential_id,
+          session_id,
+          started_at,
+          last_touched_at,
+          ended_at
+        from cleared_streams
+        order by last_touched_at asc, request_id asc
+      `,
+      [input.staleBefore]
+    );
+
+    return result.rows.map(mapActiveStream);
+  }
+}

--- a/api/tests/tokenAffinityRepository.test.ts
+++ b/api/tests/tokenAffinityRepository.test.ts
@@ -1,0 +1,388 @@
+import { describe, expect, it } from 'vitest';
+import type { SqlClient, SqlQueryResult, SqlValue, TransactionContext } from '../src/repos/sqlClient.js';
+import { TokenAffinityRepository } from '../src/repos/tokenAffinityRepository.js';
+
+class SequenceSqlClient implements SqlClient {
+  readonly queries: Array<{ sql: string; params?: SqlValue[] }> = [];
+  transactionCount = 0;
+
+  constructor(private readonly results: Array<SqlQueryResult | Error>) {}
+
+  async query<T = Record<string, unknown>>(sql: string, params?: SqlValue[]): Promise<SqlQueryResult<T>> {
+    this.queries.push({ sql, params });
+    const next = this.results.shift() ?? { rows: [], rowCount: 0 };
+    if (next instanceof Error) {
+      throw next;
+    }
+    return next as SqlQueryResult<T>;
+  }
+
+  async transaction<T>(run: (tx: TransactionContext) => Promise<T>): Promise<T> {
+    this.transactionCount += 1;
+    return run(this);
+  }
+}
+
+describe('tokenAffinityRepository', () => {
+  it('gets preferred assignment by session id', async () => {
+    const db = new SequenceSqlClient([{
+      rows: [{
+        org_id: '00000000-0000-0000-0000-000000000001',
+        provider: 'openai',
+        credential_id: '00000000-0000-0000-0000-0000000000c1',
+        session_id: 'sess_1',
+        last_activity_at: '2026-03-16T00:00:00Z',
+        grace_expires_at: '2026-03-16T00:00:05Z',
+        created_at: '2026-03-16T00:00:00Z',
+        updated_at: '2026-03-16T00:00:01Z'
+      }],
+      rowCount: 1
+    }]);
+    const repo = new TokenAffinityRepository(db);
+
+    const assignment = await repo.getPreferredAssignment({
+      orgId: '00000000-0000-0000-0000-000000000001',
+      provider: 'openai',
+      sessionId: 'sess_1'
+    });
+
+    expect(assignment).toEqual({
+      orgId: '00000000-0000-0000-0000-000000000001',
+      provider: 'openai',
+      credentialId: '00000000-0000-0000-0000-0000000000c1',
+      sessionId: 'sess_1',
+      lastActivityAt: new Date('2026-03-16T00:00:00Z'),
+      graceExpiresAt: new Date('2026-03-16T00:00:05Z'),
+      createdAt: new Date('2026-03-16T00:00:00Z'),
+      updatedAt: new Date('2026-03-16T00:00:01Z')
+    });
+    expect(db.queries[0].sql).toContain('from in_token_affinity_assignments');
+    expect(db.queries[0].sql).toContain('session_id = $3');
+  });
+
+  it('claims one preferred credential per (org_id, provider, session_id)', async () => {
+    const db = new SequenceSqlClient([{
+      rows: [{
+        org_id: '00000000-0000-0000-0000-000000000001',
+        provider: 'openai',
+        credential_id: '00000000-0000-0000-0000-0000000000c1',
+        session_id: 'sess_1',
+        last_activity_at: '2026-03-16T00:00:00Z',
+        grace_expires_at: null,
+        created_at: '2026-03-16T00:00:00Z',
+        updated_at: '2026-03-16T00:00:00Z'
+      }],
+      rowCount: 1
+    }]);
+    const repo = new TokenAffinityRepository(db);
+
+    const result = await repo.claimPreferredAssignment({
+      orgId: '00000000-0000-0000-0000-000000000001',
+      provider: 'openai',
+      sessionId: 'sess_1',
+      credentialId: '00000000-0000-0000-0000-0000000000c1'
+    });
+
+    expect(result).toEqual({
+      outcome: 'claimed',
+      assignment: {
+        orgId: '00000000-0000-0000-0000-000000000001',
+        provider: 'openai',
+        credentialId: '00000000-0000-0000-0000-0000000000c1',
+        sessionId: 'sess_1',
+        lastActivityAt: new Date('2026-03-16T00:00:00Z'),
+        graceExpiresAt: null,
+        createdAt: new Date('2026-03-16T00:00:00Z'),
+        updatedAt: new Date('2026-03-16T00:00:00Z')
+      }
+    });
+    expect(db.transactionCount).toBe(1);
+    expect(db.queries[0].sql).toContain('insert into in_token_affinity_assignments');
+    expect(db.queries[0].sql).toContain('on conflict do nothing');
+  });
+
+  it('returns already_owned_by_session when the session already owns the credential', async () => {
+    const db = new SequenceSqlClient([
+      { rows: [], rowCount: 0 },
+      {
+        rows: [{
+          org_id: '00000000-0000-0000-0000-000000000001',
+          provider: 'openai',
+          credential_id: '00000000-0000-0000-0000-0000000000c1',
+          session_id: 'sess_1',
+          last_activity_at: '2026-03-16T00:00:00Z',
+          grace_expires_at: null,
+          created_at: '2026-03-16T00:00:00Z',
+          updated_at: '2026-03-16T00:00:00Z'
+        }],
+        rowCount: 1
+      }
+    ]);
+    const repo = new TokenAffinityRepository(db);
+
+    const result = await repo.claimPreferredAssignment({
+      orgId: '00000000-0000-0000-0000-000000000001',
+      provider: 'openai',
+      sessionId: 'sess_1',
+      credentialId: '00000000-0000-0000-0000-0000000000c1'
+    });
+
+    expect(result).toEqual({
+      outcome: 'already_owned_by_session',
+      assignment: {
+        orgId: '00000000-0000-0000-0000-000000000001',
+        provider: 'openai',
+        credentialId: '00000000-0000-0000-0000-0000000000c1',
+        sessionId: 'sess_1',
+        lastActivityAt: new Date('2026-03-16T00:00:00Z'),
+        graceExpiresAt: null,
+        createdAt: new Date('2026-03-16T00:00:00Z'),
+        updatedAt: new Date('2026-03-16T00:00:00Z')
+      }
+    });
+    expect(db.queries[1].sql).toContain('session_id = $3 or credential_id = $4::uuid');
+  });
+
+  it('returns session_already_bound when the session already prefers another credential', async () => {
+    const db = new SequenceSqlClient([
+      { rows: [], rowCount: 0 },
+      {
+        rows: [{
+          org_id: '00000000-0000-0000-0000-000000000001',
+          provider: 'openai',
+          credential_id: '00000000-0000-0000-0000-0000000000c2',
+          session_id: 'sess_1',
+          last_activity_at: '2026-03-16T00:00:00Z',
+          grace_expires_at: '2026-03-16T00:00:05Z',
+          created_at: '2026-03-16T00:00:00Z',
+          updated_at: '2026-03-16T00:00:02Z'
+        }],
+        rowCount: 1
+      }
+    ]);
+    const repo = new TokenAffinityRepository(db);
+
+    const result = await repo.claimPreferredAssignment({
+      orgId: '00000000-0000-0000-0000-000000000001',
+      provider: 'openai',
+      sessionId: 'sess_1',
+      credentialId: '00000000-0000-0000-0000-0000000000c1'
+    });
+
+    expect(result).toEqual({
+      outcome: 'session_already_bound',
+      assignment: {
+        orgId: '00000000-0000-0000-0000-000000000001',
+        provider: 'openai',
+        credentialId: '00000000-0000-0000-0000-0000000000c2',
+        sessionId: 'sess_1',
+        lastActivityAt: new Date('2026-03-16T00:00:00Z'),
+        graceExpiresAt: new Date('2026-03-16T00:00:05Z'),
+        createdAt: new Date('2026-03-16T00:00:00Z'),
+        updatedAt: new Date('2026-03-16T00:00:02Z')
+      }
+    });
+  });
+
+  it('rejects competing claims for the same credential', async () => {
+    const db = new SequenceSqlClient([
+      { rows: [], rowCount: 0 },
+      {
+        rows: [{
+          org_id: '00000000-0000-0000-0000-000000000001',
+          provider: 'openai',
+          credential_id: '00000000-0000-0000-0000-0000000000c1',
+          session_id: 'sess_other',
+          last_activity_at: '2026-03-16T00:00:00Z',
+          grace_expires_at: null,
+          created_at: '2026-03-16T00:00:00Z',
+          updated_at: '2026-03-16T00:00:00Z'
+        }],
+        rowCount: 1
+      }
+    ]);
+    const repo = new TokenAffinityRepository(db);
+
+    const result = await repo.claimPreferredAssignment({
+      orgId: '00000000-0000-0000-0000-000000000001',
+      provider: 'openai',
+      sessionId: 'sess_1',
+      credentialId: '00000000-0000-0000-0000-0000000000c1'
+    });
+
+    expect(result).toEqual({ outcome: 'credential_unavailable' });
+  });
+
+  it('touches and clears preferred assignments explicitly', async () => {
+    const db = new SequenceSqlClient([
+      { rows: [], rowCount: 1 },
+      { rows: [], rowCount: 1 }
+    ]);
+    const repo = new TokenAffinityRepository(db);
+
+    await repo.touchPreferredAssignment({
+      orgId: '00000000-0000-0000-0000-000000000001',
+      provider: 'openai',
+      sessionId: 'sess_1',
+      credentialId: '00000000-0000-0000-0000-0000000000c1',
+      graceExpiresAt: new Date('2026-03-16T00:00:05Z')
+    });
+    await repo.clearPreferredAssignment({
+      orgId: '00000000-0000-0000-0000-000000000001',
+      provider: 'openai',
+      sessionId: 'sess_1',
+      credentialId: '00000000-0000-0000-0000-0000000000c1'
+    });
+
+    expect(db.queries[0].sql).toContain('update in_token_affinity_assignments');
+    expect(db.queries[0].sql).toContain('grace_expires_at = $5');
+    expect(db.queries[1].sql).toContain('delete from in_token_affinity_assignments');
+    expect(db.queries[1].sql).toContain('credential_id = $4::uuid');
+  });
+
+  it('upserts active stream state for a request id', async () => {
+    const db = new SequenceSqlClient([{
+      rows: [{
+        request_id: 'req_1',
+        org_id: '00000000-0000-0000-0000-000000000001',
+        provider: 'openai',
+        credential_id: '00000000-0000-0000-0000-0000000000c1',
+        session_id: 'sess_1',
+        started_at: '2026-03-16T00:00:00Z',
+        last_touched_at: '2026-03-16T00:00:00Z',
+        ended_at: null
+      }],
+      rowCount: 1
+    }]);
+    const repo = new TokenAffinityRepository(db);
+
+    const activeStream = await repo.upsertActiveStream({
+      requestId: 'req_1',
+      orgId: '00000000-0000-0000-0000-000000000001',
+      provider: 'openai',
+      credentialId: '00000000-0000-0000-0000-0000000000c1',
+      sessionId: 'sess_1'
+    });
+
+    expect(activeStream).toEqual({
+      requestId: 'req_1',
+      orgId: '00000000-0000-0000-0000-000000000001',
+      provider: 'openai',
+      credentialId: '00000000-0000-0000-0000-0000000000c1',
+      sessionId: 'sess_1',
+      startedAt: new Date('2026-03-16T00:00:00Z'),
+      lastTouchedAt: new Date('2026-03-16T00:00:00Z'),
+      endedAt: null
+    });
+    expect(db.queries[0].sql).toContain('insert into in_token_affinity_active_streams');
+    expect(db.queries[0].sql).toContain('on conflict (request_id)');
+    expect(db.queries[0].sql).toContain('ended_at = null');
+  });
+
+  it('refreshes last_touched_at for a live stream heartbeat', async () => {
+    const db = new SequenceSqlClient([{ rows: [], rowCount: 1 }]);
+    const repo = new TokenAffinityRepository(db);
+
+    const touched = await repo.touchActiveStream({
+      requestId: 'req_1',
+      touchedAt: new Date('2026-03-16T00:00:10Z')
+    });
+
+    expect(touched).toBe(true);
+    expect(db.queries[0].sql).toContain('update in_token_affinity_active_streams');
+    expect(db.queries[0].sql).toContain('last_touched_at = $2');
+    expect(db.queries[0].sql).toContain('ended_at is null');
+  });
+
+  it('returns cleared stream context by request id', async () => {
+    const db = new SequenceSqlClient([{
+      rows: [{
+        request_id: 'req_1',
+        org_id: '00000000-0000-0000-0000-000000000001',
+        provider: 'openai',
+        credential_id: '00000000-0000-0000-0000-0000000000c1',
+        session_id: 'sess_1',
+        started_at: '2026-03-16T00:00:00Z',
+        last_touched_at: '2026-03-16T00:00:10Z',
+        ended_at: null
+      }],
+      rowCount: 1
+    }]);
+    const repo = new TokenAffinityRepository(db);
+
+    const cleared = await repo.clearActiveStream({ requestId: 'req_1' });
+
+    expect(cleared).toEqual({
+      requestId: 'req_1',
+      orgId: '00000000-0000-0000-0000-000000000001',
+      provider: 'openai',
+      credentialId: '00000000-0000-0000-0000-0000000000c1',
+      sessionId: 'sess_1',
+      startedAt: new Date('2026-03-16T00:00:00Z'),
+      lastTouchedAt: new Date('2026-03-16T00:00:10Z'),
+      endedAt: null
+    });
+    expect(db.queries[0].sql).toContain('delete from in_token_affinity_active_streams');
+    expect(db.queries[0].sql).toContain('returning');
+  });
+
+  it('lists busy credential ids from active-stream rows', async () => {
+    const db = new SequenceSqlClient([{
+      rows: [
+        { credential_id: '00000000-0000-0000-0000-0000000000c1' },
+        { credential_id: '00000000-0000-0000-0000-0000000000c2' }
+      ],
+      rowCount: 2
+    }]);
+    const repo = new TokenAffinityRepository(db);
+
+    const credentialIds = await repo.listBusyCredentialIds({
+      orgId: '00000000-0000-0000-0000-000000000001',
+      provider: 'openai',
+      staleBefore: new Date('2026-03-16T00:00:30Z')
+    });
+
+    expect(credentialIds).toEqual([
+      '00000000-0000-0000-0000-0000000000c1',
+      '00000000-0000-0000-0000-0000000000c2'
+    ]);
+    expect(db.queries[0].sql).toContain('select distinct credential_id');
+    expect(db.queries[0].sql).toContain('last_touched_at >= $3');
+    expect(db.queries[0].sql).toContain('ended_at is null');
+  });
+
+  it('clears stale active streams and orphaned preferred ownership together', async () => {
+    const db = new SequenceSqlClient([{
+      rows: [{
+        request_id: 'req_stale',
+        org_id: '00000000-0000-0000-0000-000000000001',
+        provider: 'openai',
+        credential_id: '00000000-0000-0000-0000-0000000000c1',
+        session_id: 'sess_1',
+        started_at: '2026-03-16T00:00:00Z',
+        last_touched_at: '2026-03-16T00:00:10Z',
+        ended_at: null
+      }],
+      rowCount: 1
+    }]);
+    const repo = new TokenAffinityRepository(db);
+
+    const cleared = await repo.clearStaleActiveStreams({
+      staleBefore: new Date('2026-03-16T00:00:30Z')
+    });
+
+    expect(cleared).toEqual([{
+      requestId: 'req_stale',
+      orgId: '00000000-0000-0000-0000-000000000001',
+      provider: 'openai',
+      credentialId: '00000000-0000-0000-0000-0000000000c1',
+      sessionId: 'sess_1',
+      startedAt: new Date('2026-03-16T00:00:00Z'),
+      lastTouchedAt: new Date('2026-03-16T00:00:10Z'),
+      endedAt: null
+    }]);
+    expect(db.queries[0].sql).toContain('delete from in_token_affinity_active_streams');
+    expect(db.queries[0].sql).toContain('delete from in_token_affinity_assignments');
+    expect(db.queries[0].sql).toContain('last_touched_at < $1');
+  });
+});

--- a/docs/migrations/017_token_affinity.sql
+++ b/docs/migrations/017_token_affinity.sql
@@ -1,0 +1,36 @@
+create table if not exists in_token_affinity_assignments (
+  org_id uuid not null,
+  provider text not null,
+  credential_id uuid not null,
+  session_id text not null,
+  last_activity_at timestamptz not null default now(),
+  grace_expires_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (org_id, provider, credential_id),
+  unique (org_id, provider, session_id)
+);
+
+create table if not exists in_token_affinity_active_streams (
+  request_id text primary key,
+  org_id uuid not null,
+  provider text not null,
+  credential_id uuid not null,
+  session_id text not null,
+  started_at timestamptz not null default now(),
+  last_touched_at timestamptz not null default now(),
+  ended_at timestamptz
+);
+
+create index if not exists idx_in_token_affinity_assignments_session
+  on in_token_affinity_assignments (org_id, provider, session_id);
+
+create index if not exists idx_in_token_affinity_assignments_grace
+  on in_token_affinity_assignments (org_id, provider, grace_expires_at);
+
+create index if not exists idx_in_token_affinity_active_streams_partition
+  on in_token_affinity_active_streams (org_id, provider, credential_id);
+
+create index if not exists idx_in_token_affinity_active_streams_stale
+  on in_token_affinity_active_streams (last_touched_at)
+  where ended_at is null;

--- a/docs/migrations/017_token_affinity_no_extensions.sql
+++ b/docs/migrations/017_token_affinity_no_extensions.sql
@@ -1,0 +1,36 @@
+create table if not exists in_token_affinity_assignments (
+  org_id uuid not null,
+  provider text not null,
+  credential_id uuid not null,
+  session_id text not null,
+  last_activity_at timestamptz not null default now(),
+  grace_expires_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (org_id, provider, credential_id),
+  unique (org_id, provider, session_id)
+);
+
+create table if not exists in_token_affinity_active_streams (
+  request_id text primary key,
+  org_id uuid not null,
+  provider text not null,
+  credential_id uuid not null,
+  session_id text not null,
+  started_at timestamptz not null default now(),
+  last_touched_at timestamptz not null default now(),
+  ended_at timestamptz
+);
+
+create index if not exists idx_in_token_affinity_assignments_session
+  on in_token_affinity_assignments (org_id, provider, session_id);
+
+create index if not exists idx_in_token_affinity_assignments_grace
+  on in_token_affinity_assignments (org_id, provider, grace_expires_at);
+
+create index if not exists idx_in_token_affinity_active_streams_partition
+  on in_token_affinity_active_streams (org_id, provider, credential_id);
+
+create index if not exists idx_in_token_affinity_active_streams_stale
+  on in_token_affinity_active_streams (last_touched_at)
+  where ended_at is null;


### PR DESCRIPTION
## Summary
- add the token-affinity assignment and active-stream migrations, with matching extension-free SQL
- register the new affinity table names and add a dedicated repository for preferred-assignment and active-stream persistence operations
- add focused repository contract tests for claim conflicts, busy-stream listing, explicit touch/clear flows, and stale cleanup

## Test Plan
- [x] `cd api && npx vitest run tests/tokenAffinityRepository.test.ts`
- [x] `cd api && npx vitest run tests/tokenCredentialProviderUsageRepository.test.ts tests/tokenCredentialRepository.test.ts`
- [x] `cd api && npx tsc -p tsconfig.json --noEmit`

Closes #69.
