### PR TITLE
fix: keep SLO fallback source truthful

### DIFF
--- a/scripts/innies-slo-check.sh
+++ b/scripts/innies-slo-check.sh
@@ -38,7 +38,7 @@ routing_available=0
 routing_unavailable_reason=""
 if routing_response="$(curl -sS -w '\n%{http_code}' \
   -H "Authorization: Bearer $ADMIN_TOKEN" \
-  "${BASE_URL%/}/v1/admin/analytics/tokens/routing?window=${WINDOW}" 2>&1)"; then
+  "${BASE_URL%/}/v1/admin/analytics/tokens/routing?window=${WINDOW}" 2>/dev/null)"; then
   routing_status="$(printf '%s' "$routing_response" | tail -n1)"
   routing_body="$(printf '%s' "$routing_response" | sed '$d')"
 

--- a/scripts/innies-slo-check.sh
+++ b/scripts/innies-slo-check.sh
@@ -70,6 +70,8 @@ if [[ "$routing_available" -eq 1 ]]; then
       else
         (.fallbackCount | type) != "number"
         or (.totalAttempts | type) != "number"
+        or (.fallbackCount != (.fallbackCount | floor))
+        or (.totalAttempts != (.totalAttempts | floor))
         or (.fallbackCount < 0)
         or (.totalAttempts < 0)
         or (.fallbackCount > .totalAttempts)

--- a/scripts/innies-slo-check.sh
+++ b/scripts/innies-slo-check.sh
@@ -60,8 +60,11 @@ routing_fallback_rate="$(printf '%s' "$routing_body" | jq -r '
   | if .total_attempts == 0 then 0
     else (.total_fallbacks / .total_attempts)
     end')"
+routing_fallback_display="$(jq -n -r --argjson v "$routing_fallback_rate" '($v * 100 * 100 | round) / 100 | tostring + "%"')"
 
-# Use system-level fallback rate as primary
+# Keep the main fallback row on the whole-population system summary.
+# The routing aggregate is still useful operator context, but it excludes
+# events without a resolved tokenCredentialId.
 fallback_rate="$system_fallback_rate"
 
 # Derive timeout rate and success rate from errorRate
@@ -131,6 +134,8 @@ printf '%-28s %-12s %-12s %s\n' "Fallback rate" "flag > 20%" "$fallback_display"
 echo "================================================================"
 echo "* timeout_rate and success_rate are derived from the same errorRate metric."
 echo "  The API does not yet separate timeouts from other errors."
+echo "* Fallback source: /v1/admin/analytics/system whole-population fallback rate."
+echo "* Routing cross-check below is per-token-only and may exclude unattributed events."
 
 if [[ "$exit_code" -eq 0 ]]; then
   echo "All SLOs passed."
@@ -139,6 +144,6 @@ else
 fi
 
 echo ""
-echo "(routing cross-check: per-token aggregate fallback rate = $(jq -n --argjson v "$routing_fallback_rate" '($v * 100 * 100 | round) / 100 | tostring + "%"'))"
+echo "(routing cross-check: attributed per-token aggregate fallback rate = ${routing_fallback_display})"
 
 exit "$exit_code"

--- a/scripts/innies-slo-check.sh
+++ b/scripts/innies-slo-check.sh
@@ -61,14 +61,21 @@ total_requests="$(printf '%s' "$system_body" | jq -r '.totalRequests // 0')"
 
 # Compute fallback rate from routing tokens as cross-check when available.
 if [[ "$routing_available" -eq 1 ]]; then
-  routing_fallback_rate="$(printf '%s' "$routing_body" | jq -r '
-    [.tokens[] | {f: (.fallbackCount // 0), t: (.totalAttempts // 0)}]
-    | {total_fallbacks: (map(.f) | add // 0), total_attempts: (map(.t) | add // 0)}
-    | if .total_attempts == 0 then 0
-      else (.total_fallbacks / .total_attempts)
-      end')"
-  routing_fallback_display="$(jq -n -r --argjson v "$routing_fallback_rate" '($v * 100 * 100 | round) / 100 | tostring + "%"')"
-  routing_cross_check_line="(routing cross-check: attributed per-token aggregate fallback rate = ${routing_fallback_display})"
+  if routing_fallback_rate="$(printf '%s' "$routing_body" | jq -er '
+    if (.tokens | type) != "array" then
+      error("tokens must be an array")
+    else
+      [.tokens[] | {f: (.fallbackCount // 0), t: (.totalAttempts // 0)}]
+      | {total_fallbacks: (map(.f) | add // 0), total_attempts: (map(.t) | add // 0)}
+      | if .total_attempts == 0 then 0
+        else (.total_fallbacks / .total_attempts)
+        end
+    end' 2>/dev/null)"; then
+    routing_fallback_display="$(jq -n -r --argjson v "$routing_fallback_rate" '($v * 100 * 100 | round) / 100 | tostring + "%"')"
+    routing_cross_check_line="(routing cross-check: attributed per-token aggregate fallback rate = ${routing_fallback_display})"
+  else
+    routing_cross_check_line="(routing cross-check: unavailable - /v1/admin/analytics/tokens/routing returned malformed data)"
+  fi
 else
   routing_cross_check_line="(routing cross-check: unavailable - ${routing_unavailable_reason})"
 fi

--- a/scripts/innies-slo-check.sh
+++ b/scripts/innies-slo-check.sh
@@ -64,8 +64,14 @@ if [[ "$routing_available" -eq 1 ]]; then
   if routing_fallback_rate="$(printf '%s' "$routing_body" | jq -er '
     if (.tokens | type) != "array" then
       error("tokens must be an array")
+    elif any(.tokens[]?; (
+      (type != "object")
+      or (.fallbackCount | type) != "number"
+      or (.totalAttempts | type) != "number"
+    )) then
+      error("tokens must contain numeric fallbackCount and totalAttempts")
     else
-      [.tokens[] | {f: (.fallbackCount // 0), t: (.totalAttempts // 0)}]
+      [.tokens[] | {f: .fallbackCount, t: .totalAttempts}]
       | {total_fallbacks: (map(.f) | add // 0), total_attempts: (map(.t) | add // 0)}
       | if .total_attempts == 0 then 0
         else (.total_fallbacks / .total_attempts)

--- a/scripts/innies-slo-check.sh
+++ b/scripts/innies-slo-check.sh
@@ -64,12 +64,18 @@ if [[ "$routing_available" -eq 1 ]]; then
   if routing_fallback_rate="$(printf '%s' "$routing_body" | jq -er '
     if (.tokens | type) != "array" then
       error("tokens must be an array")
-    elif any(.tokens[]?; (
-      (type != "object")
-      or (.fallbackCount | type) != "number"
-      or (.totalAttempts | type) != "number"
-    )) then
-      error("tokens must contain numeric fallbackCount and totalAttempts")
+    elif any(.tokens[]?;
+      if (type != "object") then
+        true
+      else
+        (.fallbackCount | type) != "number"
+        or (.totalAttempts | type) != "number"
+        or (.fallbackCount < 0)
+        or (.totalAttempts < 0)
+        or (.fallbackCount > .totalAttempts)
+      end
+    ) then
+      error("tokens must contain valid fallbackCount and totalAttempts counts")
     else
       [.tokens[] | {f: .fallbackCount, t: .totalAttempts}]
       | {total_fallbacks: (map(.f) | add // 0), total_attempts: (map(.t) | add // 0)}

--- a/scripts/innies-slo-check.sh
+++ b/scripts/innies-slo-check.sh
@@ -34,17 +34,23 @@ if [[ "$system_status" != "200" ]]; then
 fi
 
 # --- fetch routing summary ---
-routing_response="$(curl -sS -w '\n%{http_code}' \
+routing_available=0
+routing_unavailable_reason=""
+if routing_response="$(curl -sS -w '\n%{http_code}' \
   -H "Authorization: Bearer $ADMIN_TOKEN" \
-  "${BASE_URL%/}/v1/admin/analytics/tokens/routing?window=${WINDOW}")"
+  "${BASE_URL%/}/v1/admin/analytics/tokens/routing?window=${WINDOW}" 2>&1)"; then
+  routing_status="$(printf '%s' "$routing_response" | tail -n1)"
+  routing_body="$(printf '%s' "$routing_response" | sed '$d')"
 
-routing_status="$(printf '%s' "$routing_response" | tail -n1)"
-routing_body="$(printf '%s' "$routing_response" | sed '$d')"
-
-if [[ "$routing_status" != "200" ]]; then
-  echo "error: /v1/admin/analytics/tokens/routing returned HTTP $routing_status" >&2
-  echo "$routing_body" >&2
-  exit 1
+  if [[ "$routing_status" == "200" ]]; then
+    routing_available=1
+  else
+    routing_unavailable_reason="/v1/admin/analytics/tokens/routing returned HTTP $routing_status"
+  fi
+else
+  routing_status=""
+  routing_body="$routing_response"
+  routing_unavailable_reason="/v1/admin/analytics/tokens/routing request failed"
 fi
 
 # --- extract metrics ---
@@ -53,14 +59,19 @@ error_rate="$(printf '%s' "$system_body" | jq -r '.errorRate // 0')"
 system_fallback_rate="$(printf '%s' "$system_body" | jq -r '.fallbackRate // 0')"
 total_requests="$(printf '%s' "$system_body" | jq -r '.totalRequests // 0')"
 
-# Compute fallback rate from routing tokens as cross-check
-routing_fallback_rate="$(printf '%s' "$routing_body" | jq -r '
-  [.tokens[] | {f: (.fallbackCount // 0), t: (.totalAttempts // 0)}]
-  | {total_fallbacks: (map(.f) | add // 0), total_attempts: (map(.t) | add // 0)}
-  | if .total_attempts == 0 then 0
-    else (.total_fallbacks / .total_attempts)
-    end')"
-routing_fallback_display="$(jq -n -r --argjson v "$routing_fallback_rate" '($v * 100 * 100 | round) / 100 | tostring + "%"')"
+# Compute fallback rate from routing tokens as cross-check when available.
+if [[ "$routing_available" -eq 1 ]]; then
+  routing_fallback_rate="$(printf '%s' "$routing_body" | jq -r '
+    [.tokens[] | {f: (.fallbackCount // 0), t: (.totalAttempts // 0)}]
+    | {total_fallbacks: (map(.f) | add // 0), total_attempts: (map(.t) | add // 0)}
+    | if .total_attempts == 0 then 0
+      else (.total_fallbacks / .total_attempts)
+      end')"
+  routing_fallback_display="$(jq -n -r --argjson v "$routing_fallback_rate" '($v * 100 * 100 | round) / 100 | tostring + "%"')"
+  routing_cross_check_line="(routing cross-check: attributed per-token aggregate fallback rate = ${routing_fallback_display})"
+else
+  routing_cross_check_line="(routing cross-check: unavailable - ${routing_unavailable_reason})"
+fi
 
 # Keep the main fallback row on the whole-population system summary.
 # The routing aggregate is still useful operator context, but it excludes
@@ -144,6 +155,6 @@ else
 fi
 
 echo ""
-echo "(routing cross-check: attributed per-token aggregate fallback rate = ${routing_fallback_display})"
+echo "${routing_cross_check_line}"
 
 exit "$exit_code"

--- a/scripts/tests/innies-slo-check.test.sh
+++ b/scripts/tests/innies-slo-check.test.sh
@@ -150,6 +150,59 @@ case "$url" in
 JSON
     ;;
   *"/v1/admin/analytics/tokens/routing?window=24h")
+    cat <<'JSON'
+{"tokens":null}
+200
+JSON
+    ;;
+  *)
+    echo "unexpected curl url: $url" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "${tmp_dir}/curl"
+
+if ! malformed_output="$(
+  PATH="${tmp_dir}:$PATH" \
+  INNIES_ADMIN_API_KEY="admin-token" \
+  INNIES_ENV_FILE="${tmp_dir}/missing.env" \
+  bash "${ROOT_DIR}/scripts/innies-slo-check.sh"
+)"; then
+  echo "expected script to keep the main SLO report running when the routing cross-check body is malformed" >&2
+  exit 1
+fi
+
+malformed_fallback_line="$(printf '%s\n' "$malformed_output" | awk '$1 == "Fallback" && $2 == "rate" { print; exit }')"
+
+if [[ "$malformed_fallback_line" != *"25%"* || "$malformed_fallback_line" != *"FLAG"* ]]; then
+  echo "expected fallback line to stay on the system summary when the routing body is malformed" >&2
+  echo "$malformed_output" >&2
+  exit 1
+fi
+
+if [[ "$malformed_output" != *"(routing cross-check: unavailable - /v1/admin/analytics/tokens/routing returned malformed data)"* ]]; then
+  echo "expected malformed routing data to be treated as an unavailable routing cross-check" >&2
+  echo "$malformed_output" >&2
+  exit 1
+fi
+
+echo "PASS: innies-slo-check keeps the main SLO report usable when routing returns malformed data"
+
+cat > "${tmp_dir}/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+url="${*: -1}"
+
+case "$url" in
+  *"/v1/admin/analytics/system?window=24h")
+    cat <<'JSON'
+{"ttfbP95Ms":1000,"errorRate":0.01,"fallbackRate":0.25,"totalRequests":4}
+200
+JSON
+    ;;
+  *"/v1/admin/analytics/tokens/routing?window=24h")
     echo "curl: (7) Failed to connect" >&2
     exit 7
     ;;

--- a/scripts/tests/innies-slo-check.test.sh
+++ b/scripts/tests/innies-slo-check.test.sh
@@ -239,3 +239,56 @@ if [[ "$transport_failure_output" != *"(routing cross-check: unavailable - /v1/a
 fi
 
 echo "PASS: innies-slo-check keeps the main SLO report usable when the routing request fails"
+
+cat > "${tmp_dir}/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+url="${*: -1}"
+
+case "$url" in
+  *"/v1/admin/analytics/system?window=24h")
+    cat <<'JSON'
+{"ttfbP95Ms":1000,"errorRate":0.01,"fallbackRate":0.25,"totalRequests":4}
+200
+JSON
+    ;;
+  *"/v1/admin/analytics/tokens/routing?window=24h")
+    cat <<'JSON'
+{"tokens":[1]}
+200
+JSON
+    ;;
+  *)
+    echo "unexpected curl url: $url" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "${tmp_dir}/curl"
+
+if ! malformed_array_output="$(
+  PATH="${tmp_dir}:$PATH" \
+  INNIES_ADMIN_API_KEY="admin-token" \
+  INNIES_ENV_FILE="${tmp_dir}/missing.env" \
+  bash "${ROOT_DIR}/scripts/innies-slo-check.sh"
+)"; then
+  echo "expected script to keep the main SLO report running when routing tokens contain malformed entries" >&2
+  exit 1
+fi
+
+malformed_array_fallback_line="$(printf '%s\n' "$malformed_array_output" | awk '$1 == "Fallback" && $2 == "rate" { print; exit }')"
+
+if [[ "$malformed_array_fallback_line" != *"25%"* || "$malformed_array_fallback_line" != *"FLAG"* ]]; then
+  echo "expected fallback line to stay on the system summary when routing tokens contain malformed entries" >&2
+  echo "$malformed_array_output" >&2
+  exit 1
+fi
+
+if [[ "$malformed_array_output" != *"(routing cross-check: unavailable - /v1/admin/analytics/tokens/routing returned malformed data)"* ]]; then
+  echo "expected malformed token entries to be treated as an unavailable routing cross-check" >&2
+  echo "$malformed_array_output" >&2
+  exit 1
+fi
+
+echo "PASS: innies-slo-check keeps the main SLO report usable when routing tokens contain malformed entries"

--- a/scripts/tests/innies-slo-check.test.sh
+++ b/scripts/tests/innies-slo-check.test.sh
@@ -135,3 +135,54 @@ if [[ "$unavailable_output" != *"(routing cross-check: unavailable"* ]]; then
 fi
 
 echo "PASS: innies-slo-check keeps the main SLO report usable when routing cross-check is unavailable"
+
+cat > "${tmp_dir}/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+url="${*: -1}"
+
+case "$url" in
+  *"/v1/admin/analytics/system?window=24h")
+    cat <<'JSON'
+{"ttfbP95Ms":1000,"errorRate":0.01,"fallbackRate":0.25,"totalRequests":4}
+200
+JSON
+    ;;
+  *"/v1/admin/analytics/tokens/routing?window=24h")
+    echo "curl: (7) Failed to connect" >&2
+    exit 7
+    ;;
+  *)
+    echo "unexpected curl url: $url" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "${tmp_dir}/curl"
+
+if ! transport_failure_output="$(
+  PATH="${tmp_dir}:$PATH" \
+  INNIES_ADMIN_API_KEY="admin-token" \
+  INNIES_ENV_FILE="${tmp_dir}/missing.env" \
+  bash "${ROOT_DIR}/scripts/innies-slo-check.sh"
+)"; then
+  echo "expected script to keep the main SLO report running when the routing request itself fails" >&2
+  exit 1
+fi
+
+transport_failure_fallback_line="$(printf '%s\n' "$transport_failure_output" | awk '$1 == "Fallback" && $2 == "rate" { print; exit }')"
+
+if [[ "$transport_failure_fallback_line" != *"25%"* || "$transport_failure_fallback_line" != *"FLAG"* ]]; then
+  echo "expected fallback line to stay on the system summary when the routing request fails" >&2
+  echo "$transport_failure_output" >&2
+  exit 1
+fi
+
+if [[ "$transport_failure_output" != *"(routing cross-check: unavailable - /v1/admin/analytics/tokens/routing request failed)"* ]]; then
+  echo "expected output to show a transport failure as an unavailable routing cross-check" >&2
+  echo "$transport_failure_output" >&2
+  exit 1
+fi
+
+echo "PASS: innies-slo-check keeps the main SLO report usable when the routing request fails"

--- a/scripts/tests/innies-slo-check.test.sh
+++ b/scripts/tests/innies-slo-check.test.sh
@@ -292,3 +292,56 @@ if [[ "$malformed_array_output" != *"(routing cross-check: unavailable - /v1/adm
 fi
 
 echo "PASS: innies-slo-check keeps the main SLO report usable when routing tokens contain malformed entries"
+
+cat > "${tmp_dir}/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+url="${*: -1}"
+
+case "$url" in
+  *"/v1/admin/analytics/system?window=24h")
+    cat <<'JSON'
+{"ttfbP95Ms":1000,"errorRate":0.01,"fallbackRate":0.25,"totalRequests":4}
+200
+JSON
+    ;;
+  *"/v1/admin/analytics/tokens/routing?window=24h")
+    cat <<'JSON'
+{"tokens":[{"fallbackCount":1}]}
+200
+JSON
+    ;;
+  *)
+    echo "unexpected curl url: $url" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "${tmp_dir}/curl"
+
+if ! partially_malformed_output="$(
+  PATH="${tmp_dir}:$PATH" \
+  INNIES_ADMIN_API_KEY="admin-token" \
+  INNIES_ENV_FILE="${tmp_dir}/missing.env" \
+  bash "${ROOT_DIR}/scripts/innies-slo-check.sh"
+)"; then
+  echo "expected script to keep the main SLO report running when routing tokens are missing required numeric fields" >&2
+  exit 1
+fi
+
+partially_malformed_fallback_line="$(printf '%s\n' "$partially_malformed_output" | awk '$1 == "Fallback" && $2 == "rate" { print; exit }')"
+
+if [[ "$partially_malformed_fallback_line" != *"25%"* || "$partially_malformed_fallback_line" != *"FLAG"* ]]; then
+  echo "expected fallback line to stay on the system summary when routing token entries are partially malformed" >&2
+  echo "$partially_malformed_output" >&2
+  exit 1
+fi
+
+if [[ "$partially_malformed_output" != *"(routing cross-check: unavailable - /v1/admin/analytics/tokens/routing returned malformed data)"* ]]; then
+  echo "expected partially malformed token entries to be treated as an unavailable routing cross-check" >&2
+  echo "$partially_malformed_output" >&2
+  exit 1
+fi
+
+echo "PASS: innies-slo-check keeps the main SLO report usable when routing token entries are missing required numeric fields"

--- a/scripts/tests/innies-slo-check.test.sh
+++ b/scripts/tests/innies-slo-check.test.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_PATH" ]]; do
+  SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+  SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"
+  [[ "$SCRIPT_PATH" != /* ]] && SCRIPT_PATH="${SCRIPT_DIR}/${SCRIPT_PATH}"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+cat > "${tmp_dir}/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+url="${*: -1}"
+
+case "$url" in
+  *"/v1/admin/analytics/system?window=24h")
+    cat <<'JSON'
+{"ttfbP95Ms":1000,"errorRate":0.01,"fallbackRate":0.25,"totalRequests":4}
+200
+JSON
+    ;;
+  *"/v1/admin/analytics/tokens/routing?window=24h")
+    cat <<'JSON'
+{"tokens":[
+  {"fallbackCount":0,"totalAttempts":3}
+]}
+200
+JSON
+    ;;
+  *)
+    echo "unexpected curl url: $url" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "${tmp_dir}/curl"
+
+output="$(
+  PATH="${tmp_dir}:$PATH" \
+  INNIES_ADMIN_API_KEY="admin-token" \
+  INNIES_ENV_FILE="${tmp_dir}/missing.env" \
+  bash "${ROOT_DIR}/scripts/innies-slo-check.sh"
+)"
+
+fallback_line="$(printf '%s\n' "$output" | awk '$1 == "Fallback" && $2 == "rate" { print; exit }')"
+
+if [[ "$fallback_line" != *"25%"* ]]; then
+  echo "expected fallback line to keep the whole-population 25% rate" >&2
+  echo "$output" >&2
+  exit 1
+fi
+
+if [[ "$fallback_line" != *"FLAG"* ]]; then
+  echo "expected fallback line to remain flagged above 20%" >&2
+  echo "$output" >&2
+  exit 1
+fi
+
+if [[ "$output" != *"Fallback source: /v1/admin/analytics/system whole-population fallback rate."* ]]; then
+  echo "expected output to identify the system endpoint as the main fallback source" >&2
+  echo "$output" >&2
+  exit 1
+fi
+
+if [[ "$output" != *"Routing cross-check below is per-token-only and may exclude unattributed events."* ]]; then
+  echo "expected output to warn that the routing cross-check is subset-only" >&2
+  echo "$output" >&2
+  exit 1
+fi
+
+if [[ "$output" != *"(routing cross-check: attributed per-token aggregate fallback rate = 0%)"* ]]; then
+  echo "expected output to show the attributed routing cross-check separately" >&2
+  echo "$output" >&2
+  exit 1
+fi
+
+echo "PASS: innies-slo-check keeps fallback truthful when routing misses unattributed events"

--- a/scripts/tests/innies-slo-check.test.sh
+++ b/scripts/tests/innies-slo-check.test.sh
@@ -345,3 +345,56 @@ if [[ "$partially_malformed_output" != *"(routing cross-check: unavailable - /v1
 fi
 
 echo "PASS: innies-slo-check keeps the main SLO report usable when routing token entries are missing required numeric fields"
+
+cat > "${tmp_dir}/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+url="${*: -1}"
+
+case "$url" in
+  *"/v1/admin/analytics/system?window=24h")
+    cat <<'JSON'
+{"ttfbP95Ms":1000,"errorRate":0.01,"fallbackRate":0.25,"totalRequests":4}
+200
+JSON
+    ;;
+  *"/v1/admin/analytics/tokens/routing?window=24h")
+    cat <<'JSON'
+{"tokens":[{"fallbackCount":3,"totalAttempts":2}]}
+200
+JSON
+    ;;
+  *)
+    echo "unexpected curl url: $url" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "${tmp_dir}/curl"
+
+if ! impossible_numeric_output="$(
+  PATH="${tmp_dir}:$PATH" \
+  INNIES_ADMIN_API_KEY="admin-token" \
+  INNIES_ENV_FILE="${tmp_dir}/missing.env" \
+  bash "${ROOT_DIR}/scripts/innies-slo-check.sh"
+)"; then
+  echo "expected script to keep the main SLO report running when routing token rows are numerically impossible" >&2
+  exit 1
+fi
+
+impossible_numeric_fallback_line="$(printf '%s\n' "$impossible_numeric_output" | awk '$1 == "Fallback" && $2 == "rate" { print; exit }')"
+
+if [[ "$impossible_numeric_fallback_line" != *"25%"* || "$impossible_numeric_fallback_line" != *"FLAG"* ]]; then
+  echo "expected fallback line to stay on the system summary when routing token rows are numerically impossible" >&2
+  echo "$impossible_numeric_output" >&2
+  exit 1
+fi
+
+if [[ "$impossible_numeric_output" != *"(routing cross-check: unavailable - /v1/admin/analytics/tokens/routing returned malformed data)"* ]]; then
+  echo "expected numerically impossible routing token rows to be treated as an unavailable routing cross-check" >&2
+  echo "$impossible_numeric_output" >&2
+  exit 1
+fi
+
+echo "PASS: innies-slo-check keeps the main SLO report usable when routing token rows are numerically impossible"

--- a/scripts/tests/innies-slo-check.test.sh
+++ b/scripts/tests/innies-slo-check.test.sh
@@ -467,6 +467,59 @@ JSON
     ;;
   *"/v1/admin/analytics/tokens/routing?window=24h")
     cat <<'JSON'
+{"tokens":[{"fallbackCount":0.5,"totalAttempts":1}]}
+200
+JSON
+    ;;
+  *)
+    echo "unexpected curl url: $url" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "${tmp_dir}/curl"
+
+if ! fractional_count_output="$(
+  PATH="${tmp_dir}:$PATH" \
+  INNIES_ADMIN_API_KEY="admin-token" \
+  INNIES_ENV_FILE="${tmp_dir}/missing.env" \
+  bash "${ROOT_DIR}/scripts/innies-slo-check.sh"
+)"; then
+  echo "expected script to keep the main SLO report running when routing tokens contain fractional counts" >&2
+  exit 1
+fi
+
+fractional_count_fallback_line="$(printf '%s\n' "$fractional_count_output" | awk '$1 == "Fallback" && $2 == "rate" { print; exit }')"
+
+if [[ "$fractional_count_fallback_line" != *"25%"* || "$fractional_count_fallback_line" != *"FLAG"* ]]; then
+  echo "expected fallback line to stay on the system summary when routing token entries contain fractional counts" >&2
+  echo "$fractional_count_output" >&2
+  exit 1
+fi
+
+if [[ "$fractional_count_output" != *"(routing cross-check: unavailable - /v1/admin/analytics/tokens/routing returned malformed data)"* ]]; then
+  echo "expected fractional routing counts to be treated as an unavailable routing cross-check" >&2
+  echo "$fractional_count_output" >&2
+  exit 1
+fi
+
+echo "PASS: innies-slo-check keeps the main SLO report usable when routing token entries contain fractional counts"
+
+cat > "${tmp_dir}/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+url="${*: -1}"
+
+case "$url" in
+  *"/v1/admin/analytics/system?window=24h")
+    cat <<'JSON'
+{"ttfbP95Ms":1000,"errorRate":0.01,"fallbackRate":0.25,"totalRequests":4}
+200
+JSON
+    ;;
+  *"/v1/admin/analytics/tokens/routing?window=24h")
+    cat <<'JSON'
 {"tokens":[{"fallbackCount":0,"totalAttempts":-1}]}
 200
 JSON

--- a/scripts/tests/innies-slo-check.test.sh
+++ b/scripts/tests/innies-slo-check.test.sh
@@ -82,3 +82,56 @@ if [[ "$output" != *"(routing cross-check: attributed per-token aggregate fallba
 fi
 
 echo "PASS: innies-slo-check keeps fallback truthful when routing misses unattributed events"
+
+cat > "${tmp_dir}/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+url="${*: -1}"
+
+case "$url" in
+  *"/v1/admin/analytics/system?window=24h")
+    cat <<'JSON'
+{"ttfbP95Ms":1000,"errorRate":0.01,"fallbackRate":0.25,"totalRequests":4}
+200
+JSON
+    ;;
+  *"/v1/admin/analytics/tokens/routing?window=24h")
+    cat <<'JSON'
+{"error":"routing unavailable"}
+500
+JSON
+    ;;
+  *)
+    echo "unexpected curl url: $url" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "${tmp_dir}/curl"
+
+if ! unavailable_output="$(
+  PATH="${tmp_dir}:$PATH" \
+  INNIES_ADMIN_API_KEY="admin-token" \
+  INNIES_ENV_FILE="${tmp_dir}/missing.env" \
+  bash "${ROOT_DIR}/scripts/innies-slo-check.sh"
+)"; then
+  echo "expected script to keep the main SLO report running when routing cross-check is unavailable" >&2
+  exit 1
+fi
+
+unavailable_fallback_line="$(printf '%s\n' "$unavailable_output" | awk '$1 == "Fallback" && $2 == "rate" { print; exit }')"
+
+if [[ "$unavailable_fallback_line" != *"25%"* || "$unavailable_fallback_line" != *"FLAG"* ]]; then
+  echo "expected fallback line to stay on the system summary when routing is unavailable" >&2
+  echo "$unavailable_output" >&2
+  exit 1
+fi
+
+if [[ "$unavailable_output" != *"(routing cross-check: unavailable"* ]]; then
+  echo "expected output to mark the routing cross-check as unavailable instead of aborting" >&2
+  echo "$unavailable_output" >&2
+  exit 1
+fi
+
+echo "PASS: innies-slo-check keeps the main SLO report usable when routing cross-check is unavailable"

--- a/scripts/tests/innies-slo-check.test.sh
+++ b/scripts/tests/innies-slo-check.test.sh
@@ -557,3 +557,57 @@ if [[ "$negative_attempts_output" != *"(routing cross-check: unavailable - /v1/a
 fi
 
 echo "PASS: innies-slo-check keeps the main SLO report usable when routing totalAttempts is negative"
+
+cat > "${tmp_dir}/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+url="${*: -1}"
+
+case "$url" in
+  *"/v1/admin/analytics/system?window=24h")
+    cat <<'JSON'
+{"ttfbP95Ms":1000,"errorRate":0.01,"fallbackRate":0.25,"totalRequests":4}
+200
+JSON
+    ;;
+  *"/v1/admin/analytics/tokens/routing?window=24h")
+    echo "notice: reused connection" >&2
+    cat <<'JSON'
+{"tokens":[{"fallbackCount":0,"totalAttempts":3}]}
+200
+JSON
+    ;;
+  *)
+    echo "unexpected curl url: $url" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "${tmp_dir}/curl"
+
+if ! stderr_noise_output="$(
+  PATH="${tmp_dir}:$PATH" \
+  INNIES_ADMIN_API_KEY="admin-token" \
+  INNIES_ENV_FILE="${tmp_dir}/missing.env" \
+  bash "${ROOT_DIR}/scripts/innies-slo-check.sh"
+)"; then
+  echo "expected script to keep the main SLO report running when routing succeeds with harmless stderr noise" >&2
+  exit 1
+fi
+
+stderr_noise_fallback_line="$(printf '%s\n' "$stderr_noise_output" | awk '$1 == "Fallback" && $2 == "rate" { print; exit }')"
+
+if [[ "$stderr_noise_fallback_line" != *"25%"* || "$stderr_noise_fallback_line" != *"FLAG"* ]]; then
+  echo "expected fallback line to stay on the system summary when routing succeeds with harmless stderr noise" >&2
+  echo "$stderr_noise_output" >&2
+  exit 1
+fi
+
+if [[ "$stderr_noise_output" != *"(routing cross-check: attributed per-token aggregate fallback rate = 0%)"* ]]; then
+  echo "expected successful routing JSON plus harmless stderr noise to preserve the truthful routing cross-check" >&2
+  echo "$stderr_noise_output" >&2
+  exit 1
+fi
+
+echo "PASS: innies-slo-check keeps the routing cross-check truthful when successful routing responses emit harmless stderr noise"

--- a/scripts/tests/innies-slo-check.test.sh
+++ b/scripts/tests/innies-slo-check.test.sh
@@ -398,3 +398,109 @@ if [[ "$impossible_numeric_output" != *"(routing cross-check: unavailable - /v1/
 fi
 
 echo "PASS: innies-slo-check keeps the main SLO report usable when routing token rows are numerically impossible"
+
+cat > "${tmp_dir}/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+url="${*: -1}"
+
+case "$url" in
+  *"/v1/admin/analytics/system?window=24h")
+    cat <<'JSON'
+{"ttfbP95Ms":1000,"errorRate":0.01,"fallbackRate":0.25,"totalRequests":4}
+200
+JSON
+    ;;
+  *"/v1/admin/analytics/tokens/routing?window=24h")
+    cat <<'JSON'
+{"tokens":[{"fallbackCount":-1,"totalAttempts":2}]}
+200
+JSON
+    ;;
+  *)
+    echo "unexpected curl url: $url" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "${tmp_dir}/curl"
+
+if ! negative_counts_output="$(
+  PATH="${tmp_dir}:$PATH" \
+  INNIES_ADMIN_API_KEY="admin-token" \
+  INNIES_ENV_FILE="${tmp_dir}/missing.env" \
+  bash "${ROOT_DIR}/scripts/innies-slo-check.sh"
+)"; then
+  echo "expected script to keep the main SLO report running when routing token counts are negative" >&2
+  exit 1
+fi
+
+negative_counts_fallback_line="$(printf '%s\n' "$negative_counts_output" | awk '$1 == "Fallback" && $2 == "rate" { print; exit }')"
+
+if [[ "$negative_counts_fallback_line" != *"25%"* || "$negative_counts_fallback_line" != *"FLAG"* ]]; then
+  echo "expected fallback line to stay on the system summary when routing token counts are negative" >&2
+  echo "$negative_counts_output" >&2
+  exit 1
+fi
+
+if [[ "$negative_counts_output" != *"(routing cross-check: unavailable - /v1/admin/analytics/tokens/routing returned malformed data)"* ]]; then
+  echo "expected negative token counts to be treated as an unavailable routing cross-check" >&2
+  echo "$negative_counts_output" >&2
+  exit 1
+fi
+
+echo "PASS: innies-slo-check keeps the main SLO report usable when routing token counts are negative"
+
+cat > "${tmp_dir}/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+url="${*: -1}"
+
+case "$url" in
+  *"/v1/admin/analytics/system?window=24h")
+    cat <<'JSON'
+{"ttfbP95Ms":1000,"errorRate":0.01,"fallbackRate":0.25,"totalRequests":4}
+200
+JSON
+    ;;
+  *"/v1/admin/analytics/tokens/routing?window=24h")
+    cat <<'JSON'
+{"tokens":[{"fallbackCount":0,"totalAttempts":-1}]}
+200
+JSON
+    ;;
+  *)
+    echo "unexpected curl url: $url" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "${tmp_dir}/curl"
+
+if ! negative_attempts_output="$(
+  PATH="${tmp_dir}:$PATH" \
+  INNIES_ADMIN_API_KEY="admin-token" \
+  INNIES_ENV_FILE="${tmp_dir}/missing.env" \
+  bash "${ROOT_DIR}/scripts/innies-slo-check.sh"
+)"; then
+  echo "expected script to keep the main SLO report running when routing totalAttempts is negative" >&2
+  exit 1
+fi
+
+negative_attempts_fallback_line="$(printf '%s\n' "$negative_attempts_output" | awk '$1 == "Fallback" && $2 == "rate" { print; exit }')"
+
+if [[ "$negative_attempts_fallback_line" != *"25%"* || "$negative_attempts_fallback_line" != *"FLAG"* ]]; then
+  echo "expected fallback line to stay on the system summary when routing totalAttempts is negative" >&2
+  echo "$negative_attempts_output" >&2
+  exit 1
+fi
+
+if [[ "$negative_attempts_output" != *"(routing cross-check: unavailable - /v1/admin/analytics/tokens/routing returned malformed data)"* ]]; then
+  echo "expected negative totalAttempts to be treated as an unavailable routing cross-check" >&2
+  echo "$negative_attempts_output" >&2
+  exit 1
+fi
+
+echo "PASS: innies-slo-check keeps the main SLO report usable when routing totalAttempts is negative"


### PR DESCRIPTION
## Summary
- keep the main `Fallback rate` row on `/v1/admin/analytics/system` so the primary SLO report stays on the whole-population fallback rate
- treat `/v1/admin/analytics/tokens/routing` as secondary attributed-token context and mark that cross-check unavailable when the endpoint fails, returns non-`200`, or returns malformed data
- extend the shell regression to cover the mixed attributed/unattributed fallback case, the routing non-`200` case, the malformed-`200` routing-body case, malformed token entries inside a `200` payload, and the routing transport-failure case

## Verification
- `bash scripts/tests/innies-slo-check.test.sh`
- `bash -n scripts/innies-slo-check.sh scripts/tests/innies-slo-check.test.sh`
- `git diff --check origin/main...HEAD`

Fixes #63
