### PR TITLE
fix: clarify truthful SLO fallback source

### DIFF
--- a/scripts/innies-slo-check.sh
+++ b/scripts/innies-slo-check.sh
@@ -60,6 +60,7 @@ routing_fallback_rate="$(printf '%s' "$routing_body" | jq -r '
   | if .total_attempts == 0 then 0
     else (.total_fallbacks / .total_attempts)
     end')"
+routing_fallback_display="$(jq -n --argjson v "$routing_fallback_rate" '($v * 100 * 100 | round) / 100 | tostring + "%"')"
 
 # Use system-level fallback rate as primary
 fallback_rate="$system_fallback_rate"
@@ -131,14 +132,14 @@ printf '%-28s %-12s %-12s %s\n' "Fallback rate" "flag > 20%" "$fallback_display"
 echo "================================================================"
 echo "* timeout_rate and success_rate are derived from the same errorRate metric."
 echo "  The API does not yet separate timeouts from other errors."
+echo "* Fallback rate source: /v1/admin/analytics/system whole-population metric."
+echo "* Routing fallback context: ${routing_fallback_display} from attributed token events only."
+echo "  Unattributed routing events are excluded from /v1/admin/analytics/tokens/routing."
 
 if [[ "$exit_code" -eq 0 ]]; then
   echo "All SLOs passed."
 else
   echo "One or more SLOs failed."
 fi
-
-echo ""
-echo "(routing cross-check: per-token aggregate fallback rate = $(jq -n --argjson v "$routing_fallback_rate" '($v * 100 * 100 | round) / 100 | tostring + "%"'))"
 
 exit "$exit_code"

--- a/scripts/tests/innies-slo-check.test.sh
+++ b/scripts/tests/innies-slo-check.test.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+cat > "${tmp_dir}/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+url="${*: -1}"
+
+case "$url" in
+  *"/v1/admin/analytics/system?window=24h")
+    cat <<'JSON'
+{"ttfbP95Ms":1000,"errorRate":0.01,"fallbackRate":0.25,"totalRequests":4}
+200
+JSON
+    ;;
+  *"/v1/admin/analytics/tokens/routing?window=24h")
+    cat <<'JSON'
+{"tokens":[
+  {"fallbackCount":0,"totalAttempts":3}
+]}
+200
+JSON
+    ;;
+  *)
+    echo "unexpected curl url: $url" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "${tmp_dir}/curl"
+
+output="$(
+  PATH="${tmp_dir}:$PATH" \
+  INNIES_ADMIN_API_KEY="admin-token" \
+  INNIES_ENV_FILE="${tmp_dir}/missing.env" \
+  bash "${ROOT_DIR}/scripts/innies-slo-check.sh"
+)"
+
+fallback_line="$(printf '%s\n' "$output" | awk '$1 == "Fallback" && $2 == "rate" { print; exit }')"
+
+if [[ "$fallback_line" != *"25%"* ]]; then
+  echo "expected fallback line to use whole-population 25% fallback rate" >&2
+  echo "$output" >&2
+  exit 1
+fi
+
+if [[ "$fallback_line" != *"FLAG"* ]]; then
+  echo "expected fallback line to remain flagged above 20%" >&2
+  echo "$output" >&2
+  exit 1
+fi
+
+if [[ "$output" != *"Fallback rate source: /v1/admin/analytics/system whole-population metric."* ]]; then
+  echo "expected output to document the primary fallback source" >&2
+  echo "$output" >&2
+  exit 1
+fi
+
+if [[ "$output" != *'Routing fallback context: "0%" from attributed token events only.'* ]]; then
+  echo "expected output to show the attributed-only routing fallback context" >&2
+  echo "$output" >&2
+  exit 1
+fi
+
+if [[ "$output" != *"Unattributed routing events are excluded from /v1/admin/analytics/tokens/routing."* ]]; then
+  echo "expected output to document the routing coverage caveat" >&2
+  echo "$output" >&2
+  exit 1
+fi
+
+echo "PASS: innies-slo-check keeps the main fallback row truthful in mixed attribution cases"


### PR DESCRIPTION
Fixes #63

## Summary
- keep the main `Fallback rate` row on `/v1/admin/analytics/system` so mixed attributed/unattributed fallback events do not underreport the real whole-population rate
- relabel the routing fallback aggregate as secondary operator context sourced from attributed token events only
- add a shell regression covering the mixed case where the system fallback is `25%` and the routing aggregate is `0%`

## Test Plan
- [x] `bash scripts/tests/innies-slo-check.test.sh`
- [x] `bash -n scripts/innies-slo-check.sh scripts/tests/innies-slo-check.test.sh`
- [x] `git diff --check HEAD~1 HEAD`
