### PR TITLE
fix: preserve inbound compat anthropic betas

### DIFF
--- a/api/src/routes/proxy.ts
+++ b/api/src/routes/proxy.ts
@@ -507,6 +507,7 @@ function buildTokenModeUpstreamHeaders(input: {
   provider: string;
   credential: TokenCredential;
   skipOauthDefaultBetas?: boolean;
+  strictUpstreamPassthrough?: boolean;
   streaming?: boolean;
 }): Record<string, string> {
   const {
@@ -516,6 +517,7 @@ function buildTokenModeUpstreamHeaders(input: {
     provider,
     credential,
     skipOauthDefaultBetas,
+    strictUpstreamPassthrough,
     streaming
   } = input;
   const authHeaders = isAnthropicOauthAccessToken(provider, credential.accessToken) || isOpenAiProvider(provider)
@@ -539,7 +541,10 @@ function buildTokenModeUpstreamHeaders(input: {
     headers.accept = 'text/event-stream';
   }
 
-  const shouldIncludeOauthBetas = !skipOauthDefaultBetas && isAnthropicOauthToken(credential, provider);
+  const shouldIncludeOauthBetas =
+    !skipOauthDefaultBetas
+    && !strictUpstreamPassthrough
+    && isAnthropicOauthToken(credential, provider);
   const inboundBetas = parseAnthropicBetaHeader(anthropicBeta ?? '');
   if (inboundBetas.length > 0 || shouldIncludeOauthBetas) {
     const mergedBetas = new Set<string>(inboundBetas);
@@ -2415,7 +2420,8 @@ async function executeTokenModeNonStreaming(input: {
         anthropicBeta: compat.anthropicBeta,
         provider,
         credential,
-        skipOauthDefaultBetas: compat.blockedRetryApplied
+        skipOauthDefaultBetas: compat.blockedRetryApplied,
+        strictUpstreamPassthrough
       });
       const upstreamBody = JSON.stringify(upstreamPayload);
 
@@ -3199,6 +3205,7 @@ async function executeTokenModeStreaming(input: {
         provider,
         credential,
         skipOauthDefaultBetas: compat.blockedRetryApplied,
+        strictUpstreamPassthrough,
         streaming: true
       });
       const upstreamPayload = normalizeTokenModeUpstreamPayload({

--- a/api/tests/anthropicCompat.route.test.ts
+++ b/api/tests/anthropicCompat.route.test.ts
@@ -1828,8 +1828,7 @@ describe('anthropic compat route', () => {
     const fetchArgs = upstreamSpy.mock.calls[0];
     const headers = (fetchArgs?.[1] as RequestInit)?.headers as Record<string, string>;
     expect(headers['anthropic-version']).toBe('2024-10-22');
-    expect(headers['anthropic-beta']).toContain('foo-2026-01-01');
-    expect(headers['anthropic-beta']).toContain('bar-2026-02-02');
+    expect(headers['anthropic-beta']).toBe('foo-2026-01-01,bar-2026-02-02');
     expect(res.statusCode).toBe(200);
 
     upstreamSpy.mockRestore();

--- a/api/tests/proxy.tokenMode.route.test.ts
+++ b/api/tests/proxy.tokenMode.route.test.ts
@@ -1215,7 +1215,7 @@ describe('proxy token-mode route behavior', () => {
     const firstBody = JSON.parse(String((upstreamSpy.mock.calls[0]?.[1] as RequestInit)?.body ?? '{}'));
     const secondBody = JSON.parse(String((upstreamSpy.mock.calls[1]?.[1] as RequestInit)?.body ?? '{}'));
 
-    expect(firstHeaders['anthropic-beta']).toContain('fine-grained-tool-streaming-2025-05-14');
+    expect(firstHeaders['anthropic-beta']).toBe('fine-grained-tool-streaming-2025-05-14');
     expect(secondHeaders['anthropic-beta']).toContain('oauth-2025-04-20');
     expect(secondHeaders['anthropic-beta']).toContain('claude-code-20250219');
     expect(firstBody.stream).toBe(true);
@@ -1272,7 +1272,8 @@ describe('proxy token-mode route behavior', () => {
         authorization: 'Bearer in_test_token',
         'content-type': 'application/json',
         'idempotency-key': 'abcdefghijklmnopqrstuvwxyz123456',
-        'anthropic-version': '2023-06-01'
+        'anthropic-version': '2023-06-01',
+        'anthropic-beta': 'fine-grained-tool-streaming-2025-05-14'
       },
       body: {
         provider: 'anthropic',
@@ -1436,7 +1437,8 @@ describe('proxy token-mode route behavior', () => {
         authorization: 'Bearer in_test_token',
         'content-type': 'application/json',
         'idempotency-key': 'abcdefghijklmnopqrstuvwxyz123456',
-        'anthropic-version': '2023-06-01'
+        'anthropic-version': '2023-06-01',
+        'anthropic-beta': 'fine-grained-tool-streaming-2025-05-14'
       },
       body: {
         provider: 'anthropic',
@@ -1461,8 +1463,7 @@ describe('proxy token-mode route behavior', () => {
 
     const firstHeaders = (upstreamSpy.mock.calls[0]?.[1] as RequestInit)?.headers as Record<string, string>;
     const secondHeaders = (upstreamSpy.mock.calls[1]?.[1] as RequestInit)?.headers as Record<string, string>;
-    expect(firstHeaders['anthropic-beta']).toContain('oauth-2025-04-20');
-    expect(firstHeaders['anthropic-beta']).toContain('claude-code-20250219');
+    expect(firstHeaders['anthropic-beta']).toBe('fine-grained-tool-streaming-2025-05-14');
     expect(secondHeaders['anthropic-beta']).toBeUndefined();
     upstreamSpy.mockRestore();
   });


### PR DESCRIPTION
## Summary
- preserve the inbound anthropic-beta header on first compat Anthropic OAuth dispatches instead of always merging Innies OAuth betas
- keep retry-specific behavior intact by still adding OAuth betas on oauth-401 compat retries and stripping betas on blocked-403 compat retries
- tighten compat route coverage so first-attempt header preservation is asserted directly

## Test Plan
- cd api && npx vitest run tests/anthropicCompat.route.test.ts tests/proxy.tokenMode.route.test.ts tests/tokenCredentialProviderUsageJob.test.ts --hookTimeout=30000
- cd api && npm run build

Fixes #80