### PR TITLE
fix: preserve initial anthropic compat beta lane

### DIFF
--- a/api/src/routes/proxy.ts
+++ b/api/src/routes/proxy.ts
@@ -500,13 +500,15 @@ function isAnthropicOauthToken(credential: TokenCredential, provider: string): b
   return isAnthropicOauthAccessToken(provider, credential.accessToken);
 }
 
+type AnthropicBetaMode = 'default_oauth' | 'preserve_inbound' | 'omit';
+
 function buildTokenModeUpstreamHeaders(input: {
   requestId: string;
   anthropicVersion: string;
   anthropicBeta?: string;
   provider: string;
   credential: TokenCredential;
-  skipOauthDefaultBetas?: boolean;
+  anthropicBetaMode?: AnthropicBetaMode;
   streaming?: boolean;
 }): Record<string, string> {
   const {
@@ -515,7 +517,7 @@ function buildTokenModeUpstreamHeaders(input: {
     anthropicBeta,
     provider,
     credential,
-    skipOauthDefaultBetas,
+    anthropicBetaMode = 'default_oauth',
     streaming
   } = input;
   const authHeaders = isAnthropicOauthAccessToken(provider, credential.accessToken) || isOpenAiProvider(provider)
@@ -539,10 +541,11 @@ function buildTokenModeUpstreamHeaders(input: {
     headers.accept = 'text/event-stream';
   }
 
-  const shouldIncludeOauthBetas = !skipOauthDefaultBetas && isAnthropicOauthToken(credential, provider);
   const inboundBetas = parseAnthropicBetaHeader(anthropicBeta ?? '');
-  if (inboundBetas.length > 0 || shouldIncludeOauthBetas) {
-    const mergedBetas = new Set<string>(inboundBetas);
+  const shouldForwardInboundBetas = anthropicBetaMode !== 'omit' && inboundBetas.length > 0;
+  const shouldIncludeOauthBetas = anthropicBetaMode === 'default_oauth' && isAnthropicOauthToken(credential, provider);
+  if (shouldForwardInboundBetas || shouldIncludeOauthBetas) {
+    const mergedBetas = new Set<string>(shouldForwardInboundBetas ? inboundBetas : []);
     if (shouldIncludeOauthBetas) {
       for (const beta of ANTHROPIC_OAUTH_BETAS) mergedBetas.add(beta);
     }
@@ -586,6 +589,19 @@ function createCompatNormalizationState(payload: unknown, anthropicBeta?: string
     blockedRetryApplied: false,
     oauthRetryApplied: false
   };
+}
+
+function resolveCompatAnthropicBetaMode(input: {
+  anthropicBeta?: string;
+  blockedRetryApplied: boolean;
+  strictUpstreamPassthrough?: boolean;
+}): AnthropicBetaMode {
+  const { anthropicBeta, blockedRetryApplied, strictUpstreamPassthrough } = input;
+  if (blockedRetryApplied) return 'omit';
+  if (strictUpstreamPassthrough && parseAnthropicBetaHeader(anthropicBeta ?? '').length > 0) {
+    return 'preserve_inbound';
+  }
+  return 'default_oauth';
 }
 
 function applyCompatNormalization(input: {
@@ -2415,8 +2431,11 @@ async function executeTokenModeNonStreaming(input: {
         anthropicBeta: compat.anthropicBeta,
         provider,
         credential,
-        // Keep the caller's beta lane intact on the initial compat passthrough.
-        skipOauthDefaultBetas: strictUpstreamPassthrough || compat.blockedRetryApplied
+        anthropicBetaMode: resolveCompatAnthropicBetaMode({
+          anthropicBeta: compat.anthropicBeta,
+          blockedRetryApplied: compat.blockedRetryApplied,
+          strictUpstreamPassthrough
+        })
       });
       const upstreamBody = JSON.stringify(upstreamPayload);
 
@@ -3199,8 +3218,11 @@ async function executeTokenModeStreaming(input: {
         anthropicBeta: compat.anthropicBeta,
         provider,
         credential,
-        // Keep the caller's beta lane intact on the initial compat passthrough.
-        skipOauthDefaultBetas: strictUpstreamPassthrough || compat.blockedRetryApplied,
+        anthropicBetaMode: resolveCompatAnthropicBetaMode({
+          anthropicBeta: compat.anthropicBeta,
+          blockedRetryApplied: compat.blockedRetryApplied,
+          strictUpstreamPassthrough
+        }),
         streaming: true
       });
       const upstreamPayload = normalizeTokenModeUpstreamPayload({

--- a/api/src/routes/proxy.ts
+++ b/api/src/routes/proxy.ts
@@ -2415,7 +2415,8 @@ async function executeTokenModeNonStreaming(input: {
         anthropicBeta: compat.anthropicBeta,
         provider,
         credential,
-        skipOauthDefaultBetas: compat.blockedRetryApplied
+        // Keep the caller's beta lane intact on the initial compat passthrough.
+        skipOauthDefaultBetas: strictUpstreamPassthrough || compat.blockedRetryApplied
       });
       const upstreamBody = JSON.stringify(upstreamPayload);
 
@@ -3198,7 +3199,8 @@ async function executeTokenModeStreaming(input: {
         anthropicBeta: compat.anthropicBeta,
         provider,
         credential,
-        skipOauthDefaultBetas: compat.blockedRetryApplied,
+        // Keep the caller's beta lane intact on the initial compat passthrough.
+        skipOauthDefaultBetas: strictUpstreamPassthrough || compat.blockedRetryApplied,
         streaming: true
       });
       const upstreamPayload = normalizeTokenModeUpstreamPayload({

--- a/api/tests/anthropicCompat.route.test.ts
+++ b/api/tests/anthropicCompat.route.test.ts
@@ -2574,6 +2574,57 @@ describe('anthropic compat route', () => {
     upstreamSpy.mockRestore();
   });
 
+  it('keeps default oauth betas on the first blocked-403 attempt when no inbound anthropic-beta header is present', async () => {
+    const upstreamSpy = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        type: 'error',
+        error: { type: 'invalid_request_error', message: 'Your request was blocked.' }
+      }), {
+        status: 403,
+        headers: { 'content-type': 'application/json' }
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        id: 'msg_blocked_default_beta_retry_ok',
+        usage: { input_tokens: 4, output_tokens: 5 }
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' }
+      }));
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/messages',
+      headers: {
+        authorization: 'Bearer in_test_token',
+        'content-type': 'application/json'
+      },
+      body: {
+        model: 'claude-opus-4-6',
+        max_tokens: 16,
+        messages: [{ role: 'user', content: 'hi' }]
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(handlers[0], req, res);
+    await invoke(handlers[1], req, res);
+    await invoke(handlers[2], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(upstreamSpy).toHaveBeenCalledTimes(2);
+
+    const firstHeaders = (upstreamSpy.mock.calls[0]?.[1] as RequestInit)?.headers as Record<string, string>;
+    const secondHeaders = (upstreamSpy.mock.calls[1]?.[1] as RequestInit)?.headers as Record<string, string>;
+
+    expect(firstHeaders['anthropic-beta']).toContain('fine-grained-tool-streaming-2025-05-14');
+    expect(firstHeaders['anthropic-beta']).toContain('interleaved-thinking-2025-05-14');
+    expect(firstHeaders['anthropic-beta']).toContain('oauth-2025-04-20');
+    expect(firstHeaders['anthropic-beta']).toContain('claude-code-20250219');
+    expect(secondHeaders['anthropic-beta']).toBeUndefined();
+
+    upstreamSpy.mockRestore();
+  });
+
   it('retries once on oauth-incompatible 401 with oauth-safe payload on /v1/messages', async () => {
     const retryAuditSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
     const upstreamSpy = vi.spyOn(globalThis, 'fetch')

--- a/api/tests/anthropicCompat.route.test.ts
+++ b/api/tests/anthropicCompat.route.test.ts
@@ -1830,6 +1830,9 @@ describe('anthropic compat route', () => {
     expect(headers['anthropic-version']).toBe('2024-10-22');
     expect(headers['anthropic-beta']).toContain('foo-2026-01-01');
     expect(headers['anthropic-beta']).toContain('bar-2026-02-02');
+    expect(headers['anthropic-beta']).not.toContain('oauth-2025-04-20');
+    expect(headers['anthropic-beta']).not.toContain('claude-code-20250219');
+    expect(headers['anthropic-beta']).not.toContain('interleaved-thinking-2025-05-14');
     expect(res.statusCode).toBe(200);
 
     upstreamSpy.mockRestore();
@@ -2625,13 +2628,18 @@ describe('anthropic compat route', () => {
 
     expect(firstHeaders.authorization).toBe('Bearer sk-ant-oat01-test-token');
     expect(firstHeaders['anthropic-beta']).toContain('fine-grained-tool-streaming-2025-05-14');
+    expect(firstHeaders['anthropic-beta']).not.toContain('oauth-2025-04-20');
+    expect(firstHeaders['anthropic-beta']).not.toContain('claude-code-20250219');
+    expect(firstHeaders['anthropic-beta']).not.toContain('interleaved-thinking-2025-05-14');
     expect(firstBody.stream).toBe(true);
     expect(firstBody.tools).toBeDefined();
     expect(firstBody.tool_choice).toEqual({ type: 'auto' });
 
     expect(secondHeaders.authorization).toBe('Bearer sk-ant-oat01-test-token');
+    expect(secondHeaders['anthropic-beta']).toContain('fine-grained-tool-streaming-2025-05-14');
     expect(secondHeaders['anthropic-beta']).toContain('oauth-2025-04-20');
     expect(secondHeaders['anthropic-beta']).toContain('claude-code-20250219');
+    expect(secondHeaders['anthropic-beta']).toContain('interleaved-thinking-2025-05-14');
     expect(secondBody.stream).toBe(true);
     expect(secondBody.tools).toBeDefined();
     expect(secondBody.tool_choice).toEqual({ type: 'auto' });

--- a/api/tests/proxy.tokenMode.route.test.ts
+++ b/api/tests/proxy.tokenMode.route.test.ts
@@ -1466,7 +1466,10 @@ describe('proxy token-mode route behavior', () => {
 
     const firstHeaders = (upstreamSpy.mock.calls[0]?.[1] as RequestInit)?.headers as Record<string, string>;
     const secondHeaders = (upstreamSpy.mock.calls[1]?.[1] as RequestInit)?.headers as Record<string, string>;
-    expect(firstHeaders['anthropic-beta']).toBeUndefined();
+    expect(firstHeaders['anthropic-beta']).toContain('fine-grained-tool-streaming-2025-05-14');
+    expect(firstHeaders['anthropic-beta']).toContain('interleaved-thinking-2025-05-14');
+    expect(firstHeaders['anthropic-beta']).toContain('oauth-2025-04-20');
+    expect(firstHeaders['anthropic-beta']).toContain('claude-code-20250219');
     expect(secondHeaders['anthropic-beta']).toBeUndefined();
     upstreamSpy.mockRestore();
   });

--- a/api/tests/proxy.tokenMode.route.test.ts
+++ b/api/tests/proxy.tokenMode.route.test.ts
@@ -1216,8 +1216,13 @@ describe('proxy token-mode route behavior', () => {
     const secondBody = JSON.parse(String((upstreamSpy.mock.calls[1]?.[1] as RequestInit)?.body ?? '{}'));
 
     expect(firstHeaders['anthropic-beta']).toContain('fine-grained-tool-streaming-2025-05-14');
+    expect(firstHeaders['anthropic-beta']).not.toContain('oauth-2025-04-20');
+    expect(firstHeaders['anthropic-beta']).not.toContain('claude-code-20250219');
+    expect(firstHeaders['anthropic-beta']).not.toContain('interleaved-thinking-2025-05-14');
+    expect(secondHeaders['anthropic-beta']).toContain('fine-grained-tool-streaming-2025-05-14');
     expect(secondHeaders['anthropic-beta']).toContain('oauth-2025-04-20');
     expect(secondHeaders['anthropic-beta']).toContain('claude-code-20250219');
+    expect(secondHeaders['anthropic-beta']).toContain('interleaved-thinking-2025-05-14');
     expect(firstBody.stream).toBe(true);
     expect(firstBody.tools).toBeDefined();
     expect(firstBody.tool_choice).toEqual({ type: 'auto' });
@@ -1461,8 +1466,7 @@ describe('proxy token-mode route behavior', () => {
 
     const firstHeaders = (upstreamSpy.mock.calls[0]?.[1] as RequestInit)?.headers as Record<string, string>;
     const secondHeaders = (upstreamSpy.mock.calls[1]?.[1] as RequestInit)?.headers as Record<string, string>;
-    expect(firstHeaders['anthropic-beta']).toContain('oauth-2025-04-20');
-    expect(firstHeaders['anthropic-beta']).toContain('claude-code-20250219');
+    expect(firstHeaders['anthropic-beta']).toBeUndefined();
     expect(secondHeaders['anthropic-beta']).toBeUndefined();
     upstreamSpy.mockRestore();
   });


### PR DESCRIPTION
## Summary
- preserve the caller's `anthropic-beta` header on the first strict Anthropic compat passthrough instead of auto-merging Innies OAuth betas
- keep the explicit Anthropic OAuth 401 recovery path injecting the compat retry betas after auth-mode failures
- strengthen compat route tests to lock the first-attempt vs retry header behavior, including blocked-403 retries with no inbound beta header

## Test Plan
- `cd api && npx vitest run tests/anthropicCompat.route.test.ts tests/proxy.tokenMode.route.test.ts`

## Notes
- `cd api && npm test` already times out on `origin/main` in several route suites (`anthropicCompat`, `proxy.tokenMode`, `proxy.sellerMode`, `compatTranslation.e2e`, `admin.tokenCredentials`, `admin.buyerProviderPreference`), so I kept verification scoped to the touched compat/token-mode suites.
- Refs #80
