### PR TITLE
fix: retry opaque Anthropic OAuth compat 400s

### DIFF
--- a/api/src/routes/proxy.ts
+++ b/api/src/routes/proxy.ts
@@ -89,6 +89,7 @@ type OpenClawCorrelation = {
 };
 type RetryReason =
   | 'blocked_403_compat_retry'
+  | 'opaque_400_header_retry'
   | 'oauth_401_compat_retry'
   | 'credential_refresh_retry'
   | 'rate_limited_backoff';
@@ -506,7 +507,7 @@ function buildTokenModeUpstreamHeaders(input: {
   anthropicBeta?: string;
   provider: string;
   credential: TokenCredential;
-  skipOauthDefaultBetas?: boolean;
+  skipInjectedOauthBetas?: boolean;
   streaming?: boolean;
 }): Record<string, string> {
   const {
@@ -515,7 +516,7 @@ function buildTokenModeUpstreamHeaders(input: {
     anthropicBeta,
     provider,
     credential,
-    skipOauthDefaultBetas,
+    skipInjectedOauthBetas,
     streaming
   } = input;
   const authHeaders = isAnthropicOauthAccessToken(provider, credential.accessToken) || isOpenAiProvider(provider)
@@ -539,7 +540,7 @@ function buildTokenModeUpstreamHeaders(input: {
     headers.accept = 'text/event-stream';
   }
 
-  const shouldIncludeOauthBetas = !skipOauthDefaultBetas && isAnthropicOauthToken(credential, provider);
+  const shouldIncludeOauthBetas = !skipInjectedOauthBetas && isAnthropicOauthToken(credential, provider);
   const inboundBetas = parseAnthropicBetaHeader(anthropicBeta ?? '');
   if (inboundBetas.length > 0 || shouldIncludeOauthBetas) {
     const mergedBetas = new Set<string>(inboundBetas);
@@ -570,13 +571,16 @@ function sanitizeCompatPayloadForBlockedRetry(payload: unknown): unknown {
 
 type CompatNormalizationReason =
   | 'retry_blocked_403'
+  | 'retry_opaque_400_strip_oauth_betas'
   | 'retry_oauth_401';
 
 type CompatNormalizationState = {
   payload: unknown;
   anthropicBeta?: string;
   blockedRetryApplied: boolean;
+  opaque400HeaderRetryApplied: boolean;
   oauthRetryApplied: boolean;
+  skipInjectedOauthBetas: boolean;
 };
 
 function createCompatNormalizationState(payload: unknown, anthropicBeta?: string): CompatNormalizationState {
@@ -584,7 +588,9 @@ function createCompatNormalizationState(payload: unknown, anthropicBeta?: string
     payload,
     anthropicBeta,
     blockedRetryApplied: false,
-    oauthRetryApplied: false
+    opaque400HeaderRetryApplied: false,
+    oauthRetryApplied: false,
+    skipInjectedOauthBetas: false
   };
 }
 
@@ -601,14 +607,20 @@ function applyCompatNormalization(input: {
   const nextState: CompatNormalizationState = { ...state };
   const beforeShape = payloadLooksLikeToolStreaming(state.payload);
   const beforeBeta = state.anthropicBeta;
+  const beforeSkipInjectedBetas = state.skipInjectedOauthBetas;
 
   if (reason === 'retry_oauth_401') {
     nextState.payload = sanitizeCompatPayloadForOauthAuthRetry(nextState.payload);
     nextState.oauthRetryApplied = true;
+    nextState.skipInjectedOauthBetas = false;
   } else if (reason === 'retry_blocked_403') {
     nextState.payload = sanitizeCompatPayloadForBlockedRetry(nextState.payload);
     nextState.anthropicBeta = undefined;
     nextState.blockedRetryApplied = true;
+    nextState.skipInjectedOauthBetas = true;
+  } else if (reason === 'retry_opaque_400_strip_oauth_betas') {
+    nextState.opaque400HeaderRetryApplied = true;
+    nextState.skipInjectedOauthBetas = true;
   }
 
   if (reason === 'retry_oauth_401' && isAnthropicOauthToken(credential, provider)) {
@@ -627,15 +639,19 @@ function applyCompatNormalization(input: {
       reason,
       flags: {
         blockedRetryApplied: nextState.blockedRetryApplied,
-        oauthRetryApplied: nextState.oauthRetryApplied
+        opaque400HeaderRetryApplied: nextState.opaque400HeaderRetryApplied,
+        oauthRetryApplied: nextState.oauthRetryApplied,
+        skipInjectedOauthBetas: nextState.skipInjectedOauthBetas
       },
       before: {
         payloadLooksToolStreaming: beforeShape,
-        anthropicBeta: beforeBeta
+        anthropicBeta: beforeBeta,
+        skipInjectedOauthBetas: beforeSkipInjectedBetas
       },
       after: {
         payloadLooksToolStreaming: payloadLooksLikeToolStreaming(nextState.payload),
-        anthropicBeta: nextState.anthropicBeta
+        anthropicBeta: nextState.anthropicBeta,
+        skipInjectedOauthBetas: nextState.skipInjectedOauthBetas
       }
     });
   }
@@ -652,6 +668,12 @@ function isOauthUnsupportedAuthError(status: number, errorMessage?: string): boo
   if (status !== 401) return false;
   if (!errorMessage) return false;
   return errorMessage.toLowerCase().includes('oauth authentication is currently not supported');
+}
+
+function isOpaqueInvalidRequestError(status: number, errorType?: string, errorMessage?: string): boolean {
+  if (status !== 400) return false;
+  if ((errorType ?? '').trim().toLowerCase() !== 'invalid_request_error') return false;
+  return (errorMessage ?? '').trim().toLowerCase() === 'error';
 }
 
 function payloadLooksLikeToolStreaming(payload: unknown): boolean {
@@ -699,6 +721,30 @@ function shouldRetryWithOauthSafeCompatPayload(input: {
     .includes('fine-grained-tool-streaming');
 
   return isAuthErrorType && (payloadLooksLikeToolStreaming(payload) || betaIncludesToolStreaming);
+}
+
+function shouldRetryCompatOpaqueInvalidRequestWithInboundBetas(input: {
+  status: number;
+  strictUpstreamPassthrough?: boolean;
+  provider: string;
+  credential: TokenCredential;
+  alreadyRetried: boolean;
+  errorType?: string;
+  errorMessage?: string;
+}): boolean {
+  const {
+    status,
+    strictUpstreamPassthrough,
+    provider,
+    credential,
+    alreadyRetried,
+    errorType,
+    errorMessage
+  } = input;
+  if (!strictUpstreamPassthrough) return false;
+  if (alreadyRetried) return false;
+  if (!isAnthropicOauthToken(credential, provider)) return false;
+  return isOpaqueInvalidRequestError(status, errorType, errorMessage);
 }
 
 function extractUpstreamErrorDetails(data: unknown): { errorType?: string; errorMessage?: string } {
@@ -2415,7 +2461,7 @@ async function executeTokenModeNonStreaming(input: {
         anthropicBeta: compat.anthropicBeta,
         provider,
         credential,
-        skipOauthDefaultBetas: compat.blockedRetryApplied
+        skipInjectedOauthBetas: compat.skipInjectedOauthBetas
       });
       const upstreamBody = JSON.stringify(upstreamPayload);
 
@@ -2913,6 +2959,39 @@ async function executeTokenModeNonStreaming(input: {
           strictUpstreamPassthrough
         });
         const { errorType, errorMessage } = extractUpstreamErrorDetails(data);
+        if (shouldRetryCompatOpaqueInvalidRequestWithInboundBetas({
+          status,
+          strictUpstreamPassthrough,
+          provider,
+          credential,
+          alreadyRetried: compat.opaque400HeaderRetryApplied,
+          errorType,
+          errorMessage
+        })) {
+          logRetryAudit({
+            orgId,
+            provider,
+            model,
+            requestId,
+            openclawRunId: correlation.openclawRunId,
+            openclawSessionId: correlation.openclawSessionId,
+            attemptNo,
+            credentialId: credential.id,
+            credentialLabel: credential.debugLabel,
+            upstreamStatus: status,
+            retryReason: 'opaque_400_header_retry'
+          });
+          compat = applyCompatNormalization({
+            requestId,
+            attemptNo,
+            credentialId: credential.id,
+            provider,
+            credential,
+            state: compat,
+            reason: 'retry_opaque_400_strip_oauth_betas'
+          });
+          continue;
+        }
         if (shouldLogCompatInvalidRequestDebug({
           strictUpstreamPassthrough,
           provider,
@@ -3198,7 +3277,7 @@ async function executeTokenModeStreaming(input: {
         anthropicBeta: compat.anthropicBeta,
         provider,
         credential,
-        skipOauthDefaultBetas: compat.blockedRetryApplied,
+        skipInjectedOauthBetas: compat.skipInjectedOauthBetas,
         streaming: true
       });
       const upstreamPayload = normalizeTokenModeUpstreamPayload({
@@ -3680,6 +3759,39 @@ async function executeTokenModeStreaming(input: {
             strictUpstreamPassthrough
           });
           const { errorType, errorMessage } = extractUpstreamErrorDetails(data);
+          if (shouldRetryCompatOpaqueInvalidRequestWithInboundBetas({
+            status,
+            strictUpstreamPassthrough,
+            provider,
+            credential,
+            alreadyRetried: compat.opaque400HeaderRetryApplied,
+            errorType,
+            errorMessage
+          })) {
+            logRetryAudit({
+              orgId,
+              provider,
+              model,
+              requestId,
+              openclawRunId: correlation.openclawRunId,
+              openclawSessionId: correlation.openclawSessionId,
+              attemptNo,
+              credentialId: credential.id,
+              credentialLabel: credential.debugLabel,
+              upstreamStatus: status,
+              retryReason: 'opaque_400_header_retry'
+            });
+            compat = applyCompatNormalization({
+              requestId,
+              attemptNo,
+              credentialId: credential.id,
+              provider,
+              credential,
+              state: compat,
+              reason: 'retry_opaque_400_strip_oauth_betas'
+            });
+            continue;
+          }
           if (shouldLogCompatInvalidRequestDebug({
             strictUpstreamPassthrough,
             provider,

--- a/api/tests/anthropicCompat.route.test.ts
+++ b/api/tests/anthropicCompat.route.test.ts
@@ -1509,7 +1509,7 @@ describe('anthropic compat route', () => {
     const upstreamSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(JSON.stringify({
         type: 'error',
-        error: { type: 'invalid_request_error', message: 'Error' }
+        error: { type: 'invalid_request_error', message: 'tool_result ids do not line up' }
       }), {
         status: 400,
         headers: { 'content-type': 'application/json' }
@@ -1573,7 +1573,7 @@ describe('anthropic compat route', () => {
       anthropic_beta: 'fine-grained-tool-streaming-2025-05-14',
       upstream_status: 400,
       upstream_error_type: 'invalid_request_error',
-      upstream_error_message: 'Error',
+      upstream_error_message: 'tool_result ids do not line up',
       request_shape: {
         stream: true,
         message_count: 2,
@@ -1686,7 +1686,7 @@ describe('anthropic compat route', () => {
       type: 'error',
       error: {
         type: 'invalid_request_error',
-        message: 'Error'
+        message: 'tool_result ids do not line up'
       }
     });
 
@@ -2642,6 +2642,73 @@ describe('anthropic compat route', () => {
     expect(retryAudit?.org_id).toBe('818d0cc7-7ed2-469f-b690-a977e72a921d');
     expect(retryAudit?.model).toBe('claude-opus-4-6');
     expect(String(retryAudit?.openclaw_run_id ?? '')).toMatch(/^run_req_/);
+
+    retryAuditSpy.mockRestore();
+    upstreamSpy.mockRestore();
+  });
+
+  it('retries opaque 400 invalid_request_error once with only inbound anthropic betas on /v1/messages', async () => {
+    const retryAuditSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    const upstreamSpy = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        type: 'error',
+        error: { type: 'invalid_request_error', message: 'Error' }
+      }), {
+        status: 400,
+        headers: { 'content-type': 'application/json' }
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        id: 'msg_opaque_400_retry_ok',
+        usage: { input_tokens: 11, output_tokens: 13 }
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' }
+      }));
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/messages',
+      headers: {
+        authorization: 'Bearer in_test_token',
+        'content-type': 'application/json',
+        'anthropic-beta': 'fine-grained-tool-streaming-2025-05-14'
+      },
+      body: {
+        model: 'claude-opus-4-6',
+        stream: true,
+        max_tokens: 2048,
+        messages: [{ role: 'user', content: 'hold the request body constant' }],
+        thinking: { type: 'enabled', budget_tokens: 1024 }
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(handlers[0], req, res);
+    await invoke(handlers[1], req, res);
+    await invoke(handlers[2], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toContain('text/event-stream');
+    expect(String(res.body)).toContain('event: message_start');
+    expect(String(res.body)).toContain('event: message_stop');
+    expect(upstreamSpy).toHaveBeenCalledTimes(2);
+
+    const firstHeaders = (upstreamSpy.mock.calls[0]?.[1] as RequestInit)?.headers as Record<string, string>;
+    const secondHeaders = (upstreamSpy.mock.calls[1]?.[1] as RequestInit)?.headers as Record<string, string>;
+    const firstBody = JSON.parse(String((upstreamSpy.mock.calls[0]?.[1] as RequestInit)?.body ?? '{}'));
+    const secondBody = JSON.parse(String((upstreamSpy.mock.calls[1]?.[1] as RequestInit)?.body ?? '{}'));
+
+    expect(firstHeaders['anthropic-beta']).toContain('fine-grained-tool-streaming-2025-05-14');
+    expect(firstHeaders['anthropic-beta']).toContain('oauth-2025-04-20');
+    expect(firstHeaders['anthropic-beta']).toContain('claude-code-20250219');
+    expect(secondHeaders['anthropic-beta']).toBe('fine-grained-tool-streaming-2025-05-14');
+    expect(secondBody).toEqual(firstBody);
+
+    const retryCalls = retryAuditSpy.mock.calls.filter((c) => c[0] === '[retry-audit] attempt');
+    expect(retryCalls.length).toBeGreaterThan(0);
+    const retryAudit = retryCalls[0]?.[1] as any;
+    expect(retryAudit?.retry_reason).toBe('opaque_400_header_retry');
+    expect(retryAudit?.org_id).toBe('818d0cc7-7ed2-469f-b690-a977e72a921d');
 
     retryAuditSpy.mockRestore();
     upstreamSpy.mockRestore();

--- a/api/tests/proxy.tokenMode.route.test.ts
+++ b/api/tests/proxy.tokenMode.route.test.ts
@@ -1228,6 +1228,96 @@ describe('proxy token-mode route behavior', () => {
     upstreamSpy.mockRestore();
   });
 
+  it('retries opaque 400 invalid_request_error with only inbound anthropic betas when compat mode is enabled', async () => {
+    process.env.TOKEN_MODE_ENABLED_ORGS = '818d0cc7-7ed2-469f-b690-a977e72a921d';
+    const retryAuditSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'listActiveForRouting').mockResolvedValue([{
+      id: 'abab7777-7777-4777-8777-777777777777',
+      orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      provider: 'anthropic',
+      authScheme: 'bearer',
+      accessToken: 'sk-ant-oat01-compat-test-opaque-400',
+      refreshToken: null,
+      expiresAt: new Date('2026-03-02T00:00:00Z'),
+      status: 'active',
+      rotationVersion: 1,
+      createdAt: new Date('2026-03-01T00:00:00Z'),
+      updatedAt: new Date('2026-03-01T00:00:00Z'),
+      revokedAt: null,
+      monthlyContributionLimitUnits: null,
+      monthlyContributionUsedUnits: 0,
+      monthlyWindowStartAt: new Date('2026-03-01T00:00:00Z')
+    } as any]);
+
+    const upstreamSpy = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        type: 'error',
+        error: { type: 'invalid_request_error', message: 'Error' }
+      }), {
+        status: 400,
+        headers: { 'content-type': 'application/json' }
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        id: 'msg_compat_opaque_400_ok',
+        usage: { input_tokens: 5, output_tokens: 8 },
+        content: [{ type: 'text', text: 'ok' }]
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' }
+      }));
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/proxy/v1/messages',
+      headers: {
+        authorization: 'Bearer in_test_token',
+        'content-type': 'application/json',
+        'idempotency-key': 'abcdefghijklmnopqrstuvwxyz123456',
+        'anthropic-version': '2023-06-01',
+        'anthropic-beta': 'fine-grained-tool-streaming-2025-05-14'
+      },
+      body: {
+        provider: 'anthropic',
+        model: 'claude-3-5-sonnet-latest',
+        streaming: true,
+        payload: {
+          model: 'claude-3-5-sonnet-latest',
+          stream: true,
+          max_tokens: 2048,
+          messages: [{ role: 'user', content: 'hold the request body constant' }],
+          thinking: { type: 'enabled', budget_tokens: 1024 }
+        }
+      }
+    });
+    (req as any).inniesCompatMode = true;
+    const res = createMockRes();
+
+    await invoke(handlers[0], req, res);
+    await invoke(handlers[1], req, res);
+
+    expect(res.statusCode, JSON.stringify(res.body)).toBe(200);
+    expect((res.body as any).id).toBe('msg_compat_opaque_400_ok');
+    expect(upstreamSpy).toHaveBeenCalledTimes(2);
+
+    const firstHeaders = (upstreamSpy.mock.calls[0]?.[1] as RequestInit)?.headers as Record<string, string>;
+    const secondHeaders = (upstreamSpy.mock.calls[1]?.[1] as RequestInit)?.headers as Record<string, string>;
+    const firstBody = JSON.parse(String((upstreamSpy.mock.calls[0]?.[1] as RequestInit)?.body ?? '{}'));
+    const secondBody = JSON.parse(String((upstreamSpy.mock.calls[1]?.[1] as RequestInit)?.body ?? '{}'));
+
+    expect(firstHeaders['anthropic-beta']).toContain('fine-grained-tool-streaming-2025-05-14');
+    expect(firstHeaders['anthropic-beta']).toContain('oauth-2025-04-20');
+    expect(firstHeaders['anthropic-beta']).toContain('claude-code-20250219');
+    expect(secondHeaders['anthropic-beta']).toBe('fine-grained-tool-streaming-2025-05-14');
+    expect(secondBody).toEqual(firstBody);
+
+    const retryCalls = retryAuditSpy.mock.calls.filter((call) => call[0] === '[retry-audit] attempt');
+    expect(retryCalls.length).toBeGreaterThan(0);
+    expect((retryCalls[0]?.[1] as any)?.retry_reason).toBe('opaque_400_header_retry');
+
+    retryAuditSpy.mockRestore();
+    upstreamSpy.mockRestore();
+  });
+
   it('retries once with oauth-safe payload when compat mode gets authentication_error 401 on tool-stream payload', async () => {
     process.env.TOKEN_MODE_ENABLED_ORGS = '818d0cc7-7ed2-469f-b690-a977e72a921d';
     vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'listActiveForRouting').mockResolvedValue([{


### PR DESCRIPTION
## Summary
- retry opaque Anthropic OAuth compat `400 invalid_request_error` responses once when the upstream message is exactly `Error`
- preserve the request body while stripping only the auto-injected OAuth betas on the retry, leaving inbound `anthropic-beta` values intact
- cover the behavior in both the public Anthropic compat route tests and the shared token-mode compat path tests

## Test Plan
- `cd api && npx vitest run anthropicCompat.route.test.ts proxy.tokenMode.route.test.ts`
- `cd api && npm run build`

Closes #80