### PR TITLE
chore: add issue 80 compat replay helper

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -24,6 +24,7 @@ innies-buyer-key-create
 innies-buyer-preference-set
 innies-buyer-preference-get
 innies-buyer-preference-check
+innies-compat-replay
 innies-slo-check
 ```
 
@@ -39,6 +40,7 @@ What they do:
 - `innies-buyer-preference-set`: set a buyer key preference to `Claude Code`, `Codex`, or `null`
 - `innies-buyer-preference-get`: read the current buyer key preference
 - `innies-buyer-preference-check`: run the provider-preference canary after prompting for the expected provider (`Claude Code` or `Codex`)
+- `innies-compat-replay`: replay a preserved Anthropic compat request body through `/v1/messages`, preserve the caller beta lane, and print Innies plus upstream request ids for incident evidence
 - `innies-slo-check`: query analytics endpoints and report Phase 1 SLO pass/fail (TTFB p95, timeout rate, success rate, fallback rate); optional arg sets the window (default `24h`); exits 0 if all SLOs pass, 1 if any fail
 
 Behavior:
@@ -79,6 +81,7 @@ Behavior:
 - non-pinned buyer traffic always gets automatic cross-provider fallback to the other provider; flipping preference flips fallback order too
 - `innies-buyer-preference-set` prints the effective preferred provider plus the automatic fallback provider before sending the update
 - `innies-buyer-preference-check` now expects and validates the two-provider plan in DB evidence mode
+- `innies-compat-replay` accepts a payload file path arg (or `INNIES_REPLAY_PAYLOAD_PATH`), uses `INNIES_BASE_URL`, `INNIES_API_BASE_URL`, or `INNIES_API_URL`, accepts `INNIES_BUYER_API_KEY` or `INNIES_TOKEN`, preserves `anthropic-beta` via `INNIES_ANTHROPIC_BETA` (default `fine-grained-tool-streaming-2025-05-14`), and writes `meta.txt`, `headers.txt`, and `body.txt` into `INNIES_REPLAY_OUT_DIR`
 
 ## Env
 

--- a/scripts/innies-compat-replay.sh
+++ b/scripts/innies-compat-replay.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_PATH" ]]; do
+  SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+  SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"
+  [[ "$SCRIPT_PATH" != /* ]] && SCRIPT_PATH="${SCRIPT_DIR}/${SCRIPT_PATH}"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+source "${SCRIPT_DIR}/_common.sh"
+
+resolve_api_url() {
+  if [[ -n "${INNIES_BASE_URL:-}" ]]; then
+    printf '%s' "${INNIES_BASE_URL%/}"
+    return
+  fi
+  if [[ -n "${INNIES_API_BASE_URL:-}" ]]; then
+    printf '%s' "${INNIES_API_BASE_URL%/}"
+    return
+  fi
+  if [[ -n "${INNIES_API_URL:-}" ]]; then
+    printf '%s' "${INNIES_API_URL%/}"
+    return
+  fi
+  printf '%s' "${BASE_URL%/}"
+}
+
+extract_header() {
+  local name="$1"
+  local file="$2"
+  awk -F': ' -v header_name="$name" '
+    BEGIN { IGNORECASE = 1 }
+    tolower($1) == tolower(header_name) {
+      gsub("\r", "", $2)
+      print $2
+    }
+  ' "$file" | tail -1
+}
+
+extract_upstream_request_id() {
+  local file="$1"
+  local value
+  value="$(sed -n 's/.*"request_id":"\([^"]*\)".*/\1/p' "$file" | head -n 1)"
+  printf '%s' "$value"
+}
+
+write_meta() {
+  local file="$1"
+  shift
+  printf '%s\n' "$@" >"$file"
+}
+
+PAYLOAD_PATH="${1:-${INNIES_REPLAY_PAYLOAD_PATH:-}}"
+require_nonempty 'payload path' "$PAYLOAD_PATH"
+
+if [[ ! -f "$PAYLOAD_PATH" ]]; then
+  echo "error: payload file not found: $PAYLOAD_PATH" >&2
+  exit 1
+fi
+
+API_URL="$(resolve_api_url)"
+BUYER_TOKEN="${INNIES_BUYER_API_KEY:-${INNIES_TOKEN:-${BUYER_TOKEN:-}}}"
+
+if [[ -z "$BUYER_TOKEN" ]]; then
+  if ! BUYER_TOKEN="$(prompt_secret 'buyer API key (press Enter to cancel)')"; then
+    exit 1
+  fi
+fi
+require_nonempty 'buyer API key' "$BUYER_TOKEN"
+
+ANTHROPIC_VERSION="${INNIES_ANTHROPIC_VERSION:-2023-06-01}"
+ANTHROPIC_BETA="${INNIES_ANTHROPIC_BETA:-fine-grained-tool-streaming-2025-05-14}"
+REQUEST_ID="${INNIES_REQUEST_ID:-req_issue80_replay_$(date -u +%Y%m%dT%H%M%SZ)}"
+OUT_DIR="${INNIES_REPLAY_OUT_DIR:-${TMPDIR:-/tmp}/innies-compat-replay-$REQUEST_ID}"
+mkdir -p "$OUT_DIR"
+
+HEADERS_FILE="$OUT_DIR/headers.txt"
+BODY_FILE="$OUT_DIR/body.txt"
+META_FILE="$OUT_DIR/meta.txt"
+TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+PAYLOAD_BYTES="$(wc -c <"$PAYLOAD_PATH" | tr -d ' ')"
+
+STATUS="$(curl -sS -D "$HEADERS_FILE" -o "$BODY_FILE" -w '%{http_code}' \
+  -X POST "${API_URL}/v1/messages" \
+  -H "Authorization: Bearer $BUYER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: text/event-stream" \
+  -H "anthropic-version: $ANTHROPIC_VERSION" \
+  -H "anthropic-beta: $ANTHROPIC_BETA" \
+  -H "x-request-id: $REQUEST_ID" \
+  --data-binary @"$PAYLOAD_PATH")"
+
+TOKEN_CREDENTIAL_ID="$(extract_header 'x-innies-token-credential-id' "$HEADERS_FILE")"
+ATTEMPT_NO="$(extract_header 'x-innies-attempt-no' "$HEADERS_FILE")"
+RESPONSE_REQUEST_ID="$(extract_header 'x-request-id' "$HEADERS_FILE")"
+UPSTREAM_REQUEST_ID="$(extract_header 'request-id' "$HEADERS_FILE")"
+if [[ -z "$UPSTREAM_REQUEST_ID" ]]; then
+  UPSTREAM_REQUEST_ID="$(extract_upstream_request_id "$BODY_FILE")"
+fi
+
+OUTCOME='completed'
+EXIT_CODE=0
+if [[ "$STATUS" == "400" ]] && grep -q '"type":"invalid_request_error"' "$BODY_FILE"; then
+  OUTCOME='reproduced_invalid_request_error'
+  EXIT_CODE=1
+elif [[ "$STATUS" =~ ^2 ]]; then
+  OUTCOME='request_succeeded'
+else
+  OUTCOME='unexpected_http_status'
+  EXIT_CODE=1
+fi
+
+META_LINES=(
+  "timestamp=$TIMESTAMP"
+  "endpoint=${API_URL}/v1/messages"
+  "payload_path=$PAYLOAD_PATH"
+  "payload_bytes=$PAYLOAD_BYTES"
+  "request_id=$REQUEST_ID"
+  "response_request_id=${RESPONSE_REQUEST_ID:-}"
+  "status=$STATUS"
+  "token_credential_id=${TOKEN_CREDENTIAL_ID:-}"
+  "attempt_no=${ATTEMPT_NO:-}"
+  "upstream_request_id=${UPSTREAM_REQUEST_ID:-}"
+  "outcome=$OUTCOME"
+  "out_dir=$OUT_DIR"
+  "headers_file=$HEADERS_FILE"
+  "body_file=$BODY_FILE"
+)
+
+write_meta "$META_FILE" "${META_LINES[@]}"
+printf '%s\n' "${META_LINES[@]}"
+echo "meta_file=$META_FILE"
+
+exit "$EXIT_CODE"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,6 +17,7 @@ ln -sf "${ROOT_DIR}/scripts/innies-buyer-key-create.sh" "${BIN_DIR}/innies-buyer
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-set.sh" "${BIN_DIR}/innies-buyer-preference-set"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-get.sh" "${BIN_DIR}/innies-buyer-preference-get"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-check.sh" "${BIN_DIR}/innies-buyer-preference-check"
+ln -sf "${ROOT_DIR}/scripts/innies-compat-replay.sh" "${BIN_DIR}/innies-compat-replay"
 ln -sf "${ROOT_DIR}/scripts/innies-slo-check.sh" "${BIN_DIR}/innies-slo-check"
 
 rm -f \
@@ -34,7 +35,8 @@ rm -f \
   "${BIN_DIR}/innies-create-buyer-key" \
   "${BIN_DIR}/innies-set-preference" \
   "${BIN_DIR}/innies-get-preference" \
-  "${BIN_DIR}/innies-check-preference"
+  "${BIN_DIR}/innies-check-preference" \
+  "${BIN_DIR}/innies-replay-compat"
 
 echo 'Installed:'
 echo "  ${BIN_DIR}/innies-token-add -> ${ROOT_DIR}/scripts/innies-token-add.sh"
@@ -48,6 +50,7 @@ echo "  ${BIN_DIR}/innies-buyer-key-create -> ${ROOT_DIR}/scripts/innies-buyer-k
 echo "  ${BIN_DIR}/innies-buyer-preference-set -> ${ROOT_DIR}/scripts/innies-buyer-preference-set.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-get -> ${ROOT_DIR}/scripts/innies-buyer-preference-get.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-check -> ${ROOT_DIR}/scripts/innies-buyer-preference-check.sh"
+echo "  ${BIN_DIR}/innies-compat-replay -> ${ROOT_DIR}/scripts/innies-compat-replay.sh"
 echo "  ${BIN_DIR}/innies-slo-check -> ${ROOT_DIR}/scripts/innies-slo-check.sh"
 echo
 echo 'If command not found, add ~/.local/bin to PATH:'

--- a/scripts/tests/innies-compat-replay.test.sh
+++ b/scripts/tests/innies-compat-replay.test.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="$ROOT_DIR/scripts/innies-compat-replay.sh"
+TMP_DIR="$(mktemp -d)"
+SERVER_LOG="$TMP_DIR/server.log"
+REQUEST_HEADERS="$TMP_DIR/request-headers.json"
+REQUEST_BODY="$TMP_DIR/request-body.json"
+PAYLOAD_PATH="$TMP_DIR/payload.json"
+OUTPUT_PATH="$TMP_DIR/output.txt"
+
+cleanup() {
+  if [[ -n "${SERVER_PID:-}" ]]; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+cat >"$PAYLOAD_PATH" <<'JSON'
+{"model":"claude-opus-4-6","stream":true,"max_tokens":16,"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}
+JSON
+
+cat >"$TMP_DIR/server.mjs" <<'NODE'
+import { createServer } from 'node:http';
+import { writeFileSync } from 'node:fs';
+
+const port = Number(process.env.PORT);
+const headersPath = process.env.REQUEST_HEADERS_PATH;
+const bodyPath = process.env.REQUEST_BODY_PATH;
+
+const server = createServer((req, res) => {
+  const chunks = [];
+  req.on('data', (chunk) => chunks.push(chunk));
+  req.on('end', () => {
+    writeFileSync(headersPath, JSON.stringify({
+      method: req.method,
+      url: req.url,
+      headers: req.headers
+    }, null, 2));
+    writeFileSync(bodyPath, Buffer.concat(chunks).toString('utf8'));
+    res.statusCode = 400;
+    res.setHeader('content-type', 'application/json');
+    res.setHeader('x-request-id', 'req_test_replay');
+    res.setHeader('x-innies-token-credential-id', 'cred_test_replay');
+    res.setHeader('x-innies-attempt-no', '1');
+    res.end(JSON.stringify({
+      type: 'error',
+      error: { type: 'invalid_request_error', message: 'Error' },
+      request_id: 'req_upstream_test'
+    }));
+  });
+});
+
+server.listen(port, '127.0.0.1', () => {
+  process.stdout.write(`ready:${port}\n`);
+});
+NODE
+
+PORT="$(node -e "const net=require('node:net');const s=net.createServer();s.listen(0,'127.0.0.1',()=>{const {port}=s.address();console.log(port);s.close();});")"
+REQUEST_HEADERS_PATH="$REQUEST_HEADERS" REQUEST_BODY_PATH="$REQUEST_BODY" PORT="$PORT" node "$TMP_DIR/server.mjs" >"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+
+for _ in $(seq 1 50); do
+  if grep -q '^ready:' "$SERVER_LOG" 2>/dev/null; then
+    break
+  fi
+  sleep 0.1
+done
+
+if ! grep -q '^ready:' "$SERVER_LOG" 2>/dev/null; then
+  echo "server did not start"
+  cat "$SERVER_LOG"
+  exit 1
+fi
+
+set +e
+INNIES_BASE_URL="http://127.0.0.1:$PORT" \
+INNIES_BUYER_API_KEY="buyer_test_token" \
+INNIES_REQUEST_ID="req_test_replay" \
+"$SCRIPT_PATH" "$PAYLOAD_PATH" >"$OUTPUT_PATH" 2>&1
+SCRIPT_EXIT=$?
+set -e
+
+if [[ "$SCRIPT_EXIT" -ne 1 ]]; then
+  echo "expected replay helper to exit 1 on 400, got $SCRIPT_EXIT"
+  cat "$OUTPUT_PATH"
+  exit 1
+fi
+
+grep -q 'status=400' "$OUTPUT_PATH"
+grep -q 'request_id=req_test_replay' "$OUTPUT_PATH"
+grep -q 'token_credential_id=cred_test_replay' "$OUTPUT_PATH"
+grep -q 'attempt_no=1' "$OUTPUT_PATH"
+grep -q 'upstream_request_id=req_upstream_test' "$OUTPUT_PATH"
+grep -q 'outcome=reproduced_invalid_request_error' "$OUTPUT_PATH"
+
+grep -q '"url": "/v1/messages"' "$REQUEST_HEADERS"
+grep -q '"authorization": "Bearer buyer_test_token"' "$REQUEST_HEADERS"
+grep -q '"anthropic-beta": "fine-grained-tool-streaming-2025-05-14"' "$REQUEST_HEADERS"
+grep -q '"anthropic-version": "2023-06-01"' "$REQUEST_HEADERS"
+grep -q '"x-request-id": "req_test_replay"' "$REQUEST_HEADERS"
+
+cmp -s "$PAYLOAD_PATH" "$REQUEST_BODY"


### PR DESCRIPTION
## Summary
- add `scripts/innies-compat-replay.sh` so issue #80 can replay preserved Anthropic compat payloads through `/v1/messages` and capture request ids plus artifacts in `meta.txt`, `headers.txt`, and `body.txt`
- wire the helper into `scripts/install.sh` and `scripts/README.md`, and cover it with a focused shell regression test
- re-run the preserved-body replay on post-merge `main`; the opaque `400 invalid_request_error` still reproduces on attempt `1`, so the extra-beta hypothesis is falsified rather than confirmed

## Replay Evidence
- Replay time: `2026-03-17T15:47:01Z`
- Replay request id: `req_issue80_replay_20260317T154701Z`
- Replay upstream request id: `req_011CZ8uwT2ZWfSQVhPmeCTGJ`
- Replay token credential id: `98233c10-db4e-4709-aa7f-3b945d6ee81d`
- Replay result: `400 invalid_request_error` on attempt `1`
- Artifact bundle: `/private/tmp/issue80-replay-req_issue80_replay_20260317T154701Z`

## Test Plan
- `bash scripts/tests/innies-compat-replay.test.sh`
- `INNIES_REQUEST_ID=req_issue80_replay_20260317T154701Z INNIES_REPLAY_OUT_DIR=/private/tmp/issue80-replay-req_issue80_replay_20260317T154701Z scripts/innies-compat-replay.sh /private/tmp/innies-issue-80-preserved-body.json`

Refs #80
