### PR TITLE
fix: enforce anthropic lane on compat compare helper

### DIFF
--- a/api/src/routes/proxy.ts
+++ b/api/src/routes/proxy.ts
@@ -78,6 +78,17 @@ type ProxyRouteResult = {
   alreadyRecorded: boolean;
   routeDecision?: Record<string, unknown>;
   ttfbMs?: number | null;
+  debugUpstreamLane?: UpstreamLaneDebug;
+};
+
+type UpstreamLaneDebug = {
+  targetUrl: string;
+  proxiedPath: string;
+  provider: string;
+  stream: boolean;
+  credentialId: string;
+  tokenKind: 'anthropic_oauth' | 'openai_oauth' | 'bearer' | 'api_key';
+  headers: Record<string, string>;
 };
 
 type MeteringSource = 'payload_usage' | 'stream_usage' | 'stream_estimate';
@@ -171,6 +182,14 @@ function readHeader(req: any, ...names: string[]): string | undefined {
     if (trimmed.length > 0) return trimmed;
   }
   return undefined;
+}
+
+function shouldEnableUpstreamLaneDebug(req: any): boolean {
+  if (process.env.INNIES_ENABLE_UPSTREAM_DEBUG_HEADERS !== 'true') return false;
+  const raw = readHeader(req, 'x-innies-debug-upstream-lane');
+  if (!raw) return false;
+  const normalized = raw.trim().toLowerCase();
+  return normalized === '1' || normalized === 'true' || normalized === 'yes';
 }
 
 function resolveOpenClawCorrelation(req: any, requestId: string): OpenClawCorrelation {
@@ -814,6 +833,73 @@ function redactTraceHeaders(headers: Record<string, string>): Record<string, str
   return Object.fromEntries(
     Object.entries(headers).map(([name, value]) => [name, redactTraceHeaderValue(name, value)])
   );
+}
+
+function resolveUpstreamTokenKind(credential: TokenCredential, provider: string): UpstreamLaneDebug['tokenKind'] {
+  if (isAnthropicOauthToken(credential, provider)) return 'anthropic_oauth';
+  if (isOpenAiOauthToken(credential, provider)) return 'openai_oauth';
+  return credential.authScheme === 'bearer' ? 'bearer' : 'api_key';
+}
+
+function captureUpstreamLaneDebug(input: {
+  targetUrl: string;
+  proxiedPath: string;
+  provider: string;
+  stream: boolean;
+  credential: TokenCredential;
+  headers: Record<string, string>;
+}): UpstreamLaneDebug {
+  return {
+    targetUrl: input.targetUrl,
+    proxiedPath: input.proxiedPath,
+    provider: input.provider,
+    stream: input.stream,
+    credentialId: input.credential.id,
+    tokenKind: resolveUpstreamTokenKind(input.credential, input.provider),
+    headers: redactTraceHeaders(input.headers)
+  };
+}
+
+function withDebugUpstreamLane(result: ProxyRouteResult, debugUpstreamLane?: UpstreamLaneDebug | null): ProxyRouteResult {
+  if (!debugUpstreamLane) return result;
+  return {
+    ...result,
+    debugUpstreamLane
+  };
+}
+
+function applyUpstreamLaneDebugHeaders(res: Response, debugUpstreamLane?: UpstreamLaneDebug | null): void {
+  if (!debugUpstreamLane) return;
+  res.setHeader('x-innies-debug-upstream-target-url', debugUpstreamLane.targetUrl);
+  res.setHeader('x-innies-debug-upstream-proxied-path', debugUpstreamLane.proxiedPath);
+  res.setHeader('x-innies-debug-upstream-provider', debugUpstreamLane.provider);
+  res.setHeader('x-innies-debug-upstream-stream', String(debugUpstreamLane.stream));
+  res.setHeader('x-innies-debug-upstream-credential-id', debugUpstreamLane.credentialId);
+  res.setHeader('x-innies-debug-upstream-token-kind', debugUpstreamLane.tokenKind);
+  res.setHeader(
+    'x-innies-debug-upstream-header-names',
+    Object.keys(debugUpstreamLane.headers).sort().join(',')
+  );
+
+  const headers = debugUpstreamLane.headers;
+  if (headers.authorization) {
+    res.setHeader('x-innies-debug-upstream-authorization', headers.authorization);
+  }
+  if (headers.accept) {
+    res.setHeader('x-innies-debug-upstream-accept', headers.accept);
+  }
+  if (headers['anthropic-version']) {
+    res.setHeader('x-innies-debug-upstream-anthropic-version', headers['anthropic-version']);
+  }
+  if (headers['anthropic-beta']) {
+    res.setHeader('x-innies-debug-upstream-anthropic-beta', headers['anthropic-beta']);
+  }
+  if (headers['user-agent']) {
+    res.setHeader('x-innies-debug-upstream-user-agent', headers['user-agent']);
+  }
+  if (headers['x-request-id']) {
+    res.setHeader('x-innies-debug-upstream-request-id', headers['x-request-id']);
+  }
 }
 
 function responseHeadersToObject(response: globalThis.Response): Record<string, string> {
@@ -2381,6 +2467,7 @@ async function executeTokenModeNonStreaming(input: {
   providerPreference?: ProviderPreferenceMeta;
   compatTranslation?: CompatTranslationMeta;
   allowCompatTerminalErrorResponse?: boolean;
+  upstreamLaneDebugEnabled?: boolean;
 }): Promise<ProxyRouteResult> {
   const {
     requestId,
@@ -2400,7 +2487,8 @@ async function executeTokenModeNonStreaming(input: {
     strictUpstreamPassthrough,
     providerPreference,
     compatTranslation,
-    allowCompatTerminalErrorResponse
+    allowCompatTerminalErrorResponse,
+    upstreamLaneDebugEnabled
   } = input;
   const {
     credentials,
@@ -2434,6 +2522,7 @@ async function executeTokenModeNonStreaming(input: {
   let terminalStrictPassthroughData: unknown = null;
   let terminalStrictPassthroughCredentialId: string | null = null;
   let terminalStrictPassthroughAttemptNo = 0;
+  let firstUpstreamLane: UpstreamLaneDebug | null = null;
   for (const initialCredential of credentials) {
     attemptNo += 1;
     let credential = initialCredential;
@@ -2472,6 +2561,17 @@ async function executeTokenModeNonStreaming(input: {
         forwardedUserAgent
       });
       const upstreamBody = JSON.stringify(upstreamPayload);
+
+      if (!firstUpstreamLane && upstreamLaneDebugEnabled) {
+        firstUpstreamLane = captureUpstreamLaneDebug({
+          targetUrl: String(targetUrl),
+          proxiedPath,
+          provider,
+          stream: false,
+          credential,
+          headers: upstreamHeaders
+        });
+      }
 
       logCompatUpstreamRequestTrace({
         requestId,
@@ -2631,7 +2731,7 @@ async function executeTokenModeNonStreaming(input: {
             errorMessage
           });
 
-          return {
+          return withDebugUpstreamLane({
             requestId,
             keyId: credential.id,
             attemptNo,
@@ -2641,7 +2741,7 @@ async function executeTokenModeNonStreaming(input: {
             data,
             routeKind: 'token_credential',
             alreadyRecorded: true
-          };
+          }, firstUpstreamLane);
         }
       }
 
@@ -3075,7 +3175,7 @@ async function executeTokenModeNonStreaming(input: {
         }).catch(() => {});
       }
 
-      return {
+      return withDebugUpstreamLane({
         requestId,
         keyId: credential.id,
         attemptNo,
@@ -3085,7 +3185,7 @@ async function executeTokenModeNonStreaming(input: {
         data: downstreamData,
         routeKind: 'token_credential',
         alreadyRecorded: true
-      };
+      }, firstUpstreamLane);
     }
   }
 
@@ -3099,7 +3199,7 @@ async function executeTokenModeNonStreaming(input: {
     : null;
 
   if (allowCompatTerminalErrorResponse && compatTerminalResult) {
-    return compatTerminalResult;
+    return withDebugUpstreamLane(compatTerminalResult, firstUpstreamLane);
   }
 
   const strictPassthroughResult = terminalStrictPassthroughStatus != null
@@ -3117,7 +3217,7 @@ async function executeTokenModeNonStreaming(input: {
     : null;
 
   if (allowCompatTerminalErrorResponse && strictPassthroughResult) {
-    return strictPassthroughResult;
+    return withDebugUpstreamLane(strictPassthroughResult, firstUpstreamLane);
   }
 
   if (sawAuthFailure) {
@@ -3176,6 +3276,7 @@ async function executeTokenModeStreaming(input: {
   compatTranslation?: CompatTranslationMeta;
   compatMode?: boolean;
   allowCompatTerminalErrorResponse?: boolean;
+  upstreamLaneDebugEnabled?: boolean;
 }): Promise<ProxyRouteResult | null> {
   const {
     requestId,
@@ -3198,7 +3299,8 @@ async function executeTokenModeStreaming(input: {
     providerPreference,
     compatTranslation,
     compatMode: compatModeFlag,
-    allowCompatTerminalErrorResponse
+    allowCompatTerminalErrorResponse,
+    upstreamLaneDebugEnabled
   } = input;
 
   const {
@@ -3233,6 +3335,7 @@ async function executeTokenModeStreaming(input: {
   let terminalStrictPassthroughData: unknown = null;
   let terminalStrictPassthroughCredentialId: string | null = null;
   let terminalStrictPassthroughAttemptNo = 0;
+  let firstUpstreamLane: UpstreamLaneDebug | null = null;
 
   for (const initialCredential of credentials) {
     attemptNo += 1;
@@ -3274,6 +3377,17 @@ async function executeTokenModeStreaming(input: {
       });
       const upstreamBody = JSON.stringify(upstreamPayload);
       const dispatchStartedAt = Date.now();
+
+      if (!firstUpstreamLane && upstreamLaneDebugEnabled) {
+        firstUpstreamLane = captureUpstreamLaneDebug({
+          targetUrl: String(targetUrl),
+          proxiedPath,
+          provider,
+          stream: true,
+          credential,
+          headers: upstreamHeaders
+        });
+      }
 
       logCompatUpstreamRequestTrace({
         requestId,
@@ -3432,7 +3546,7 @@ async function executeTokenModeStreaming(input: {
             errorMessage
           });
 
-          return {
+          return withDebugUpstreamLane({
             requestId,
             keyId: credential.id,
             attemptNo,
@@ -3442,7 +3556,7 @@ async function executeTokenModeStreaming(input: {
             data,
             routeKind: 'token_credential',
             alreadyRecorded: true
-          };
+          }, firstUpstreamLane);
         }
       }
 
@@ -3828,6 +3942,7 @@ async function executeTokenModeStreaming(input: {
           res.setHeader('x-request-id', requestId);
           res.setHeader('x-innies-token-credential-id', credential.id);
           res.setHeader('x-innies-attempt-no', String(attemptNo));
+          applyUpstreamLaneDebugHeaders(res, firstUpstreamLane);
           res.setHeader('content-type', 'text/event-stream; charset=utf-8');
           res.setHeader('cache-control', 'no-cache, no-transform');
           res.setHeader('connection', 'keep-alive');
@@ -3957,7 +4072,7 @@ async function executeTokenModeStreaming(input: {
                 responsePreview: extractResponsePreview(rawText)
               }).catch(() => {});
             }
-            return {
+            return withDebugUpstreamLane({
               requestId,
               keyId: credential.id,
               attemptNo,
@@ -3967,7 +4082,7 @@ async function executeTokenModeStreaming(input: {
               data: null,
               routeKind: 'token_credential',
               alreadyRecorded: true
-            };
+            }, firstUpstreamLane);
           }
 
           const syntheticMessage = (data && typeof data === 'object' ? data : {}) as Record<string, unknown>;
@@ -4088,7 +4203,7 @@ async function executeTokenModeStreaming(input: {
               responsePreview: extractResponsePreview(data)
             }).catch(() => {});
           }
-          return {
+          return withDebugUpstreamLane({
             requestId,
             keyId: credential.id,
             attemptNo,
@@ -4098,10 +4213,10 @@ async function executeTokenModeStreaming(input: {
             data: null,
             routeKind: 'token_credential',
             alreadyRecorded: true
-          };
+          }, firstUpstreamLane);
         }
 
-        return {
+        return withDebugUpstreamLane({
           requestId,
           keyId: credential.id,
           attemptNo,
@@ -4111,12 +4226,13 @@ async function executeTokenModeStreaming(input: {
           data: downstreamData,
           routeKind: 'token_credential',
           alreadyRecorded: true
-        };
+        }, firstUpstreamLane);
       }
 
       res.setHeader('x-request-id', requestId);
       res.setHeader('x-innies-token-credential-id', credential.id);
       res.setHeader('x-innies-attempt-no', String(attemptNo));
+      applyUpstreamLaneDebugHeaders(res, firstUpstreamLane);
       res.setHeader('content-type', compatTranslation ? 'text/event-stream; charset=utf-8' : contentType);
       // Force pass-through semantics for SSE across reverse proxies.
       res.setHeader('cache-control', 'no-cache, no-transform');
@@ -4437,7 +4553,7 @@ async function executeTokenModeStreaming(input: {
     : null;
 
   if (allowCompatTerminalErrorResponse && compatTerminalResult) {
-    return compatTerminalResult;
+    return withDebugUpstreamLane(compatTerminalResult, firstUpstreamLane);
   }
 
   const strictPassthroughResult = terminalStrictPassthroughStatus != null
@@ -4455,7 +4571,7 @@ async function executeTokenModeStreaming(input: {
     : null;
 
   if (allowCompatTerminalErrorResponse && strictPassthroughResult) {
-    return strictPassthroughResult;
+    return withDebugUpstreamLane(strictPassthroughResult, firstUpstreamLane);
   }
 
   if (sawAuthFailure) {
@@ -4562,6 +4678,7 @@ export async function proxyPostHandler(req: any, res: Response, next: any): Prom
     const anthropicBeta = req.header('anthropic-beta') ?? undefined;
     const forwardedClientApp = readHeader(req, 'x-app');
     const forwardedUserAgent = readHeader(req, 'user-agent');
+    const upstreamLaneDebugEnabled = shouldEnableUpstreamLaneDebug(req);
     let result: ProxyRouteResult | null = null;
     const requestPinSelectionReason = (readProviderPinSignal(req) || isClaudeCliPinnedRequest(req, proxiedPath))
       ? 'cli_provider_pinned'
@@ -4669,7 +4786,8 @@ export async function proxyPostHandler(req: any, res: Response, next: any): Prom
               providerPreference,
               compatTranslation: upstreamRequest.compatTranslation,
               compatMode,
-              allowCompatTerminalErrorResponse: provider === providerPlan[providerPlan.length - 1]
+              allowCompatTerminalErrorResponse: provider === providerPlan[providerPlan.length - 1],
+              upstreamLaneDebugEnabled
             });
             if (streamedResult === null || res.headersSent || res.writableEnded) return;
             result = streamedResult;
@@ -4692,7 +4810,8 @@ export async function proxyPostHandler(req: any, res: Response, next: any): Prom
               strictUpstreamPassthrough: upstreamRequest.strictUpstreamPassthrough,
               providerPreference,
               compatTranslation: upstreamRequest.compatTranslation,
-              allowCompatTerminalErrorResponse: provider === providerPlan[providerPlan.length - 1]
+              allowCompatTerminalErrorResponse: provider === providerPlan[providerPlan.length - 1],
+              upstreamLaneDebugEnabled
             });
           }
           terminalError = null;
@@ -5004,6 +5123,7 @@ export async function proxyPostHandler(req: any, res: Response, next: any): Prom
       res.setHeader('x-innies-token-credential-id', result.keyId);
     }
     res.setHeader('x-innies-attempt-no', String(result.attemptNo));
+    applyUpstreamLaneDebugHeaders(res, result.debugUpstreamLane);
     if (result.contentType) {
       res.setHeader('content-type', result.contentType);
     }

--- a/api/tests/anthropicCompat.route.test.ts
+++ b/api/tests/anthropicCompat.route.test.ts
@@ -1909,11 +1909,14 @@ describe('anthropic compat route', () => {
     expect(res.headers['x-innies-debug-upstream-token-kind']).toBe('anthropic_oauth');
     expect(res.headers['x-innies-debug-upstream-authorization']).toBe('Bearer <redacted:23>');
     expect(res.headers['x-innies-debug-upstream-anthropic-version']).toBe('2023-06-01');
-    expect(res.headers['x-innies-debug-upstream-anthropic-beta']).toBe('fine-grained-tool-streaming-2025-05-14,oauth-2025-04-20');
+    expect(res.headers['x-innies-debug-upstream-anthropic-beta']).toBe(
+      'fine-grained-tool-streaming-2025-05-14,claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14'
+    );
     expect(res.headers['x-innies-debug-upstream-accept']).toBe('text/event-stream');
+    expect(res.headers['x-innies-debug-upstream-user-agent']).toBe('claude-cli/2.1.62');
     expect(res.headers['x-innies-debug-upstream-request-id']).toMatch(/^req_/);
     expect(res.headers['x-innies-debug-upstream-header-names']).toBe(
-      'accept,anthropic-beta,anthropic-version,authorization,content-type,x-request-id'
+      'accept,anthropic-beta,anthropic-dangerous-direct-browser-access,anthropic-version,authorization,content-type,user-agent,x-app,x-request-id'
     );
     expect(String(res.body)).toContain('event: message_start');
 

--- a/api/tests/anthropicCompat.route.test.ts
+++ b/api/tests/anthropicCompat.route.test.ts
@@ -333,6 +333,7 @@ describe('anthropic compat route', () => {
     delete process.env.ANTHROPIC_COMPAT_MAX_REQUEST_BYTES;
     delete process.env.OPENAI_UPSTREAM_BASE_URL;
     delete process.env.COMPAT_CODEX_DEFAULT_MODEL;
+    delete process.env.INNIES_ENABLE_UPSTREAM_DEBUG_HEADERS;
     resetAnthropicUsageRetryStateForTests();
     vi.restoreAllMocks();
   });
@@ -1854,6 +1855,67 @@ describe('anthropic compat route', () => {
     expect(headers['anthropic-beta']).toContain('claude-code-20250219');
     expect(headers['anthropic-beta']).toContain('interleaved-thinking-2025-05-14');
     expect(res.statusCode).toBe(200);
+
+    upstreamSpy.mockRestore();
+  });
+
+  it('returns first-pass upstream lane debug headers on compat SSE responses when explicitly enabled', async () => {
+    process.env.ANTHROPIC_UPSTREAM_BASE_URL = 'https://anthropic.internal.test';
+    process.env.INNIES_ENABLE_UPSTREAM_DEBUG_HEADERS = 'true';
+
+    const encoder = new TextEncoder();
+    const sseBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode('event: message_start\ndata: {"type":"message_start"}\n\n'));
+        controller.enqueue(encoder.encode('event: message_stop\ndata: {"type":"message_stop"}\n\n'));
+        controller.close();
+      }
+    });
+    const upstreamSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(sseBody, {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream; charset=utf-8' }
+      })
+    );
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/messages',
+      headers: {
+        authorization: 'Bearer in_test_token',
+        'content-type': 'application/json',
+        'anthropic-version': '2023-06-01',
+        'anthropic-beta': 'fine-grained-tool-streaming-2025-05-14',
+        'x-innies-debug-upstream-lane': '1'
+      },
+      body: {
+        model: 'claude-opus-4-6',
+        stream: true,
+        max_tokens: 8,
+        messages: [{ role: 'user', content: 'hi' }]
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(handlers[0], req, res);
+    await invoke(handlers[1], req, res);
+    await invoke(handlers[2], req, res);
+
+    expect(upstreamSpy).toHaveBeenCalledTimes(1);
+    expect(res.headers['x-innies-debug-upstream-target-url']).toBe('https://anthropic.internal.test/v1/messages');
+    expect(res.headers['x-innies-debug-upstream-proxied-path']).toBe('/v1/messages');
+    expect(res.headers['x-innies-debug-upstream-provider']).toBe('anthropic');
+    expect(res.headers['x-innies-debug-upstream-stream']).toBe('true');
+    expect(res.headers['x-innies-debug-upstream-token-kind']).toBe('anthropic_oauth');
+    expect(res.headers['x-innies-debug-upstream-authorization']).toBe('Bearer <redacted:23>');
+    expect(res.headers['x-innies-debug-upstream-anthropic-version']).toBe('2023-06-01');
+    expect(res.headers['x-innies-debug-upstream-anthropic-beta']).toBe('fine-grained-tool-streaming-2025-05-14,oauth-2025-04-20');
+    expect(res.headers['x-innies-debug-upstream-accept']).toBe('text/event-stream');
+    expect(res.headers['x-innies-debug-upstream-request-id']).toMatch(/^req_/);
+    expect(res.headers['x-innies-debug-upstream-header-names']).toBe(
+      'accept,anthropic-beta,anthropic-version,authorization,content-type,x-request-id'
+    );
+    expect(String(res.body)).toContain('event: message_start');
 
     upstreamSpy.mockRestore();
   });

--- a/docs/API_CONTRACT.md
+++ b/docs/API_CONTRACT.md
@@ -158,6 +158,8 @@ Notes:
   - Deterministic local Anthropic compat validation failures also emit `[compat-local-validation-failed]` with the same redacted request-shape trace before returning a local `400`.
 - Optional operational debug tracing:
   - `INNIES_COMPAT_TRACE=true` enables redacted request/response logs for `/v1/messages` only.
+  - `INNIES_ENABLE_UPSTREAM_DEBUG_HEADERS=true` allows opt-in first-pass upstream lane headers on compat responses when the caller sends `x-innies-debug-upstream-lane: 1`.
+  - exposed debug headers are redacted and include target URL, forwarded request-id, token kind, header names, plus key Anthropic header values (`accept`, `anthropic-version`, `anthropic-beta`, optional `user-agent`).
   - Keep disabled in normal production operation due to log volume.
 
 ### `POST /v1/seller-keys`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -24,6 +24,7 @@ innies-buyer-key-create
 innies-buyer-preference-set
 innies-buyer-preference-get
 innies-buyer-preference-check
+innies-compat-lane-compare
 innies-slo-check
 ```
 
@@ -39,6 +40,7 @@ What they do:
 - `innies-buyer-preference-set`: set a buyer key preference to `Claude Code`, `Codex`, or `null`
 - `innies-buyer-preference-get`: read the current buyer key preference
 - `innies-buyer-preference-check`: run the provider-preference canary after prompting for the expected provider (`Claude Code` or `Codex`)
+- `innies-compat-lane-compare`: replay a preserved Anthropic compat payload through Innies with first-pass upstream lane debug enabled, send the same payload directly to Anthropic OAuth, and write a side-by-side lane diff bundle
 - `innies-slo-check`: query analytics endpoints and report Phase 1 SLO pass/fail (TTFB p95, timeout rate, success rate, fallback rate); optional arg sets the window (default `24h`); exits 0 if all SLOs pass, 1 if any fail
 
 Behavior:
@@ -79,6 +81,12 @@ Behavior:
 - non-pinned buyer traffic always gets automatic cross-provider fallback to the other provider; flipping preference flips fallback order too
 - `innies-buyer-preference-set` prints the effective preferred provider plus the automatic fallback provider before sending the update
 - `innies-buyer-preference-check` now expects and validates the two-provider plan in DB evidence mode
+- `innies-compat-lane-compare` requires `INNIES_ENABLE_UPSTREAM_DEBUG_HEADERS=true` on the API server and accepts:
+  - a payload file path arg (or `INNIES_REPLAY_PAYLOAD_PATH`)
+  - Innies buyer auth via `INNIES_BUYER_API_KEY` / `INNIES_TOKEN`
+  - direct Anthropic OAuth auth via `ANTHROPIC_OAUTH_ACCESS_TOKEN`
+  - optional `ANTHROPIC_DIRECT_USER_AGENT` / `ANTHROPIC_DIRECT_BETA` / `ANTHROPIC_DIRECT_VERSION`
+  - optional output dir override via `INNIES_LANE_OUT_DIR`
 
 ## Env
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -89,10 +89,13 @@ Behavior:
   - live Innies mode:
     - requires `INNIES_ENABLE_UPSTREAM_DEBUG_HEADERS=true` on the API server
     - uses Innies buyer auth via `INNIES_BUYER_API_KEY` / `INNIES_TOKEN`
+    - sends `x-innies-provider-pin: true` so the compat request stays on the Anthropic lane while collecting the first-pass debug headers
+    - aborts if the observed `x-innies-debug-upstream-provider` is not `anthropic`
   - captured-artifact mode:
     - set `INNIES_CAPTURED_RESPONSE_HTML=/path/to/response.html` (or `INNIES_CAPTURED_LOG_PATH`)
     - set `INNIES_CAPTURED_REQUEST_ID=req_...` for the failing Innies request id to extract
     - skips the live Innies request and reuses the exact captured first-pass upstream lane from the artifact instead
+    - aborts if the captured upstream provider for that request id is not `anthropic`
 
 ## Env
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -40,7 +40,7 @@ What they do:
 - `innies-buyer-preference-set`: set a buyer key preference to `Claude Code`, `Codex`, or `null`
 - `innies-buyer-preference-get`: read the current buyer key preference
 - `innies-buyer-preference-check`: run the provider-preference canary after prompting for the expected provider (`Claude Code` or `Codex`)
-- `innies-compat-lane-compare`: replay a preserved Anthropic compat payload through Innies with first-pass upstream lane debug enabled, send the same payload directly to Anthropic OAuth, and write a side-by-side lane diff bundle
+- `innies-compat-lane-compare`: compare a preserved Anthropic compat payload against the direct Anthropic OAuth lane, either by calling Innies live with first-pass upstream lane debug enabled or by reusing a captured compat response HTML/log artifact, then write a side-by-side lane diff bundle
 - `innies-slo-check`: query analytics endpoints and report Phase 1 SLO pass/fail (TTFB p95, timeout rate, success rate, fallback rate); optional arg sets the window (default `24h`); exits 0 if all SLOs pass, 1 if any fail
 
 Behavior:
@@ -81,12 +81,18 @@ Behavior:
 - non-pinned buyer traffic always gets automatic cross-provider fallback to the other provider; flipping preference flips fallback order too
 - `innies-buyer-preference-set` prints the effective preferred provider plus the automatic fallback provider before sending the update
 - `innies-buyer-preference-check` now expects and validates the two-provider plan in DB evidence mode
-- `innies-compat-lane-compare` requires `INNIES_ENABLE_UPSTREAM_DEBUG_HEADERS=true` on the API server and accepts:
+- `innies-compat-lane-compare` accepts:
   - a payload file path arg (or `INNIES_REPLAY_PAYLOAD_PATH`)
-  - Innies buyer auth via `INNIES_BUYER_API_KEY` / `INNIES_TOKEN`
   - direct Anthropic OAuth auth via `ANTHROPIC_OAUTH_ACCESS_TOKEN`
   - optional `ANTHROPIC_DIRECT_USER_AGENT` / `ANTHROPIC_DIRECT_BETA` / `ANTHROPIC_DIRECT_VERSION`
   - optional output dir override via `INNIES_LANE_OUT_DIR`
+  - live Innies mode:
+    - requires `INNIES_ENABLE_UPSTREAM_DEBUG_HEADERS=true` on the API server
+    - uses Innies buyer auth via `INNIES_BUYER_API_KEY` / `INNIES_TOKEN`
+  - captured-artifact mode:
+    - set `INNIES_CAPTURED_RESPONSE_HTML=/path/to/response.html` (or `INNIES_CAPTURED_LOG_PATH`)
+    - set `INNIES_CAPTURED_REQUEST_ID=req_...` for the failing Innies request id to extract
+    - skips the live Innies request and reuses the exact captured first-pass upstream lane from the artifact instead
 
 ## Env
 

--- a/scripts/innies-compat-lane-compare.sh
+++ b/scripts/innies-compat-lane-compare.sh
@@ -77,6 +77,23 @@ redact_bearer_value() {
   printf 'Bearer <redacted:%s>' "${#token}"
 }
 
+require_anthropic_lane() {
+  local mode="$1"
+  local provider="${2:-}"
+  local prefix=''
+  provider="$(printf '%s' "$provider" | tr '[:upper:]' '[:lower:]')"
+  if [[ "$provider" != 'anthropic' ]]; then
+    if [[ -z "$provider" ]]; then
+      provider='unknown'
+    fi
+    if [[ -n "$mode" ]]; then
+      prefix="${mode} "
+    fi
+    echo "error: ${prefix}Innies lane resolved to ${provider}; expected anthropic" >&2
+    exit 1
+  fi
+}
+
 load_captured_innies_lane() {
   local captured_html="$1"
   local request_id="$2"
@@ -345,6 +362,7 @@ else
     -H "anthropic-version: $ANTHROPIC_VERSION" \
     -H "anthropic-beta: $ANTHROPIC_BETA" \
     -H "x-request-id: $INNIES_REQUEST_ID" \
+    -H 'x-innies-provider-pin: true' \
     -H 'x-innies-debug-upstream-lane: 1' \
     --data-binary @"$PAYLOAD_PATH")"
 
@@ -377,6 +395,12 @@ if [[ -z "$INNIES_UPSTREAM_TARGET_URL" ]]; then
     echo 'error: missing x-innies-debug-upstream-target-url response header; enable INNIES_ENABLE_UPSTREAM_DEBUG_HEADERS=true on the API server' >&2
   fi
   exit 1
+fi
+
+if [[ "$USE_CAPTURED_RESPONSE" == 'true' ]]; then
+  require_anthropic_lane 'captured' "$INNIES_UPSTREAM_PROVIDER"
+else
+  require_anthropic_lane 'live' "$INNIES_UPSTREAM_PROVIDER"
 fi
 
 write_lines "$INNIES_META_FILE" \

--- a/scripts/innies-compat-lane-compare.sh
+++ b/scripts/innies-compat-lane-compare.sh
@@ -77,6 +77,150 @@ redact_bearer_value() {
   printf 'Bearer <redacted:%s>' "${#token}"
 }
 
+load_captured_innies_lane() {
+  local captured_html="$1"
+  local request_id="$2"
+  node - "$captured_html" "$request_id" <<'NODE'
+const fs = require('fs');
+
+const capturedHtmlPath = process.argv[2];
+const requestId = process.argv[3];
+
+function stripLogPrefix(line) {
+  return line.replace(/^.*?\]:\s*/, '');
+}
+
+function parseJsLiteral(literal) {
+  return Function('"use strict"; return (' + literal + ');')();
+}
+
+function parseSerializedValue(text) {
+  try {
+    return JSON.parse(text);
+  } catch {}
+  return parseJsLiteral(text);
+}
+
+function parseChunkSeries(lines, startIndex, label) {
+  const parts = [];
+  let expectedChunkCount = null;
+  let index = startIndex;
+  while (index < lines.length) {
+    const header = stripLogPrefix(lines[index]);
+    if (header !== `${label} {`) break;
+    const chunkIndexLine = stripLogPrefix(lines[index + 1] ?? '');
+    const chunkCountLine = stripLogPrefix(lines[index + 2] ?? '');
+    const jsonLine = stripLogPrefix(lines[index + 3] ?? '');
+    const closeLine = stripLogPrefix(lines[index + 4] ?? '');
+    const chunkIndexMatch = chunkIndexLine.match(/^chunk_index:\s*(\d+),?$/);
+    const chunkCountMatch = chunkCountLine.match(/^chunk_count:\s*(\d+),?$/);
+    const jsonMatch = jsonLine.match(/^json:\s*(.+)$/);
+    if (!chunkIndexMatch || !chunkCountMatch || !jsonMatch || closeLine !== '}') {
+      throw new Error(`Malformed ${label} chunk near line ${index + 1}`);
+    }
+    const chunkIndex = Number(chunkIndexMatch[1]);
+    const chunkCount = Number(chunkCountMatch[1]);
+    if (expectedChunkCount === null) expectedChunkCount = chunkCount;
+    else if (expectedChunkCount !== chunkCount) throw new Error(`Mismatched ${label} chunk_count near line ${index + 1}`);
+    if (chunkIndex !== parts.length) throw new Error(`Out-of-order ${label} chunk_index near line ${index + 1}`);
+    parts.push(parseJsLiteral(jsonMatch[1]));
+    index += 5;
+    if (parts.length === expectedChunkCount) {
+      return { text: parts.join(''), nextIndex: index - 1 };
+    }
+  }
+  throw new Error(`Incomplete ${label} chunk series near line ${startIndex + 1}`);
+}
+
+function readRequestId(value) {
+  const raw = value?.request_id ?? value?.requestId;
+  return typeof raw === 'string' && raw.length > 0 ? raw : undefined;
+}
+
+function normalizeCsv(values) {
+  return [...new Set(values.filter(Boolean).map((value) => String(value).trim()).filter(Boolean))]
+    .sort()
+    .join(',');
+}
+
+function inferTokenKind(provider, authorization) {
+  if (typeof authorization !== 'string' || !authorization.startsWith('Bearer ')) {
+    return 'api_key';
+  }
+  if (provider === 'anthropic') return 'anthropic_oauth';
+  if (provider === 'openai') return 'openai_oauth';
+  return 'bearer';
+}
+
+const lines = fs.readFileSync(capturedHtmlPath, 'utf8').split(/\r?\n/);
+const upstreamRequests = [];
+const upstreamResponses = [];
+for (let index = 0; index < lines.length; index += 1) {
+  const body = stripLogPrefix(lines[index]);
+  if (body === '[compat-upstream-request-json-chunk] {') {
+    const { text, nextIndex } = parseChunkSeries(lines, index, '[compat-upstream-request-json-chunk]');
+    upstreamRequests.push(parseSerializedValue(text));
+    index = nextIndex;
+    continue;
+  }
+  if (body === '[compat-upstream-response-json-chunk] {') {
+    const { text, nextIndex } = parseChunkSeries(lines, index, '[compat-upstream-response-json-chunk]');
+    upstreamResponses.push(parseSerializedValue(text));
+    index = nextIndex;
+  }
+}
+
+const upstreamRequest = upstreamRequests.find((value) => readRequestId(value) === requestId);
+if (!upstreamRequest) {
+  console.error(`error: no captured compat upstream request found for ${requestId}`);
+  process.exit(1);
+}
+const upstreamResponse = upstreamResponses.find((value) => readRequestId(value) === requestId);
+if (!upstreamResponse) {
+  console.error(`error: no captured compat upstream response found for ${requestId}`);
+  process.exit(1);
+}
+
+const headers = upstreamRequest.headers && typeof upstreamRequest.headers === 'object' ? upstreamRequest.headers : {};
+const responseHeaders = upstreamResponse.response_headers && typeof upstreamResponse.response_headers === 'object'
+  ? upstreamResponse.response_headers
+  : {};
+const parsedBody = upstreamResponse.parsed_body && typeof upstreamResponse.parsed_body === 'object'
+  ? upstreamResponse.parsed_body
+  : {};
+const providerRequestId = responseHeaders['request-id']
+  ?? responseHeaders['x-request-id']
+  ?? parsedBody.request_id
+  ?? '';
+
+const values = {
+  status: String(upstreamResponse.upstream_status ?? ''),
+  request_id: String(requestId),
+  response_request_id: String(upstreamResponse.request_id ?? requestId),
+  forwarded_request_id: String(upstreamRequest.request_id ?? requestId),
+  provider_request_id: String(providerRequestId),
+  token_credential_id: String(upstreamRequest.credential_id ?? upstreamResponse.credential_id ?? ''),
+  attempt_no: String(upstreamRequest.attempt_no ?? upstreamResponse.attempt_no ?? ''),
+  upstream_target_url: String(upstreamRequest.target_url ?? ''),
+  upstream_proxied_path: String(upstreamRequest.proxied_path ?? ''),
+  upstream_provider: String(upstreamRequest.provider ?? ''),
+  upstream_stream: String(Boolean(upstreamRequest.stream)),
+  upstream_credential_id: String(upstreamRequest.credential_id ?? upstreamResponse.credential_id ?? ''),
+  upstream_token_kind: inferTokenKind(String(upstreamRequest.provider ?? ''), String(headers.authorization ?? '')),
+  upstream_authorization: String(headers.authorization ?? ''),
+  upstream_accept: String(headers.accept ?? ''),
+  upstream_anthropic_version: String(headers['anthropic-version'] ?? ''),
+  upstream_anthropic_beta: String(headers['anthropic-beta'] ?? ''),
+  upstream_user_agent: String(headers['user-agent'] ?? ''),
+  upstream_header_names: normalizeCsv(Object.keys(headers))
+};
+
+for (const [key, value] of Object.entries(values)) {
+  process.stdout.write(`${key}=${value}\n`);
+}
+NODE
+}
+
 resolve_direct_base_url() {
   if [[ -n "${ANTHROPIC_DIRECT_BASE_URL:-}" ]]; then
     printf '%s' "${ANTHROPIC_DIRECT_BASE_URL%/}"
@@ -97,14 +241,28 @@ if [[ ! -f "$PAYLOAD_PATH" ]]; then
   exit 1
 fi
 
-API_URL="$(resolve_api_url)"
-BUYER_TOKEN="${INNIES_BUYER_API_KEY:-${INNIES_TOKEN:-${BUYER_TOKEN:-}}}"
-if [[ -z "$BUYER_TOKEN" ]]; then
-  if ! BUYER_TOKEN="$(prompt_secret 'buyer API key (press Enter to cancel)')"; then
+CAPTURED_RESPONSE_HTML="${INNIES_CAPTURED_RESPONSE_HTML:-${INNIES_CAPTURED_LOG_PATH:-}}"
+CAPTURED_REQUEST_ID="${INNIES_CAPTURED_REQUEST_ID:-${INNIES_REQUEST_ID:-}}"
+USE_CAPTURED_RESPONSE='false'
+if [[ -n "$CAPTURED_RESPONSE_HTML" ]]; then
+  if [[ ! -f "$CAPTURED_RESPONSE_HTML" ]]; then
+    echo "error: captured response HTML not found: $CAPTURED_RESPONSE_HTML" >&2
     exit 1
   fi
+  require_nonempty 'captured Innies request id' "$CAPTURED_REQUEST_ID"
+  USE_CAPTURED_RESPONSE='true'
 fi
-require_nonempty 'buyer API key' "$BUYER_TOKEN"
+
+if [[ "$USE_CAPTURED_RESPONSE" != 'true' ]]; then
+  API_URL="$(resolve_api_url)"
+  BUYER_TOKEN="${INNIES_BUYER_API_KEY:-${INNIES_TOKEN:-${BUYER_TOKEN:-}}}"
+  if [[ -z "$BUYER_TOKEN" ]]; then
+    if ! BUYER_TOKEN="$(prompt_secret 'buyer API key (press Enter to cancel)')"; then
+      exit 1
+    fi
+  fi
+  require_nonempty 'buyer API key' "$BUYER_TOKEN"
+fi
 
 DIRECT_TOKEN="${ANTHROPIC_OAUTH_ACCESS_TOKEN:-${CLAUDE_OAUTH_ACCESS_TOKEN:-}}"
 if [[ -z "$DIRECT_TOKEN" ]]; then
@@ -116,7 +274,7 @@ require_nonempty 'Anthropic OAuth access token' "$DIRECT_TOKEN"
 
 ANTHROPIC_VERSION="${INNIES_ANTHROPIC_VERSION:-2023-06-01}"
 ANTHROPIC_BETA="${INNIES_ANTHROPIC_BETA:-fine-grained-tool-streaming-2025-05-14}"
-INNIES_REQUEST_ID="${INNIES_REQUEST_ID:-req_issue80_innies_$(date -u +%Y%m%dT%H%M%SZ)}"
+INNIES_REQUEST_ID="${INNIES_REQUEST_ID:-${CAPTURED_REQUEST_ID:-req_issue80_innies_$(date -u +%Y%m%dT%H%M%SZ)}}"
 DIRECT_REQUEST_ID="${ANTHROPIC_DIRECT_REQUEST_ID:-req_issue80_direct_$(date -u +%Y%m%dT%H%M%SZ)}"
 DIRECT_BASE_URL="$(resolve_direct_base_url)"
 DIRECT_VERSION="${ANTHROPIC_DIRECT_VERSION:-$ANTHROPIC_VERSION}"
@@ -135,46 +293,96 @@ DIRECT_BODY_FILE="$OUT_DIR/direct-body.txt"
 DIRECT_META_FILE="$OUT_DIR/direct-meta.txt"
 COMPARISON_FILE="$OUT_DIR/comparison.txt"
 
-INNIES_STATUS="$(curl -sS -D "$INNIES_HEADERS_FILE" -o "$INNIES_BODY_FILE" -w '%{http_code}' \
-  -X POST "${API_URL}/v1/messages" \
-  -H "Authorization: Bearer $BUYER_TOKEN" \
-  -H 'Content-Type: application/json' \
-  -H 'Accept: text/event-stream' \
-  -H "anthropic-version: $ANTHROPIC_VERSION" \
-  -H "anthropic-beta: $ANTHROPIC_BETA" \
-  -H "x-request-id: $INNIES_REQUEST_ID" \
-  -H 'x-innies-debug-upstream-lane: 1' \
-  --data-binary @"$PAYLOAD_PATH")"
+INNIES_STATUS=''
+INNIES_RESPONSE_REQUEST_ID=''
+INNIES_TOKEN_CREDENTIAL_ID=''
+INNIES_ATTEMPT_NO=''
+INNIES_UPSTREAM_TARGET_URL=''
+INNIES_UPSTREAM_PROXIED_PATH=''
+INNIES_UPSTREAM_PROVIDER=''
+INNIES_UPSTREAM_STREAM=''
+INNIES_UPSTREAM_CREDENTIAL_ID=''
+INNIES_UPSTREAM_TOKEN_KIND=''
+INNIES_UPSTREAM_AUTHORIZATION=''
+INNIES_UPSTREAM_ACCEPT=''
+INNIES_UPSTREAM_ANTHROPIC_VERSION=''
+INNIES_UPSTREAM_ANTHROPIC_BETA=''
+INNIES_UPSTREAM_USER_AGENT=''
+INNIES_FORWARDED_REQUEST_ID=''
+INNIES_UPSTREAM_HEADER_NAMES=''
+INNIES_PROVIDER_REQUEST_ID=''
 
-INNIES_RESPONSE_REQUEST_ID="$(extract_header 'x-request-id' "$INNIES_HEADERS_FILE")"
-INNIES_TOKEN_CREDENTIAL_ID="$(extract_header 'x-innies-token-credential-id' "$INNIES_HEADERS_FILE")"
-INNIES_ATTEMPT_NO="$(extract_header 'x-innies-attempt-no' "$INNIES_HEADERS_FILE")"
-INNIES_UPSTREAM_TARGET_URL="$(extract_header 'x-innies-debug-upstream-target-url' "$INNIES_HEADERS_FILE")"
-INNIES_UPSTREAM_PROXIED_PATH="$(extract_header 'x-innies-debug-upstream-proxied-path' "$INNIES_HEADERS_FILE")"
-INNIES_UPSTREAM_PROVIDER="$(extract_header 'x-innies-debug-upstream-provider' "$INNIES_HEADERS_FILE")"
-INNIES_UPSTREAM_STREAM="$(extract_header 'x-innies-debug-upstream-stream' "$INNIES_HEADERS_FILE")"
-INNIES_UPSTREAM_CREDENTIAL_ID="$(extract_header 'x-innies-debug-upstream-credential-id' "$INNIES_HEADERS_FILE")"
-INNIES_UPSTREAM_TOKEN_KIND="$(extract_header 'x-innies-debug-upstream-token-kind' "$INNIES_HEADERS_FILE")"
-INNIES_UPSTREAM_AUTHORIZATION="$(extract_header 'x-innies-debug-upstream-authorization' "$INNIES_HEADERS_FILE")"
-INNIES_UPSTREAM_ACCEPT="$(extract_header 'x-innies-debug-upstream-accept' "$INNIES_HEADERS_FILE")"
-INNIES_UPSTREAM_ANTHROPIC_VERSION="$(extract_header 'x-innies-debug-upstream-anthropic-version' "$INNIES_HEADERS_FILE")"
-INNIES_UPSTREAM_ANTHROPIC_BETA="$(extract_header 'x-innies-debug-upstream-anthropic-beta' "$INNIES_HEADERS_FILE")"
-INNIES_UPSTREAM_USER_AGENT="$(extract_header 'x-innies-debug-upstream-user-agent' "$INNIES_HEADERS_FILE")"
-INNIES_FORWARDED_REQUEST_ID="$(extract_header 'x-innies-debug-upstream-request-id' "$INNIES_HEADERS_FILE")"
-INNIES_UPSTREAM_HEADER_NAMES="$(normalize_csv "$(extract_header 'x-innies-debug-upstream-header-names' "$INNIES_HEADERS_FILE")")"
-INNIES_PROVIDER_REQUEST_ID="$(extract_header 'request-id' "$INNIES_HEADERS_FILE")"
-if [[ -z "$INNIES_PROVIDER_REQUEST_ID" ]]; then
-  INNIES_PROVIDER_REQUEST_ID="$(extract_body_request_id "$INNIES_BODY_FILE")"
+if [[ "$USE_CAPTURED_RESPONSE" == 'true' ]]; then
+  while IFS='=' read -r key value; do
+    case "$key" in
+      status) INNIES_STATUS="$value" ;;
+      request_id) INNIES_REQUEST_ID="$value" ;;
+      response_request_id) INNIES_RESPONSE_REQUEST_ID="$value" ;;
+      forwarded_request_id) INNIES_FORWARDED_REQUEST_ID="$value" ;;
+      provider_request_id) INNIES_PROVIDER_REQUEST_ID="$value" ;;
+      token_credential_id) INNIES_TOKEN_CREDENTIAL_ID="$value" ;;
+      attempt_no) INNIES_ATTEMPT_NO="$value" ;;
+      upstream_target_url) INNIES_UPSTREAM_TARGET_URL="$value" ;;
+      upstream_proxied_path) INNIES_UPSTREAM_PROXIED_PATH="$value" ;;
+      upstream_provider) INNIES_UPSTREAM_PROVIDER="$value" ;;
+      upstream_stream) INNIES_UPSTREAM_STREAM="$value" ;;
+      upstream_credential_id) INNIES_UPSTREAM_CREDENTIAL_ID="$value" ;;
+      upstream_token_kind) INNIES_UPSTREAM_TOKEN_KIND="$value" ;;
+      upstream_authorization) INNIES_UPSTREAM_AUTHORIZATION="$value" ;;
+      upstream_accept) INNIES_UPSTREAM_ACCEPT="$value" ;;
+      upstream_anthropic_version) INNIES_UPSTREAM_ANTHROPIC_VERSION="$value" ;;
+      upstream_anthropic_beta) INNIES_UPSTREAM_ANTHROPIC_BETA="$value" ;;
+      upstream_user_agent) INNIES_UPSTREAM_USER_AGENT="$value" ;;
+      upstream_header_names) INNIES_UPSTREAM_HEADER_NAMES="$value" ;;
+    esac
+  done < <(load_captured_innies_lane "$CAPTURED_RESPONSE_HTML" "$CAPTURED_REQUEST_ID")
+else
+  INNIES_STATUS="$(curl -sS -D "$INNIES_HEADERS_FILE" -o "$INNIES_BODY_FILE" -w '%{http_code}' \
+    -X POST "${API_URL}/v1/messages" \
+    -H "Authorization: Bearer $BUYER_TOKEN" \
+    -H 'Content-Type: application/json' \
+    -H 'Accept: text/event-stream' \
+    -H "anthropic-version: $ANTHROPIC_VERSION" \
+    -H "anthropic-beta: $ANTHROPIC_BETA" \
+    -H "x-request-id: $INNIES_REQUEST_ID" \
+    -H 'x-innies-debug-upstream-lane: 1' \
+    --data-binary @"$PAYLOAD_PATH")"
+
+  INNIES_RESPONSE_REQUEST_ID="$(extract_header 'x-request-id' "$INNIES_HEADERS_FILE")"
+  INNIES_TOKEN_CREDENTIAL_ID="$(extract_header 'x-innies-token-credential-id' "$INNIES_HEADERS_FILE")"
+  INNIES_ATTEMPT_NO="$(extract_header 'x-innies-attempt-no' "$INNIES_HEADERS_FILE")"
+  INNIES_UPSTREAM_TARGET_URL="$(extract_header 'x-innies-debug-upstream-target-url' "$INNIES_HEADERS_FILE")"
+  INNIES_UPSTREAM_PROXIED_PATH="$(extract_header 'x-innies-debug-upstream-proxied-path' "$INNIES_HEADERS_FILE")"
+  INNIES_UPSTREAM_PROVIDER="$(extract_header 'x-innies-debug-upstream-provider' "$INNIES_HEADERS_FILE")"
+  INNIES_UPSTREAM_STREAM="$(extract_header 'x-innies-debug-upstream-stream' "$INNIES_HEADERS_FILE")"
+  INNIES_UPSTREAM_CREDENTIAL_ID="$(extract_header 'x-innies-debug-upstream-credential-id' "$INNIES_HEADERS_FILE")"
+  INNIES_UPSTREAM_TOKEN_KIND="$(extract_header 'x-innies-debug-upstream-token-kind' "$INNIES_HEADERS_FILE")"
+  INNIES_UPSTREAM_AUTHORIZATION="$(extract_header 'x-innies-debug-upstream-authorization' "$INNIES_HEADERS_FILE")"
+  INNIES_UPSTREAM_ACCEPT="$(extract_header 'x-innies-debug-upstream-accept' "$INNIES_HEADERS_FILE")"
+  INNIES_UPSTREAM_ANTHROPIC_VERSION="$(extract_header 'x-innies-debug-upstream-anthropic-version' "$INNIES_HEADERS_FILE")"
+  INNIES_UPSTREAM_ANTHROPIC_BETA="$(extract_header 'x-innies-debug-upstream-anthropic-beta' "$INNIES_HEADERS_FILE")"
+  INNIES_UPSTREAM_USER_AGENT="$(extract_header 'x-innies-debug-upstream-user-agent' "$INNIES_HEADERS_FILE")"
+  INNIES_FORWARDED_REQUEST_ID="$(extract_header 'x-innies-debug-upstream-request-id' "$INNIES_HEADERS_FILE")"
+  INNIES_UPSTREAM_HEADER_NAMES="$(normalize_csv "$(extract_header 'x-innies-debug-upstream-header-names' "$INNIES_HEADERS_FILE")")"
+  INNIES_PROVIDER_REQUEST_ID="$(extract_header 'request-id' "$INNIES_HEADERS_FILE")"
+  if [[ -z "$INNIES_PROVIDER_REQUEST_ID" ]]; then
+    INNIES_PROVIDER_REQUEST_ID="$(extract_body_request_id "$INNIES_BODY_FILE")"
+  fi
 fi
 
 if [[ -z "$INNIES_UPSTREAM_TARGET_URL" ]]; then
-  echo 'error: missing x-innies-debug-upstream-target-url response header; enable INNIES_ENABLE_UPSTREAM_DEBUG_HEADERS=true on the API server' >&2
+  if [[ "$USE_CAPTURED_RESPONSE" == 'true' ]]; then
+    echo "error: captured response did not contain an Innies upstream lane for request $CAPTURED_REQUEST_ID" >&2
+  else
+    echo 'error: missing x-innies-debug-upstream-target-url response header; enable INNIES_ENABLE_UPSTREAM_DEBUG_HEADERS=true on the API server' >&2
+  fi
   exit 1
 fi
 
 write_lines "$INNIES_META_FILE" \
   "timestamp=$TIMESTAMP" \
   "payload_path=$PAYLOAD_PATH" \
+  "captured_response_html=${CAPTURED_RESPONSE_HTML:-}" \
   "payload_bytes=$PAYLOAD_BYTES" \
   "status=$INNIES_STATUS" \
   "request_id=$INNIES_REQUEST_ID" \

--- a/scripts/innies-compat-lane-compare.sh
+++ b/scripts/innies-compat-lane-compare.sh
@@ -1,0 +1,321 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_PATH" ]]; do
+  SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+  SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"
+  [[ "$SCRIPT_PATH" != /* ]] && SCRIPT_PATH="${SCRIPT_DIR}/${SCRIPT_PATH}"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+source "${SCRIPT_DIR}/_common.sh"
+
+resolve_api_url() {
+  if [[ -n "${INNIES_BASE_URL:-}" ]]; then
+    printf '%s' "${INNIES_BASE_URL%/}"
+    return
+  fi
+  if [[ -n "${INNIES_API_BASE_URL:-}" ]]; then
+    printf '%s' "${INNIES_API_BASE_URL%/}"
+    return
+  fi
+  if [[ -n "${INNIES_API_URL:-}" ]]; then
+    printf '%s' "${INNIES_API_URL%/}"
+    return
+  fi
+  printf '%s' "${BASE_URL%/}"
+}
+
+extract_header() {
+  local name="$1"
+  local file="$2"
+  awk -F': ' -v header_name="$name" '
+    BEGIN { IGNORECASE = 1 }
+    tolower($1) == tolower(header_name) {
+      gsub("\r", "", $2)
+      print $2
+    }
+  ' "$file" | tail -1
+}
+
+extract_body_request_id() {
+  local file="$1"
+  sed -n 's/.*"request_id":"\([^"]*\)".*/\1/p' "$file" | head -n 1
+}
+
+write_lines() {
+  local file="$1"
+  shift
+  printf '%s\n' "$@" >"$file"
+}
+
+normalize_csv() {
+  local value="${1:-}"
+  if [[ -z "$value" ]]; then
+    printf '%s' ''
+    return
+  fi
+  printf '%s' "$value" \
+    | tr ',' '\n' \
+    | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' \
+    | sed '/^$/d' \
+    | sort -u \
+    | paste -sd',' -
+}
+
+csv_only_in_left() {
+  local left="${1:-}"
+  local right="${2:-}"
+  comm -23 \
+    <(printf '%s' "$left" | tr ',' '\n' | sed '/^$/d' | sort -u) \
+    <(printf '%s' "$right" | tr ',' '\n' | sed '/^$/d' | sort -u) \
+    | paste -sd',' -
+}
+
+redact_bearer_value() {
+  local token="$1"
+  printf 'Bearer <redacted:%s>' "${#token}"
+}
+
+resolve_direct_base_url() {
+  if [[ -n "${ANTHROPIC_DIRECT_BASE_URL:-}" ]]; then
+    printf '%s' "${ANTHROPIC_DIRECT_BASE_URL%/}"
+    return
+  fi
+  if [[ -n "${ANTHROPIC_BASE_URL:-}" ]]; then
+    printf '%s' "${ANTHROPIC_BASE_URL%/}"
+    return
+  fi
+  printf '%s' 'https://api.anthropic.com'
+}
+
+PAYLOAD_PATH="${1:-${INNIES_REPLAY_PAYLOAD_PATH:-}}"
+require_nonempty 'payload path' "$PAYLOAD_PATH"
+
+if [[ ! -f "$PAYLOAD_PATH" ]]; then
+  echo "error: payload file not found: $PAYLOAD_PATH" >&2
+  exit 1
+fi
+
+API_URL="$(resolve_api_url)"
+BUYER_TOKEN="${INNIES_BUYER_API_KEY:-${INNIES_TOKEN:-${BUYER_TOKEN:-}}}"
+if [[ -z "$BUYER_TOKEN" ]]; then
+  if ! BUYER_TOKEN="$(prompt_secret 'buyer API key (press Enter to cancel)')"; then
+    exit 1
+  fi
+fi
+require_nonempty 'buyer API key' "$BUYER_TOKEN"
+
+DIRECT_TOKEN="${ANTHROPIC_OAUTH_ACCESS_TOKEN:-${CLAUDE_OAUTH_ACCESS_TOKEN:-}}"
+if [[ -z "$DIRECT_TOKEN" ]]; then
+  if ! DIRECT_TOKEN="$(prompt_secret 'Anthropic OAuth access token (press Enter to cancel)')"; then
+    exit 1
+  fi
+fi
+require_nonempty 'Anthropic OAuth access token' "$DIRECT_TOKEN"
+
+ANTHROPIC_VERSION="${INNIES_ANTHROPIC_VERSION:-2023-06-01}"
+ANTHROPIC_BETA="${INNIES_ANTHROPIC_BETA:-fine-grained-tool-streaming-2025-05-14}"
+INNIES_REQUEST_ID="${INNIES_REQUEST_ID:-req_issue80_innies_$(date -u +%Y%m%dT%H%M%SZ)}"
+DIRECT_REQUEST_ID="${ANTHROPIC_DIRECT_REQUEST_ID:-req_issue80_direct_$(date -u +%Y%m%dT%H%M%SZ)}"
+DIRECT_BASE_URL="$(resolve_direct_base_url)"
+DIRECT_VERSION="${ANTHROPIC_DIRECT_VERSION:-$ANTHROPIC_VERSION}"
+DIRECT_BETA="${ANTHROPIC_DIRECT_BETA:-$ANTHROPIC_BETA}"
+DIRECT_USER_AGENT="${ANTHROPIC_DIRECT_USER_AGENT:-}"
+OUT_DIR="${INNIES_LANE_OUT_DIR:-${TMPDIR:-/tmp}/innies-compat-lane-compare-${INNIES_REQUEST_ID}}"
+PAYLOAD_BYTES="$(wc -c <"$PAYLOAD_PATH" | tr -d ' ')"
+TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+mkdir -p "$OUT_DIR"
+
+INNIES_HEADERS_FILE="$OUT_DIR/innies-headers.txt"
+INNIES_BODY_FILE="$OUT_DIR/innies-body.txt"
+INNIES_META_FILE="$OUT_DIR/innies-meta.txt"
+DIRECT_HEADERS_FILE="$OUT_DIR/direct-headers.txt"
+DIRECT_BODY_FILE="$OUT_DIR/direct-body.txt"
+DIRECT_META_FILE="$OUT_DIR/direct-meta.txt"
+COMPARISON_FILE="$OUT_DIR/comparison.txt"
+
+INNIES_STATUS="$(curl -sS -D "$INNIES_HEADERS_FILE" -o "$INNIES_BODY_FILE" -w '%{http_code}' \
+  -X POST "${API_URL}/v1/messages" \
+  -H "Authorization: Bearer $BUYER_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: text/event-stream' \
+  -H "anthropic-version: $ANTHROPIC_VERSION" \
+  -H "anthropic-beta: $ANTHROPIC_BETA" \
+  -H "x-request-id: $INNIES_REQUEST_ID" \
+  -H 'x-innies-debug-upstream-lane: 1' \
+  --data-binary @"$PAYLOAD_PATH")"
+
+INNIES_RESPONSE_REQUEST_ID="$(extract_header 'x-request-id' "$INNIES_HEADERS_FILE")"
+INNIES_TOKEN_CREDENTIAL_ID="$(extract_header 'x-innies-token-credential-id' "$INNIES_HEADERS_FILE")"
+INNIES_ATTEMPT_NO="$(extract_header 'x-innies-attempt-no' "$INNIES_HEADERS_FILE")"
+INNIES_UPSTREAM_TARGET_URL="$(extract_header 'x-innies-debug-upstream-target-url' "$INNIES_HEADERS_FILE")"
+INNIES_UPSTREAM_PROXIED_PATH="$(extract_header 'x-innies-debug-upstream-proxied-path' "$INNIES_HEADERS_FILE")"
+INNIES_UPSTREAM_PROVIDER="$(extract_header 'x-innies-debug-upstream-provider' "$INNIES_HEADERS_FILE")"
+INNIES_UPSTREAM_STREAM="$(extract_header 'x-innies-debug-upstream-stream' "$INNIES_HEADERS_FILE")"
+INNIES_UPSTREAM_CREDENTIAL_ID="$(extract_header 'x-innies-debug-upstream-credential-id' "$INNIES_HEADERS_FILE")"
+INNIES_UPSTREAM_TOKEN_KIND="$(extract_header 'x-innies-debug-upstream-token-kind' "$INNIES_HEADERS_FILE")"
+INNIES_UPSTREAM_AUTHORIZATION="$(extract_header 'x-innies-debug-upstream-authorization' "$INNIES_HEADERS_FILE")"
+INNIES_UPSTREAM_ACCEPT="$(extract_header 'x-innies-debug-upstream-accept' "$INNIES_HEADERS_FILE")"
+INNIES_UPSTREAM_ANTHROPIC_VERSION="$(extract_header 'x-innies-debug-upstream-anthropic-version' "$INNIES_HEADERS_FILE")"
+INNIES_UPSTREAM_ANTHROPIC_BETA="$(extract_header 'x-innies-debug-upstream-anthropic-beta' "$INNIES_HEADERS_FILE")"
+INNIES_UPSTREAM_USER_AGENT="$(extract_header 'x-innies-debug-upstream-user-agent' "$INNIES_HEADERS_FILE")"
+INNIES_FORWARDED_REQUEST_ID="$(extract_header 'x-innies-debug-upstream-request-id' "$INNIES_HEADERS_FILE")"
+INNIES_UPSTREAM_HEADER_NAMES="$(normalize_csv "$(extract_header 'x-innies-debug-upstream-header-names' "$INNIES_HEADERS_FILE")")"
+INNIES_PROVIDER_REQUEST_ID="$(extract_header 'request-id' "$INNIES_HEADERS_FILE")"
+if [[ -z "$INNIES_PROVIDER_REQUEST_ID" ]]; then
+  INNIES_PROVIDER_REQUEST_ID="$(extract_body_request_id "$INNIES_BODY_FILE")"
+fi
+
+if [[ -z "$INNIES_UPSTREAM_TARGET_URL" ]]; then
+  echo 'error: missing x-innies-debug-upstream-target-url response header; enable INNIES_ENABLE_UPSTREAM_DEBUG_HEADERS=true on the API server' >&2
+  exit 1
+fi
+
+write_lines "$INNIES_META_FILE" \
+  "timestamp=$TIMESTAMP" \
+  "payload_path=$PAYLOAD_PATH" \
+  "payload_bytes=$PAYLOAD_BYTES" \
+  "status=$INNIES_STATUS" \
+  "request_id=$INNIES_REQUEST_ID" \
+  "response_request_id=${INNIES_RESPONSE_REQUEST_ID:-}" \
+  "forwarded_request_id=${INNIES_FORWARDED_REQUEST_ID:-}" \
+  "provider_request_id=${INNIES_PROVIDER_REQUEST_ID:-}" \
+  "token_credential_id=${INNIES_TOKEN_CREDENTIAL_ID:-}" \
+  "attempt_no=${INNIES_ATTEMPT_NO:-}" \
+  "upstream_target_url=${INNIES_UPSTREAM_TARGET_URL:-}" \
+  "upstream_proxied_path=${INNIES_UPSTREAM_PROXIED_PATH:-}" \
+  "upstream_provider=${INNIES_UPSTREAM_PROVIDER:-}" \
+  "upstream_stream=${INNIES_UPSTREAM_STREAM:-}" \
+  "upstream_credential_id=${INNIES_UPSTREAM_CREDENTIAL_ID:-}" \
+  "upstream_token_kind=${INNIES_UPSTREAM_TOKEN_KIND:-}" \
+  "upstream_authorization=${INNIES_UPSTREAM_AUTHORIZATION:-}" \
+  "upstream_accept=${INNIES_UPSTREAM_ACCEPT:-}" \
+  "upstream_anthropic_version=${INNIES_UPSTREAM_ANTHROPIC_VERSION:-}" \
+  "upstream_anthropic_beta=${INNIES_UPSTREAM_ANTHROPIC_BETA:-}" \
+  "upstream_user_agent=${INNIES_UPSTREAM_USER_AGENT:-}" \
+  "upstream_header_names=${INNIES_UPSTREAM_HEADER_NAMES:-}" \
+  "headers_file=$INNIES_HEADERS_FILE" \
+  "body_file=$INNIES_BODY_FILE"
+
+DIRECT_HEADER_NAMES='accept,anthropic-beta,anthropic-version,authorization,content-type,x-request-id'
+if [[ -n "$DIRECT_USER_AGENT" ]]; then
+  DIRECT_HEADER_NAMES="${DIRECT_HEADER_NAMES},user-agent"
+fi
+DIRECT_HEADER_NAMES="$(normalize_csv "$DIRECT_HEADER_NAMES")"
+
+DIRECT_CURL_ARGS=(
+  -sS
+  -D "$DIRECT_HEADERS_FILE"
+  -o "$DIRECT_BODY_FILE"
+  -w '%{http_code}'
+  -X POST "${DIRECT_BASE_URL}/v1/messages"
+  -H "Authorization: Bearer $DIRECT_TOKEN"
+  -H 'Content-Type: application/json'
+  -H 'Accept: text/event-stream'
+  -H "anthropic-version: $DIRECT_VERSION"
+  -H "anthropic-beta: $DIRECT_BETA"
+  -H "x-request-id: $DIRECT_REQUEST_ID"
+)
+if [[ -n "$DIRECT_USER_AGENT" ]]; then
+  DIRECT_CURL_ARGS+=(-H "user-agent: $DIRECT_USER_AGENT")
+fi
+DIRECT_CURL_ARGS+=(--data-binary @"$PAYLOAD_PATH")
+DIRECT_STATUS="$(curl "${DIRECT_CURL_ARGS[@]}")"
+
+DIRECT_RESPONSE_REQUEST_ID="$(extract_header 'x-request-id' "$DIRECT_HEADERS_FILE")"
+DIRECT_PROVIDER_REQUEST_ID="$(extract_header 'request-id' "$DIRECT_HEADERS_FILE")"
+if [[ -z "$DIRECT_PROVIDER_REQUEST_ID" ]]; then
+  DIRECT_PROVIDER_REQUEST_ID="$(extract_body_request_id "$DIRECT_BODY_FILE")"
+fi
+DIRECT_AUTHORIZATION="$(redact_bearer_value "$DIRECT_TOKEN")"
+DIRECT_TOKEN_KIND='bearer'
+if [[ "$DIRECT_TOKEN" == sk-ant-oat* ]]; then
+  DIRECT_TOKEN_KIND='anthropic_oauth'
+fi
+
+write_lines "$DIRECT_META_FILE" \
+  "timestamp=$TIMESTAMP" \
+  "payload_path=$PAYLOAD_PATH" \
+  "payload_bytes=$PAYLOAD_BYTES" \
+  "status=$DIRECT_STATUS" \
+  "request_id=$DIRECT_REQUEST_ID" \
+  "response_request_id=${DIRECT_RESPONSE_REQUEST_ID:-}" \
+  "provider_request_id=${DIRECT_PROVIDER_REQUEST_ID:-}" \
+  "target_url=${DIRECT_BASE_URL}/v1/messages" \
+  "token_kind=$DIRECT_TOKEN_KIND" \
+  "authorization=$DIRECT_AUTHORIZATION" \
+  "accept=text/event-stream" \
+  "anthropic_version=$DIRECT_VERSION" \
+  "anthropic_beta=$DIRECT_BETA" \
+  "user_agent=${DIRECT_USER_AGENT:-}" \
+  "header_names=$DIRECT_HEADER_NAMES" \
+  "headers_file=$DIRECT_HEADERS_FILE" \
+  "body_file=$DIRECT_BODY_FILE"
+
+SHARED_HEADER_NAMES="$(normalize_csv "$(comm -12 \
+  <(printf '%s' "$INNIES_UPSTREAM_HEADER_NAMES" | tr ',' '\n' | sed '/^$/d' | sort -u) \
+  <(printf '%s' "$DIRECT_HEADER_NAMES" | tr ',' '\n' | sed '/^$/d' | sort -u) \
+  | paste -sd',' -)")"
+INNIES_ONLY_HEADER_NAMES="$(csv_only_in_left "$INNIES_UPSTREAM_HEADER_NAMES" "$DIRECT_HEADER_NAMES")"
+DIRECT_ONLY_HEADER_NAMES="$(csv_only_in_left "$DIRECT_HEADER_NAMES" "$INNIES_UPSTREAM_HEADER_NAMES")"
+
+HEADER_VALUE_DIFF_NAMES=''
+if [[ "${INNIES_UPSTREAM_ACCEPT:-}" != 'text/event-stream' ]]; then
+  HEADER_VALUE_DIFF_NAMES="$(normalize_csv "${HEADER_VALUE_DIFF_NAMES},accept")"
+fi
+if [[ "${INNIES_UPSTREAM_ANTHROPIC_VERSION:-}" != "$DIRECT_VERSION" ]]; then
+  HEADER_VALUE_DIFF_NAMES="$(normalize_csv "${HEADER_VALUE_DIFF_NAMES},anthropic-version")"
+fi
+if [[ "${INNIES_UPSTREAM_ANTHROPIC_BETA:-}" != "$DIRECT_BETA" ]]; then
+  HEADER_VALUE_DIFF_NAMES="$(normalize_csv "${HEADER_VALUE_DIFF_NAMES},anthropic-beta")"
+fi
+if [[ "${INNIES_UPSTREAM_AUTHORIZATION:-}" != "$DIRECT_AUTHORIZATION" ]]; then
+  HEADER_VALUE_DIFF_NAMES="$(normalize_csv "${HEADER_VALUE_DIFF_NAMES},authorization")"
+fi
+if [[ "${INNIES_UPSTREAM_USER_AGENT:-}" != "$DIRECT_USER_AGENT" ]]; then
+  HEADER_VALUE_DIFF_NAMES="$(normalize_csv "${HEADER_VALUE_DIFF_NAMES},user-agent")"
+fi
+
+write_lines "$COMPARISON_FILE" \
+  "timestamp=$TIMESTAMP" \
+  "payload_path=$PAYLOAD_PATH" \
+  "payload_bytes=$PAYLOAD_BYTES" \
+  "innies_status=$INNIES_STATUS" \
+  "innies_request_id=$INNIES_REQUEST_ID" \
+  "innies_response_request_id=${INNIES_RESPONSE_REQUEST_ID:-}" \
+  "innies_forwarded_request_id=${INNIES_FORWARDED_REQUEST_ID:-}" \
+  "innies_provider_request_id=${INNIES_PROVIDER_REQUEST_ID:-}" \
+  "innies_token_credential_id=${INNIES_TOKEN_CREDENTIAL_ID:-}" \
+  "innies_attempt_no=${INNIES_ATTEMPT_NO:-}" \
+  "innies_upstream_target_url=${INNIES_UPSTREAM_TARGET_URL:-}" \
+  "innies_upstream_proxied_path=${INNIES_UPSTREAM_PROXIED_PATH:-}" \
+  "innies_upstream_provider=${INNIES_UPSTREAM_PROVIDER:-}" \
+  "innies_upstream_stream=${INNIES_UPSTREAM_STREAM:-}" \
+  "innies_upstream_credential_id=${INNIES_UPSTREAM_CREDENTIAL_ID:-}" \
+  "innies_upstream_token_kind=${INNIES_UPSTREAM_TOKEN_KIND:-}" \
+  "innies_upstream_authorization=${INNIES_UPSTREAM_AUTHORIZATION:-}" \
+  "innies_upstream_accept=${INNIES_UPSTREAM_ACCEPT:-}" \
+  "innies_upstream_anthropic_version=${INNIES_UPSTREAM_ANTHROPIC_VERSION:-}" \
+  "innies_upstream_anthropic_beta=${INNIES_UPSTREAM_ANTHROPIC_BETA:-}" \
+  "innies_upstream_user_agent=${INNIES_UPSTREAM_USER_AGENT:-}" \
+  "innies_upstream_header_names=${INNIES_UPSTREAM_HEADER_NAMES:-}" \
+  "direct_status=$DIRECT_STATUS" \
+  "direct_request_id=$DIRECT_REQUEST_ID" \
+  "direct_response_request_id=${DIRECT_RESPONSE_REQUEST_ID:-}" \
+  "direct_provider_request_id=${DIRECT_PROVIDER_REQUEST_ID:-}" \
+  "direct_target_url=${DIRECT_BASE_URL}/v1/messages" \
+  "direct_token_kind=$DIRECT_TOKEN_KIND" \
+  "direct_authorization=$DIRECT_AUTHORIZATION" \
+  "direct_accept=text/event-stream" \
+  "direct_anthropic_version=$DIRECT_VERSION" \
+  "direct_anthropic_beta=$DIRECT_BETA" \
+  "direct_user_agent=${DIRECT_USER_AGENT:-}" \
+  "direct_header_names=$DIRECT_HEADER_NAMES" \
+  "shared_header_names=${SHARED_HEADER_NAMES:-}" \
+  "innies_only_header_names=${INNIES_ONLY_HEADER_NAMES:-}" \
+  "direct_only_header_names=${DIRECT_ONLY_HEADER_NAMES:-}" \
+  "header_value_diff_names=${HEADER_VALUE_DIFF_NAMES:-}"
+
+cat "$COMPARISON_FILE"
+printf 'comparison_file=%s\n' "$COMPARISON_FILE"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,6 +17,7 @@ ln -sf "${ROOT_DIR}/scripts/innies-buyer-key-create.sh" "${BIN_DIR}/innies-buyer
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-set.sh" "${BIN_DIR}/innies-buyer-preference-set"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-get.sh" "${BIN_DIR}/innies-buyer-preference-get"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-check.sh" "${BIN_DIR}/innies-buyer-preference-check"
+ln -sf "${ROOT_DIR}/scripts/innies-compat-lane-compare.sh" "${BIN_DIR}/innies-compat-lane-compare"
 ln -sf "${ROOT_DIR}/scripts/innies-slo-check.sh" "${BIN_DIR}/innies-slo-check"
 
 rm -f \
@@ -48,6 +49,7 @@ echo "  ${BIN_DIR}/innies-buyer-key-create -> ${ROOT_DIR}/scripts/innies-buyer-k
 echo "  ${BIN_DIR}/innies-buyer-preference-set -> ${ROOT_DIR}/scripts/innies-buyer-preference-set.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-get -> ${ROOT_DIR}/scripts/innies-buyer-preference-get.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-check -> ${ROOT_DIR}/scripts/innies-buyer-preference-check.sh"
+echo "  ${BIN_DIR}/innies-compat-lane-compare -> ${ROOT_DIR}/scripts/innies-compat-lane-compare.sh"
 echo "  ${BIN_DIR}/innies-slo-check -> ${ROOT_DIR}/scripts/innies-slo-check.sh"
 echo
 echo 'If command not found, add ~/.local/bin to PATH:'

--- a/scripts/tests/innies-compat-lane-compare.test.sh
+++ b/scripts/tests/innies-compat-lane-compare.test.sh
@@ -10,9 +10,12 @@ INNIES_REQUEST_BODY="$TMP_DIR/innies-request-body.json"
 DIRECT_REQUEST_HEADERS="$TMP_DIR/direct-request-headers.json"
 DIRECT_REQUEST_BODY="$TMP_DIR/direct-request-body.json"
 OUTPUT_PATH="$TMP_DIR/output.txt"
+OUTPUT_FROM_LOG_PATH="$TMP_DIR/output-from-log.txt"
 INNIES_SERVER_LOG="$TMP_DIR/innies-server.log"
 DIRECT_SERVER_LOG="$TMP_DIR/direct-server.log"
 OUT_DIR="$TMP_DIR/out"
+OUT_DIR_FROM_LOG="$TMP_DIR/out-from-log"
+CAPTURED_RESPONSE_HTML="$TMP_DIR/response.html"
 
 cleanup() {
   if [[ -n "${INNIES_SERVER_PID:-}" ]]; then
@@ -144,3 +147,40 @@ cmp -s "$PAYLOAD_PATH" "$DIRECT_REQUEST_BODY"
 
 grep -q '^direct_only_header_names=user-agent$' "$OUT_DIR/comparison.txt"
 grep -q '^innies_only_header_names=$' "$OUT_DIR/comparison.txt"
+
+cat >"$CAPTURED_RESPONSE_HTML" <<'LOG'
+Mar 17 11:10:39 sf-prod bash[263845]: [compat-upstream-request-json-chunk] {
+Mar 17 11:10:39 sf-prod bash[263845]:   chunk_index: 0,
+Mar 17 11:10:39 sf-prod bash[263845]:   chunk_count: 1,
+Mar 17 11:10:39 sf-prod bash[263845]:   json: '{"attempt_no":1,"credential_id":"cred_issue80_from_log","credential_label":"aelix","headers":{"accept":"text/event-stream","anthropic-beta":"fine-grained-tool-streaming-2025-05-14,oauth-2025-04-20","anthropic-version":"2023-06-01","authorization":"Bearer <redacted:108>","content-type":"application/json","x-request-id":"req_issue80_from_log"},"method":"POST","model":"claude-opus-4-6","payload":{"model":"claude-opus-4-6","stream":true,"max_tokens":16,"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]},"provider":"anthropic","proxied_path":"/v1/messages","request_id":"req_issue80_from_log","stream":true,"target_url":"https://api.anthropic.com/v1/messages"}'
+Mar 17 11:10:39 sf-prod bash[263845]: }
+Mar 17 11:10:39 sf-prod bash[263845]: [compat-upstream-response-json-chunk] {
+Mar 17 11:10:39 sf-prod bash[263845]:   chunk_index: 0,
+Mar 17 11:10:39 sf-prod bash[263845]:   chunk_count: 1,
+Mar 17 11:10:39 sf-prod bash[263845]:   json: '{"attempt_no":1,"credential_id":"cred_issue80_from_log","credential_label":"aelix","parsed_body":{"error":{"message":"Error","type":"invalid_request_error"},"request_id":"req_upstream_from_log","type":"error"},"provider":"anthropic","proxied_path":"/v1/messages","request_id":"req_issue80_from_log","response_headers":{"content-type":"application/json","request-id":"req_upstream_from_log"},"stream":true,"target_url":"https://api.anthropic.com/v1/messages","upstream_content_type":"application/json","upstream_status":400}'
+Mar 17 11:10:39 sf-prod bash[263845]: }
+LOG
+
+INNIES_CAPTURED_RESPONSE_HTML="$CAPTURED_RESPONSE_HTML" \
+INNIES_CAPTURED_REQUEST_ID="req_issue80_from_log" \
+INNIES_LANE_OUT_DIR="$OUT_DIR_FROM_LOG" \
+ANTHROPIC_OAUTH_ACCESS_TOKEN="sk-ant-oat-direct-token" \
+ANTHROPIC_DIRECT_BASE_URL="http://127.0.0.1:$DIRECT_PORT" \
+ANTHROPIC_DIRECT_REQUEST_ID="req_issue80_direct_from_log" \
+ANTHROPIC_DIRECT_USER_AGENT="OpenClawGateway/1.0" \
+"$SCRIPT_PATH" "$PAYLOAD_PATH" >"$OUTPUT_FROM_LOG_PATH"
+
+grep -q 'innies_status=400' "$OUTPUT_FROM_LOG_PATH"
+grep -q 'innies_request_id=req_issue80_from_log' "$OUTPUT_FROM_LOG_PATH"
+grep -q 'innies_forwarded_request_id=req_issue80_from_log' "$OUTPUT_FROM_LOG_PATH"
+grep -q 'innies_provider_request_id=req_upstream_from_log' "$OUTPUT_FROM_LOG_PATH"
+grep -q 'innies_upstream_token_kind=anthropic_oauth' "$OUTPUT_FROM_LOG_PATH"
+grep -q 'innies_upstream_header_names=accept,anthropic-beta,anthropic-version,authorization,content-type,x-request-id' "$OUTPUT_FROM_LOG_PATH"
+grep -q 'direct_status=200' "$OUTPUT_FROM_LOG_PATH"
+grep -q 'comparison_file=' "$OUTPUT_FROM_LOG_PATH"
+
+grep -q '"authorization": "Bearer sk-ant-oat-direct-token"' "$DIRECT_REQUEST_HEADERS"
+cmp -s "$PAYLOAD_PATH" "$DIRECT_REQUEST_BODY"
+
+grep -q '^innies_upstream_token_kind=anthropic_oauth$' "$OUT_DIR_FROM_LOG/comparison.txt"
+grep -q '^direct_only_header_names=user-agent$' "$OUT_DIR_FROM_LOG/comparison.txt"

--- a/scripts/tests/innies-compat-lane-compare.test.sh
+++ b/scripts/tests/innies-compat-lane-compare.test.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="$ROOT_DIR/scripts/innies-compat-lane-compare.sh"
+TMP_DIR="$(mktemp -d)"
+PAYLOAD_PATH="$TMP_DIR/payload.json"
+INNIES_REQUEST_HEADERS="$TMP_DIR/innies-request-headers.json"
+INNIES_REQUEST_BODY="$TMP_DIR/innies-request-body.json"
+DIRECT_REQUEST_HEADERS="$TMP_DIR/direct-request-headers.json"
+DIRECT_REQUEST_BODY="$TMP_DIR/direct-request-body.json"
+OUTPUT_PATH="$TMP_DIR/output.txt"
+INNIES_SERVER_LOG="$TMP_DIR/innies-server.log"
+DIRECT_SERVER_LOG="$TMP_DIR/direct-server.log"
+OUT_DIR="$TMP_DIR/out"
+
+cleanup() {
+  if [[ -n "${INNIES_SERVER_PID:-}" ]]; then
+    kill "$INNIES_SERVER_PID" >/dev/null 2>&1 || true
+    wait "$INNIES_SERVER_PID" 2>/dev/null || true
+  fi
+  if [[ -n "${DIRECT_SERVER_PID:-}" ]]; then
+    kill "$DIRECT_SERVER_PID" >/dev/null 2>&1 || true
+    wait "$DIRECT_SERVER_PID" 2>/dev/null || true
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+cat >"$PAYLOAD_PATH" <<'JSON'
+{"model":"claude-opus-4-6","stream":true,"max_tokens":16,"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}
+JSON
+
+cat >"$TMP_DIR/mock-server.mjs" <<'NODE'
+import { createServer } from 'node:http';
+import { writeFileSync } from 'node:fs';
+
+const port = Number(process.env.PORT);
+const mode = process.env.MODE;
+const headersPath = process.env.HEADERS_PATH;
+const bodyPath = process.env.BODY_PATH;
+
+const server = createServer((req, res) => {
+  const chunks = [];
+  req.on('data', (chunk) => chunks.push(chunk));
+  req.on('end', () => {
+    writeFileSync(headersPath, JSON.stringify({
+      method: req.method,
+      url: req.url,
+      headers: req.headers
+    }, null, 2));
+    writeFileSync(bodyPath, Buffer.concat(chunks).toString('utf8'));
+
+    if (mode === 'innies') {
+      res.statusCode = 400;
+      res.setHeader('content-type', 'application/json');
+      res.setHeader('x-request-id', 'req_issue80_innies_test');
+      res.setHeader('x-innies-token-credential-id', 'cred_issue80_test');
+      res.setHeader('x-innies-attempt-no', '1');
+      res.setHeader('x-innies-debug-upstream-target-url', 'https://api.anthropic.com/v1/messages');
+      res.setHeader('x-innies-debug-upstream-proxied-path', '/v1/messages');
+      res.setHeader('x-innies-debug-upstream-provider', 'anthropic');
+      res.setHeader('x-innies-debug-upstream-stream', 'true');
+      res.setHeader('x-innies-debug-upstream-token-kind', 'anthropic_oauth');
+      res.setHeader('x-innies-debug-upstream-authorization', 'Bearer <redacted:23>');
+      res.setHeader('x-innies-debug-upstream-anthropic-version', '2023-06-01');
+      res.setHeader('x-innies-debug-upstream-anthropic-beta', 'fine-grained-tool-streaming-2025-05-14,oauth-2025-04-20');
+      res.setHeader('x-innies-debug-upstream-accept', 'text/event-stream');
+      res.setHeader('x-innies-debug-upstream-request-id', 'req_issue80_innies_test');
+      res.setHeader('x-innies-debug-upstream-header-names', 'accept,anthropic-beta,anthropic-version,authorization,content-type,x-request-id');
+      res.end(JSON.stringify({
+        type: 'error',
+        error: { type: 'invalid_request_error', message: 'Error' },
+        request_id: 'req_upstream_innies_test'
+      }));
+      return;
+    }
+
+    res.statusCode = 200;
+    res.setHeader('content-type', 'application/json');
+    res.setHeader('request-id', 'req_upstream_direct_test');
+    res.end(JSON.stringify({ id: 'msg_direct_ok', type: 'message' }));
+  });
+});
+
+server.listen(port, '127.0.0.1', () => {
+  process.stdout.write(`ready:${port}\n`);
+});
+NODE
+
+start_server() {
+  local mode="$1"
+  local port_var="$2"
+  local log_path="$3"
+  local headers_path="$4"
+  local body_path="$5"
+  local pid_var="$6"
+  local port
+  port="$(node -e "const net=require('node:net');const s=net.createServer();s.listen(0,'127.0.0.1',()=>{const {port}=s.address();console.log(port);s.close();});")"
+  MODE="$mode" HEADERS_PATH="$headers_path" BODY_PATH="$body_path" PORT="$port" \
+    node "$TMP_DIR/mock-server.mjs" >"$log_path" 2>&1 &
+  local pid=$!
+  for _ in $(seq 1 50); do
+    if grep -q '^ready:' "$log_path" 2>/dev/null; then
+      printf -v "$port_var" '%s' "$port"
+      printf -v "$pid_var" '%s' "$pid"
+      return
+    fi
+    sleep 0.1
+  done
+  echo "server did not start: $mode"
+  cat "$log_path"
+  exit 1
+}
+
+start_server innies INNIES_PORT "$INNIES_SERVER_LOG" "$INNIES_REQUEST_HEADERS" "$INNIES_REQUEST_BODY" INNIES_SERVER_PID
+start_server direct DIRECT_PORT "$DIRECT_SERVER_LOG" "$DIRECT_REQUEST_HEADERS" "$DIRECT_REQUEST_BODY" DIRECT_SERVER_PID
+
+INNIES_BASE_URL="http://127.0.0.1:$INNIES_PORT" \
+INNIES_BUYER_API_KEY="buyer_test_token" \
+INNIES_REQUEST_ID="req_issue80_innies_test" \
+INNIES_LANE_OUT_DIR="$OUT_DIR" \
+ANTHROPIC_OAUTH_ACCESS_TOKEN="sk-ant-oat-direct-token" \
+ANTHROPIC_DIRECT_BASE_URL="http://127.0.0.1:$DIRECT_PORT" \
+ANTHROPIC_DIRECT_REQUEST_ID="req_issue80_direct_test" \
+ANTHROPIC_DIRECT_USER_AGENT="OpenClawGateway/1.0" \
+"$SCRIPT_PATH" "$PAYLOAD_PATH" >"$OUTPUT_PATH"
+
+grep -q 'innies_status=400' "$OUTPUT_PATH"
+grep -q 'direct_status=200' "$OUTPUT_PATH"
+grep -q 'direct_only_header_names=user-agent' "$OUTPUT_PATH"
+grep -q 'comparison_file=' "$OUTPUT_PATH"
+grep -q 'innies_forwarded_request_id=req_issue80_innies_test' "$OUTPUT_PATH"
+grep -q 'innies_provider_request_id=req_upstream_innies_test' "$OUTPUT_PATH"
+grep -q 'direct_provider_request_id=req_upstream_direct_test' "$OUTPUT_PATH"
+
+grep -q '"x-innies-debug-upstream-lane": "1"' "$INNIES_REQUEST_HEADERS"
+grep -q '"authorization": "Bearer buyer_test_token"' "$INNIES_REQUEST_HEADERS"
+grep -q '"authorization": "Bearer sk-ant-oat-direct-token"' "$DIRECT_REQUEST_HEADERS"
+grep -q '"user-agent": "OpenClawGateway/1.0"' "$DIRECT_REQUEST_HEADERS"
+
+cmp -s "$PAYLOAD_PATH" "$INNIES_REQUEST_BODY"
+cmp -s "$PAYLOAD_PATH" "$DIRECT_REQUEST_BODY"
+
+grep -q '^direct_only_header_names=user-agent$' "$OUT_DIR/comparison.txt"
+grep -q '^innies_only_header_names=$' "$OUT_DIR/comparison.txt"

--- a/scripts/tests/innies-compat-lane-compare.test.sh
+++ b/scripts/tests/innies-compat-lane-compare.test.sh
@@ -7,20 +7,30 @@ TMP_DIR="$(mktemp -d)"
 PAYLOAD_PATH="$TMP_DIR/payload.json"
 INNIES_REQUEST_HEADERS="$TMP_DIR/innies-request-headers.json"
 INNIES_REQUEST_BODY="$TMP_DIR/innies-request-body.json"
+INNIES_OPENAI_REQUEST_HEADERS="$TMP_DIR/innies-openai-request-headers.json"
+INNIES_OPENAI_REQUEST_BODY="$TMP_DIR/innies-openai-request-body.json"
 DIRECT_REQUEST_HEADERS="$TMP_DIR/direct-request-headers.json"
 DIRECT_REQUEST_BODY="$TMP_DIR/direct-request-body.json"
 OUTPUT_PATH="$TMP_DIR/output.txt"
 OUTPUT_FROM_LOG_PATH="$TMP_DIR/output-from-log.txt"
+OUTPUT_BAD_PROVIDER_PATH="$TMP_DIR/output-bad-provider.txt"
+OUTPUT_BAD_CAPTURED_PATH="$TMP_DIR/output-bad-captured.txt"
 INNIES_SERVER_LOG="$TMP_DIR/innies-server.log"
+INNIES_OPENAI_SERVER_LOG="$TMP_DIR/innies-openai-server.log"
 DIRECT_SERVER_LOG="$TMP_DIR/direct-server.log"
 OUT_DIR="$TMP_DIR/out"
 OUT_DIR_FROM_LOG="$TMP_DIR/out-from-log"
 CAPTURED_RESPONSE_HTML="$TMP_DIR/response.html"
+CAPTURED_OPENAI_RESPONSE_HTML="$TMP_DIR/response-openai.html"
 
 cleanup() {
   if [[ -n "${INNIES_SERVER_PID:-}" ]]; then
     kill "$INNIES_SERVER_PID" >/dev/null 2>&1 || true
     wait "$INNIES_SERVER_PID" 2>/dev/null || true
+  fi
+  if [[ -n "${INNIES_OPENAI_SERVER_PID:-}" ]]; then
+    kill "$INNIES_OPENAI_SERVER_PID" >/dev/null 2>&1 || true
+    wait "$INNIES_OPENAI_SERVER_PID" 2>/dev/null || true
   fi
   if [[ -n "${DIRECT_SERVER_PID:-}" ]]; then
     kill "$DIRECT_SERVER_PID" >/dev/null 2>&1 || true
@@ -42,6 +52,17 @@ const port = Number(process.env.PORT);
 const mode = process.env.MODE;
 const headersPath = process.env.HEADERS_PATH;
 const bodyPath = process.env.BODY_PATH;
+const upstreamProvider = process.env.UPSTREAM_PROVIDER ?? 'anthropic';
+const upstreamTargetUrl = process.env.UPSTREAM_TARGET_URL ?? 'https://api.anthropic.com/v1/messages';
+const upstreamProxiedPath = process.env.UPSTREAM_PROXIED_PATH ?? '/v1/messages';
+const upstreamTokenKind = process.env.UPSTREAM_TOKEN_KIND ?? 'anthropic_oauth';
+const upstreamAuthorization = process.env.UPSTREAM_AUTHORIZATION ?? 'Bearer <redacted:23>';
+const upstreamAnthropicVersion = process.env.UPSTREAM_ANTHROPIC_VERSION ?? '2023-06-01';
+const upstreamAnthropicBeta = process.env.UPSTREAM_ANTHROPIC_BETA ?? 'fine-grained-tool-streaming-2025-05-14,oauth-2025-04-20';
+const upstreamAccept = process.env.UPSTREAM_ACCEPT ?? 'text/event-stream';
+const upstreamHeaderNames = process.env.UPSTREAM_HEADER_NAMES ?? 'accept,anthropic-beta,anthropic-version,authorization,content-type,x-request-id';
+const upstreamRequestId = process.env.UPSTREAM_REQUEST_ID ?? 'req_issue80_innies_test';
+const upstreamProviderRequestId = process.env.UPSTREAM_PROVIDER_REQUEST_ID ?? 'req_upstream_innies_test';
 
 const server = createServer((req, res) => {
   const chunks = [];
@@ -57,24 +78,24 @@ const server = createServer((req, res) => {
     if (mode === 'innies') {
       res.statusCode = 400;
       res.setHeader('content-type', 'application/json');
-      res.setHeader('x-request-id', 'req_issue80_innies_test');
+      res.setHeader('x-request-id', upstreamRequestId);
       res.setHeader('x-innies-token-credential-id', 'cred_issue80_test');
       res.setHeader('x-innies-attempt-no', '1');
-      res.setHeader('x-innies-debug-upstream-target-url', 'https://api.anthropic.com/v1/messages');
-      res.setHeader('x-innies-debug-upstream-proxied-path', '/v1/messages');
-      res.setHeader('x-innies-debug-upstream-provider', 'anthropic');
+      res.setHeader('x-innies-debug-upstream-target-url', upstreamTargetUrl);
+      res.setHeader('x-innies-debug-upstream-proxied-path', upstreamProxiedPath);
+      res.setHeader('x-innies-debug-upstream-provider', upstreamProvider);
       res.setHeader('x-innies-debug-upstream-stream', 'true');
-      res.setHeader('x-innies-debug-upstream-token-kind', 'anthropic_oauth');
-      res.setHeader('x-innies-debug-upstream-authorization', 'Bearer <redacted:23>');
-      res.setHeader('x-innies-debug-upstream-anthropic-version', '2023-06-01');
-      res.setHeader('x-innies-debug-upstream-anthropic-beta', 'fine-grained-tool-streaming-2025-05-14,oauth-2025-04-20');
-      res.setHeader('x-innies-debug-upstream-accept', 'text/event-stream');
-      res.setHeader('x-innies-debug-upstream-request-id', 'req_issue80_innies_test');
-      res.setHeader('x-innies-debug-upstream-header-names', 'accept,anthropic-beta,anthropic-version,authorization,content-type,x-request-id');
+      res.setHeader('x-innies-debug-upstream-token-kind', upstreamTokenKind);
+      res.setHeader('x-innies-debug-upstream-authorization', upstreamAuthorization);
+      res.setHeader('x-innies-debug-upstream-anthropic-version', upstreamAnthropicVersion);
+      res.setHeader('x-innies-debug-upstream-anthropic-beta', upstreamAnthropicBeta);
+      res.setHeader('x-innies-debug-upstream-accept', upstreamAccept);
+      res.setHeader('x-innies-debug-upstream-request-id', upstreamRequestId);
+      res.setHeader('x-innies-debug-upstream-header-names', upstreamHeaderNames);
       res.end(JSON.stringify({
         type: 'error',
         error: { type: 'invalid_request_error', message: 'Error' },
-        request_id: 'req_upstream_innies_test'
+        request_id: upstreamProviderRequestId
       }));
       return;
     }
@@ -98,10 +119,17 @@ start_server() {
   local headers_path="$4"
   local body_path="$5"
   local pid_var="$6"
+  shift 6
+  local env_args=("$@")
   local port
   port="$(node -e "const net=require('node:net');const s=net.createServer();s.listen(0,'127.0.0.1',()=>{const {port}=s.address();console.log(port);s.close();});")"
-  MODE="$mode" HEADERS_PATH="$headers_path" BODY_PATH="$body_path" PORT="$port" \
-    node "$TMP_DIR/mock-server.mjs" >"$log_path" 2>&1 &
+  if (( ${#env_args[@]} > 0 )); then
+    env MODE="$mode" HEADERS_PATH="$headers_path" BODY_PATH="$body_path" PORT="$port" "${env_args[@]}" \
+      node "$TMP_DIR/mock-server.mjs" >"$log_path" 2>&1 &
+  else
+    env MODE="$mode" HEADERS_PATH="$headers_path" BODY_PATH="$body_path" PORT="$port" \
+      node "$TMP_DIR/mock-server.mjs" >"$log_path" 2>&1 &
+  fi
   local pid=$!
   for _ in $(seq 1 50); do
     if grep -q '^ready:' "$log_path" 2>/dev/null; then
@@ -117,6 +145,15 @@ start_server() {
 }
 
 start_server innies INNIES_PORT "$INNIES_SERVER_LOG" "$INNIES_REQUEST_HEADERS" "$INNIES_REQUEST_BODY" INNIES_SERVER_PID
+start_server innies INNIES_OPENAI_PORT "$INNIES_OPENAI_SERVER_LOG" "$INNIES_OPENAI_REQUEST_HEADERS" "$INNIES_OPENAI_REQUEST_BODY" INNIES_OPENAI_SERVER_PID \
+  "UPSTREAM_PROVIDER=openai" \
+  "UPSTREAM_TARGET_URL=https://chatgpt.com/backend-api/codex/responses" \
+  "UPSTREAM_PROXIED_PATH=/v1/responses" \
+  "UPSTREAM_TOKEN_KIND=openai_oauth" \
+  "UPSTREAM_AUTHORIZATION=Bearer <redacted:31>" \
+  "UPSTREAM_HEADER_NAMES=authorization,content-type,x-request-id" \
+  "UPSTREAM_REQUEST_ID=req_issue80_openai_test" \
+  "UPSTREAM_PROVIDER_REQUEST_ID=req_upstream_openai_test"
 start_server direct DIRECT_PORT "$DIRECT_SERVER_LOG" "$DIRECT_REQUEST_HEADERS" "$DIRECT_REQUEST_BODY" DIRECT_SERVER_PID
 
 INNIES_BASE_URL="http://127.0.0.1:$INNIES_PORT" \
@@ -138,6 +175,7 @@ grep -q 'innies_provider_request_id=req_upstream_innies_test' "$OUTPUT_PATH"
 grep -q 'direct_provider_request_id=req_upstream_direct_test' "$OUTPUT_PATH"
 
 grep -q '"x-innies-debug-upstream-lane": "1"' "$INNIES_REQUEST_HEADERS"
+grep -q '"x-innies-provider-pin": "true"' "$INNIES_REQUEST_HEADERS"
 grep -q '"authorization": "Bearer buyer_test_token"' "$INNIES_REQUEST_HEADERS"
 grep -q '"authorization": "Bearer sk-ant-oat-direct-token"' "$DIRECT_REQUEST_HEADERS"
 grep -q '"user-agent": "OpenClawGateway/1.0"' "$DIRECT_REQUEST_HEADERS"
@@ -147,6 +185,22 @@ cmp -s "$PAYLOAD_PATH" "$DIRECT_REQUEST_BODY"
 
 grep -q '^direct_only_header_names=user-agent$' "$OUT_DIR/comparison.txt"
 grep -q '^innies_only_header_names=$' "$OUT_DIR/comparison.txt"
+
+if INNIES_BASE_URL="http://127.0.0.1:$INNIES_OPENAI_PORT" \
+  INNIES_BUYER_API_KEY="buyer_test_token" \
+  INNIES_REQUEST_ID="req_issue80_openai_test" \
+  INNIES_LANE_OUT_DIR="$TMP_DIR/out-openai" \
+  ANTHROPIC_OAUTH_ACCESS_TOKEN="sk-ant-oat-direct-token" \
+  ANTHROPIC_DIRECT_BASE_URL="http://127.0.0.1:$DIRECT_PORT" \
+  ANTHROPIC_DIRECT_REQUEST_ID="req_issue80_direct_openai_test" \
+  ANTHROPIC_DIRECT_USER_AGENT="OpenClawGateway/1.0" \
+  "$SCRIPT_PATH" "$PAYLOAD_PATH" >"$OUTPUT_BAD_PROVIDER_PATH" 2>&1; then
+  echo 'expected live compare to fail when Innies routed to openai' >&2
+  exit 1
+fi
+
+grep -q 'error: live Innies lane resolved to openai; expected anthropic' "$OUTPUT_BAD_PROVIDER_PATH"
+grep -q '"x-innies-provider-pin": "true"' "$INNIES_OPENAI_REQUEST_HEADERS"
 
 cat >"$CAPTURED_RESPONSE_HTML" <<'LOG'
 Mar 17 11:10:39 sf-prod bash[263845]: [compat-upstream-request-json-chunk] {
@@ -184,3 +238,30 @@ cmp -s "$PAYLOAD_PATH" "$DIRECT_REQUEST_BODY"
 
 grep -q '^innies_upstream_token_kind=anthropic_oauth$' "$OUT_DIR_FROM_LOG/comparison.txt"
 grep -q '^direct_only_header_names=user-agent$' "$OUT_DIR_FROM_LOG/comparison.txt"
+
+cat >"$CAPTURED_OPENAI_RESPONSE_HTML" <<'LOG'
+Mar 17 11:10:39 sf-prod bash[263845]: [compat-upstream-request-json-chunk] {
+Mar 17 11:10:39 sf-prod bash[263845]:   chunk_index: 0,
+Mar 17 11:10:39 sf-prod bash[263845]:   chunk_count: 1,
+Mar 17 11:10:39 sf-prod bash[263845]:   json: '{"attempt_no":1,"credential_id":"cred_issue80_openai_from_log","credential_label":"codex","headers":{"authorization":"Bearer <redacted:96>","content-type":"application/json","x-request-id":"req_issue80_openai_from_log"},"method":"POST","model":"gpt-5.4","payload":{"model":"claude-opus-4-6","stream":true,"max_tokens":16,"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]},"provider":"openai","proxied_path":"/v1/responses","request_id":"req_issue80_openai_from_log","stream":true,"target_url":"https://chatgpt.com/backend-api/codex/responses"}'
+Mar 17 11:10:39 sf-prod bash[263845]: }
+Mar 17 11:10:39 sf-prod bash[263845]: [compat-upstream-response-json-chunk] {
+Mar 17 11:10:39 sf-prod bash[263845]:   chunk_index: 0,
+Mar 17 11:10:39 sf-prod bash[263845]:   chunk_count: 1,
+Mar 17 11:10:39 sf-prod bash[263845]:   json: '{"attempt_no":1,"credential_id":"cred_issue80_openai_from_log","credential_label":"codex","parsed_body":{"error":{"message":"Error","type":"invalid_request_error"},"request_id":"req_upstream_openai_from_log","type":"error"},"provider":"openai","proxied_path":"/v1/responses","request_id":"req_issue80_openai_from_log","response_headers":{"content-type":"application/json","request-id":"req_upstream_openai_from_log"},"stream":true,"target_url":"https://chatgpt.com/backend-api/codex/responses","upstream_content_type":"application/json","upstream_status":400}'
+Mar 17 11:10:39 sf-prod bash[263845]: }
+LOG
+
+if INNIES_CAPTURED_RESPONSE_HTML="$CAPTURED_OPENAI_RESPONSE_HTML" \
+  INNIES_CAPTURED_REQUEST_ID="req_issue80_openai_from_log" \
+  INNIES_LANE_OUT_DIR="$TMP_DIR/out-openai-from-log" \
+  ANTHROPIC_OAUTH_ACCESS_TOKEN="sk-ant-oat-direct-token" \
+  ANTHROPIC_DIRECT_BASE_URL="http://127.0.0.1:$DIRECT_PORT" \
+  ANTHROPIC_DIRECT_REQUEST_ID="req_issue80_direct_openai_from_log" \
+  ANTHROPIC_DIRECT_USER_AGENT="OpenClawGateway/1.0" \
+  "$SCRIPT_PATH" "$PAYLOAD_PATH" >"$OUTPUT_BAD_CAPTURED_PATH" 2>&1; then
+  echo 'expected captured compare to fail when captured lane is openai' >&2
+  exit 1
+fi
+
+grep -q 'error: captured Innies lane resolved to openai; expected anthropic' "$OUTPUT_BAD_CAPTURED_PATH"

--- a/scripts/tests/innies-compat-lane-provider-guard.test.sh
+++ b/scripts/tests/innies-compat-lane-provider-guard.test.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="$ROOT_DIR/scripts/innies-compat-lane-compare.sh"
+TMP_DIR="$(mktemp -d)"
+PAYLOAD_PATH="$TMP_DIR/payload.json"
+INNIES_HEADERS_PATH="$TMP_DIR/innies-headers.json"
+DIRECT_HEADERS_PATH="$TMP_DIR/direct-headers.json"
+INNIES_BODY_PATH="$TMP_DIR/innies-body.json"
+DIRECT_BODY_PATH="$TMP_DIR/direct-body.json"
+INNIES_LOG_PATH="$TMP_DIR/innies.log"
+DIRECT_LOG_PATH="$TMP_DIR/direct.log"
+STDOUT_PATH="$TMP_DIR/stdout.txt"
+STDERR_PATH="$TMP_DIR/stderr.txt"
+CAPTURED_HTML_PATH="$TMP_DIR/response.html"
+
+cleanup() {
+  if [[ -n "${INNIES_SERVER_PID:-}" ]]; then
+    kill "$INNIES_SERVER_PID" >/dev/null 2>&1 || true
+    wait "$INNIES_SERVER_PID" 2>/dev/null || true
+  fi
+  if [[ -n "${DIRECT_SERVER_PID:-}" ]]; then
+    kill "$DIRECT_SERVER_PID" >/dev/null 2>&1 || true
+    wait "$DIRECT_SERVER_PID" 2>/dev/null || true
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+cat >"$PAYLOAD_PATH" <<'JSON'
+{"model":"claude-opus-4-6","stream":true,"max_tokens":16,"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}
+JSON
+
+cat >"$TMP_DIR/mock-server.mjs" <<'NODE'
+import { createServer } from 'node:http';
+import { writeFileSync } from 'node:fs';
+
+const port = Number(process.env.PORT);
+const mode = process.env.MODE;
+const upstreamProvider = process.env.UPSTREAM_PROVIDER;
+const headersPath = process.env.HEADERS_PATH;
+const bodyPath = process.env.BODY_PATH;
+
+const server = createServer((req, res) => {
+  const chunks = [];
+  req.on('data', (chunk) => chunks.push(chunk));
+  req.on('end', () => {
+    writeFileSync(headersPath, JSON.stringify({
+      method: req.method,
+      url: req.url,
+      headers: req.headers
+    }, null, 2));
+    writeFileSync(bodyPath, Buffer.concat(chunks).toString('utf8'));
+
+    if (mode === 'innies') {
+      res.statusCode = 400;
+      res.setHeader('content-type', 'application/json');
+      res.setHeader('x-request-id', 'req_issue80_guard_innies');
+      res.setHeader('x-innies-token-credential-id', 'cred_issue80_guard');
+      res.setHeader('x-innies-attempt-no', '1');
+      res.setHeader('x-innies-debug-upstream-target-url', upstreamProvider === 'anthropic'
+        ? 'https://api.anthropic.com/v1/messages'
+        : 'https://chatgpt.com/backend-api/codex/responses');
+      res.setHeader('x-innies-debug-upstream-proxied-path', '/v1/messages');
+      res.setHeader('x-innies-debug-upstream-provider', upstreamProvider);
+      res.setHeader('x-innies-debug-upstream-stream', 'true');
+      res.setHeader('x-innies-debug-upstream-token-kind', upstreamProvider === 'anthropic' ? 'anthropic_oauth' : 'openai_oauth');
+      res.setHeader('x-innies-debug-upstream-authorization', 'Bearer <redacted:23>');
+      res.setHeader('x-innies-debug-upstream-anthropic-version', '2023-06-01');
+      res.setHeader('x-innies-debug-upstream-anthropic-beta', 'fine-grained-tool-streaming-2025-05-14');
+      res.setHeader('x-innies-debug-upstream-accept', 'text/event-stream');
+      res.setHeader('x-innies-debug-upstream-request-id', 'req_issue80_guard_innies');
+      res.setHeader('x-innies-debug-upstream-header-names', 'accept,anthropic-beta,anthropic-version,authorization,content-type,x-request-id');
+      res.end(JSON.stringify({
+        type: 'error',
+        error: { type: 'invalid_request_error', message: 'Error' },
+        request_id: upstreamProvider === 'anthropic'
+          ? 'req_upstream_guard_anthropic'
+          : 'req_upstream_guard_openai'
+      }));
+      return;
+    }
+
+    res.statusCode = 200;
+    res.setHeader('content-type', 'application/json');
+    res.setHeader('request-id', 'req_upstream_guard_direct');
+    res.end(JSON.stringify({ id: 'msg_direct_ok', type: 'message' }));
+  });
+});
+
+server.listen(port, '127.0.0.1', () => {
+  process.stdout.write(`ready:${port}\n`);
+});
+NODE
+
+start_server() {
+  local mode="$1"
+  local provider="$2"
+  local port_var="$3"
+  local log_path="$4"
+  local headers_path="$5"
+  local body_path="$6"
+  local pid_var="$7"
+  local port
+  port="$(node -e "const net=require('node:net');const s=net.createServer();s.listen(0,'127.0.0.1',()=>{const {port}=s.address();console.log(port);s.close();});")"
+  MODE="$mode" UPSTREAM_PROVIDER="$provider" HEADERS_PATH="$headers_path" BODY_PATH="$body_path" PORT="$port" \
+    node "$TMP_DIR/mock-server.mjs" >"$log_path" 2>&1 &
+  local pid=$!
+  for _ in $(seq 1 50); do
+    if grep -q '^ready:' "$log_path" 2>/dev/null; then
+      printf -v "$port_var" '%s' "$port"
+      printf -v "$pid_var" '%s' "$pid"
+      return
+    fi
+    sleep 0.1
+  done
+  echo "server did not start: $mode"
+  cat "$log_path"
+  exit 1
+}
+
+run_live_compare() {
+  local upstream_provider="$1"
+  : >"$STDOUT_PATH"
+  : >"$STDERR_PATH"
+
+  start_server innies "$upstream_provider" INNIES_PORT "$INNIES_LOG_PATH" "$INNIES_HEADERS_PATH" "$INNIES_BODY_PATH" INNIES_SERVER_PID
+  start_server direct anthropic DIRECT_PORT "$DIRECT_LOG_PATH" "$DIRECT_HEADERS_PATH" "$DIRECT_BODY_PATH" DIRECT_SERVER_PID
+
+  set +e
+  INNIES_BASE_URL="http://127.0.0.1:$INNIES_PORT" \
+  INNIES_BUYER_API_KEY="buyer_test_token" \
+  INNIES_REQUEST_ID="req_issue80_guard_innies" \
+  INNIES_LANE_OUT_DIR="$TMP_DIR/out-live-$upstream_provider" \
+  ANTHROPIC_OAUTH_ACCESS_TOKEN="sk-ant-oat-direct-token" \
+  ANTHROPIC_DIRECT_BASE_URL="http://127.0.0.1:$DIRECT_PORT" \
+  ANTHROPIC_DIRECT_REQUEST_ID="req_issue80_guard_direct" \
+  "$SCRIPT_PATH" "$PAYLOAD_PATH" >"$STDOUT_PATH" 2>"$STDERR_PATH"
+  local status=$?
+  set -e
+
+  kill "$INNIES_SERVER_PID" >/dev/null 2>&1 || true
+  wait "$INNIES_SERVER_PID" 2>/dev/null || true
+  unset INNIES_SERVER_PID
+  kill "$DIRECT_SERVER_PID" >/dev/null 2>&1 || true
+  wait "$DIRECT_SERVER_PID" 2>/dev/null || true
+  unset DIRECT_SERVER_PID
+
+  return "$status"
+}
+
+if ! run_live_compare anthropic; then
+  cat "$STDERR_PATH"
+  exit 1
+fi
+
+grep -q '"x-innies-provider-pin": "true"' "$INNIES_HEADERS_PATH"
+grep -q 'innies_upstream_provider=anthropic' "$STDOUT_PATH"
+
+if run_live_compare openai; then
+  echo 'expected openai Innies live lane to fail'
+  exit 1
+fi
+
+grep -q 'error: live Innies lane resolved to openai; expected anthropic' "$STDERR_PATH"
+
+cat >"$CAPTURED_HTML_PATH" <<'LOG'
+Mar 17 11:10:39 sf-prod bash[263845]: [compat-upstream-request-json-chunk] {
+Mar 17 11:10:39 sf-prod bash[263845]:   chunk_index: 0,
+Mar 17 11:10:39 sf-prod bash[263845]:   chunk_count: 1,
+Mar 17 11:10:39 sf-prod bash[263845]:   json: '{"attempt_no":1,"credential_id":"cred_issue80_from_log","headers":{"accept":"text/event-stream","anthropic-version":"2023-06-01","authorization":"Bearer <redacted:108>","content-type":"application/json","x-request-id":"req_issue80_from_log"},"provider":"openai","proxied_path":"/v1/messages","request_id":"req_issue80_from_log","stream":true,"target_url":"https://chatgpt.com/backend-api/codex/responses"}'
+Mar 17 11:10:39 sf-prod bash[263845]: }
+Mar 17 11:10:39 sf-prod bash[263845]: [compat-upstream-response-json-chunk] {
+Mar 17 11:10:39 sf-prod bash[263845]:   chunk_index: 0,
+Mar 17 11:10:39 sf-prod bash[263845]:   chunk_count: 1,
+Mar 17 11:10:39 sf-prod bash[263845]:   json: '{"attempt_no":1,"credential_id":"cred_issue80_from_log","parsed_body":{"error":{"message":"Error","type":"invalid_request_error"},"request_id":"req_upstream_from_log","type":"error"},"provider":"openai","proxied_path":"/v1/messages","request_id":"req_issue80_from_log","response_headers":{"content-type":"application/json","request-id":"req_upstream_from_log"},"stream":true,"target_url":"https://chatgpt.com/backend-api/codex/responses","upstream_content_type":"application/json","upstream_status":400}'
+Mar 17 11:10:39 sf-prod bash[263845]: }
+LOG
+
+start_server direct anthropic DIRECT_PORT "$DIRECT_LOG_PATH" "$DIRECT_HEADERS_PATH" "$DIRECT_BODY_PATH" DIRECT_SERVER_PID
+
+set +e
+INNIES_CAPTURED_RESPONSE_HTML="$CAPTURED_HTML_PATH" \
+INNIES_CAPTURED_REQUEST_ID="req_issue80_from_log" \
+INNIES_LANE_OUT_DIR="$TMP_DIR/out-captured-openai" \
+ANTHROPIC_OAUTH_ACCESS_TOKEN="sk-ant-oat-direct-token" \
+ANTHROPIC_DIRECT_BASE_URL="http://127.0.0.1:$DIRECT_PORT" \
+ANTHROPIC_DIRECT_REQUEST_ID="req_issue80_guard_direct" \
+"$SCRIPT_PATH" "$PAYLOAD_PATH" >"$STDOUT_PATH" 2>"$STDERR_PATH"
+CAPTURED_STATUS=$?
+set -e
+
+kill "$DIRECT_SERVER_PID" >/dev/null 2>&1 || true
+wait "$DIRECT_SERVER_PID" 2>/dev/null || true
+unset DIRECT_SERVER_PID
+
+if [[ "$CAPTURED_STATUS" -eq 0 ]]; then
+  echo 'expected captured openai Innies lane to fail'
+  exit 1
+fi
+
+grep -q 'error: captured Innies lane resolved to openai; expected anthropic' "$STDERR_PATH"


### PR DESCRIPTION
## Summary
- add the compat upstream lane comparison helper and debug-header plumbing needed for issue #80
- pin live helper runs to the Anthropic compat lane and fail fast when either live or captured-artifact evidence resolves to a non-Anthropic Innies lane
- cover the guard behavior with focused shell regressions and refresh the compat debug-header expectation for the current four-beta Anthropic OAuth lane

## Test Plan
- `cd api && npx vitest run tests/anthropicCompat.route.test.ts tests/proxy.tokenMode.route.test.ts --hookTimeout=30000`
- `cd api && npm run build`
- `bash scripts/tests/innies-compat-lane-compare.test.sh && bash scripts/tests/innies-compat-lane-provider-guard.test.sh && bash -n scripts/innies-compat-lane-compare.sh scripts/tests/innies-compat-lane-compare.test.sh scripts/tests/innies-compat-lane-provider-guard.test.sh`

Refs #80