### PR TITLE
chore: add captured anthropic lane replay helper

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -24,6 +24,7 @@ innies-buyer-key-create
 innies-buyer-preference-set
 innies-buyer-preference-get
 innies-buyer-preference-check
+innies-compat-captured-lane-replay
 innies-slo-check
 ```
 
@@ -39,6 +40,7 @@ What they do:
 - `innies-buyer-preference-set`: set a buyer key preference to `Claude Code`, `Codex`, or `null`
 - `innies-buyer-preference-get`: read the current buyer key preference
 - `innies-buyer-preference-check`: run the provider-preference canary after prompting for the expected provider (`Claude Code` or `Codex`)
+- `innies-compat-captured-lane-replay`: replay a preserved `/v1/messages` payload directly against Anthropic using the exact first-pass headers captured from an Innies compat upstream request
 - `innies-slo-check`: query analytics endpoints and report Phase 1 SLO pass/fail (TTFB p95, timeout rate, success rate, fallback rate); optional arg sets the window (default `24h`); exits 0 if all SLOs pass, 1 if any fail
 
 Behavior:
@@ -79,6 +81,9 @@ Behavior:
 - non-pinned buyer traffic always gets automatic cross-provider fallback to the other provider; flipping preference flips fallback order too
 - `innies-buyer-preference-set` prints the effective preferred provider plus the automatic fallback provider before sending the update
 - `innies-buyer-preference-check` now expects and validates the two-provider plan in DB evidence mode
+- `innies-compat-captured-lane-replay` needs a captured compat response HTML plus the matching request id so it can extract the exact first-pass Anthropic headers from `[compat-upstream-request-json-chunk]`
+- `innies-compat-captured-lane-replay` needs `ANTHROPIC_OAUTH_ACCESS_TOKEN` (or `ANTHROPIC_ACCESS_TOKEN` / `CLAUDE_CODE_OAUTH_TOKEN`) because it replays the captured header lane directly against Anthropic
+- `innies-compat-captured-lane-replay` refuses non-Anthropic captured lanes and payload-byte mismatches so the replay stays on the intended provider and body-held-constant path
 
 ## Env
 

--- a/scripts/innies-compat-captured-lane-replay.sh
+++ b/scripts/innies-compat-captured-lane-replay.sh
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_PATH" ]]; do
+  SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+  SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"
+  [[ "$SCRIPT_PATH" != /* ]] && SCRIPT_PATH="${SCRIPT_DIR}/${SCRIPT_PATH}"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+source "${SCRIPT_DIR}/_common.sh"
+
+extract_header() {
+  local name="$1"
+  local file="$2"
+  awk -F': ' -v header_name="$name" '
+    BEGIN { IGNORECASE = 1 }
+    tolower($1) == tolower(header_name) {
+      gsub("\r", "", $2)
+      print $2
+    }
+  ' "$file" | tail -1
+}
+
+extract_body_request_id() {
+  local file="$1"
+  sed -n 's/.*"request_id":"\([^"]*\)".*/\1/p' "$file" | head -n 1
+}
+
+resolve_direct_base_url() {
+  if [[ -n "${ANTHROPIC_DIRECT_BASE_URL:-}" ]]; then
+    printf '%s' "${ANTHROPIC_DIRECT_BASE_URL%/}"
+    return
+  fi
+  if [[ -n "${ANTHROPIC_BASE_URL:-}" ]]; then
+    printf '%s' "${ANTHROPIC_BASE_URL%/}"
+    return
+  fi
+  printf '%s' 'https://api.anthropic.com'
+}
+
+write_lines() {
+  local file="$1"
+  shift
+  printf '%s\n' "$@" >"$file"
+}
+
+extract_captured_request() {
+  local captured_html="$1"
+  local request_id="$2"
+  local headers_tsv="$3"
+  local meta_file="$4"
+  node - "$captured_html" "$request_id" "$headers_tsv" "$meta_file" <<'NODE'
+const fs = require('fs');
+
+const capturedHtmlPath = process.argv[2];
+const requestId = process.argv[3];
+const headersPath = process.argv[4];
+const metaPath = process.argv[5];
+
+function stripLogPrefix(line) {
+  return line.replace(/^.*?\]:\s*/, '');
+}
+
+function parseJsLiteral(literal) {
+  return Function('"use strict"; return (' + literal + ');')();
+}
+
+function parseSerializedValue(text) {
+  try {
+    return JSON.parse(text);
+  } catch {}
+  return parseJsLiteral(text);
+}
+
+function parseChunkSeries(lines, startIndex, label) {
+  const parts = [];
+  let expectedChunkCount = null;
+  let index = startIndex;
+  while (index < lines.length) {
+    const header = stripLogPrefix(lines[index]);
+    if (header !== `${label} {`) break;
+    const chunkIndexLine = stripLogPrefix(lines[index + 1] ?? '');
+    const chunkCountLine = stripLogPrefix(lines[index + 2] ?? '');
+    const jsonLine = stripLogPrefix(lines[index + 3] ?? '');
+    const closeLine = stripLogPrefix(lines[index + 4] ?? '');
+    const chunkIndexMatch = chunkIndexLine.match(/^chunk_index:\s*(\d+),?$/);
+    const chunkCountMatch = chunkCountLine.match(/^chunk_count:\s*(\d+),?$/);
+    const jsonMatch = jsonLine.match(/^json:\s*(.+)$/);
+    if (!chunkIndexMatch || !chunkCountMatch || !jsonMatch || closeLine !== '}') {
+      throw new Error(`Malformed ${label} chunk near line ${index + 1}`);
+    }
+    const chunkIndex = Number(chunkIndexMatch[1]);
+    const chunkCount = Number(chunkCountMatch[1]);
+    if (expectedChunkCount === null) {
+      expectedChunkCount = chunkCount;
+    } else if (expectedChunkCount !== chunkCount) {
+      throw new Error(`Mismatched ${label} chunk_count near line ${index + 1}`);
+    }
+    if (chunkIndex !== parts.length) {
+      throw new Error(`Out-of-order ${label} chunk_index near line ${index + 1}`);
+    }
+    parts.push(parseJsLiteral(jsonMatch[1]));
+    index += 5;
+    if (parts.length === expectedChunkCount) {
+      return { text: parts.join(''), nextIndex: index - 1 };
+    }
+  }
+  throw new Error(`Incomplete ${label} chunk series near line ${startIndex + 1}`);
+}
+
+const lines = fs.readFileSync(capturedHtmlPath, 'utf8').split(/\r?\n/);
+const upstreamRequests = [];
+for (let index = 0; index < lines.length; index += 1) {
+  const body = stripLogPrefix(lines[index]);
+  if (body === '[compat-upstream-request-json-chunk] {') {
+    const { text, nextIndex } = parseChunkSeries(lines, index, '[compat-upstream-request-json-chunk]');
+    upstreamRequests.push(parseSerializedValue(text));
+    index = nextIndex;
+  }
+}
+
+const request = upstreamRequests.find((value) => value?.request_id === requestId);
+if (!request) {
+  console.error(`error: no captured compat upstream request found for ${requestId}`);
+  process.exit(1);
+}
+
+const headers = request.headers && typeof request.headers === 'object' ? request.headers : {};
+const headerLines = Object.entries(headers).map(([name, value]) => `${name}\t${String(value)}`);
+fs.writeFileSync(headersPath, `${headerLines.join('\n')}\n`);
+fs.writeFileSync(metaPath, [
+  `captured_request_id=${request.request_id ?? ''}`,
+  `captured_provider=${request.provider ?? ''}`,
+  `captured_target_url=${request.target_url ?? ''}`,
+  `captured_proxied_path=${request.proxied_path ?? ''}`,
+  `captured_attempt_no=${request.attempt_no ?? ''}`,
+  `captured_stream=${String(Boolean(request.stream))}`,
+  `captured_body_bytes=${request.body_bytes ?? ''}`
+].join('\n') + '\n');
+NODE
+}
+
+PAYLOAD_PATH="${1:-${INNIES_REPLAY_PAYLOAD_PATH:-}}"
+require_nonempty 'payload path' "$PAYLOAD_PATH"
+
+if [[ ! -f "$PAYLOAD_PATH" ]]; then
+  echo "error: payload file not found: $PAYLOAD_PATH" >&2
+  exit 1
+fi
+
+CAPTURED_RESPONSE_HTML="${INNIES_CAPTURED_RESPONSE_HTML:-${INNIES_CAPTURED_LOG_PATH:-}}"
+CAPTURED_REQUEST_ID="${INNIES_CAPTURED_REQUEST_ID:-${INNIES_REQUEST_ID:-}}"
+require_nonempty 'captured response HTML' "$CAPTURED_RESPONSE_HTML"
+require_nonempty 'captured request id' "$CAPTURED_REQUEST_ID"
+
+if [[ ! -f "$CAPTURED_RESPONSE_HTML" ]]; then
+  echo "error: captured response HTML not found: $CAPTURED_RESPONSE_HTML" >&2
+  exit 1
+fi
+
+DIRECT_BASE_URL="$(resolve_direct_base_url)"
+ACCESS_TOKEN="${ANTHROPIC_OAUTH_ACCESS_TOKEN:-${ANTHROPIC_ACCESS_TOKEN:-${CLAUDE_CODE_OAUTH_TOKEN:-}}}"
+require_nonempty 'Anthropic OAuth access token' "$ACCESS_TOKEN"
+
+DIRECT_REQUEST_ID="${INNIES_DIRECT_REQUEST_ID:-req_issue80_direct_$(date -u +%Y%m%dT%H%M%SZ)}"
+OUT_DIR="${INNIES_REPLAY_OUT_DIR:-${TMPDIR:-/tmp}/innies-compat-captured-lane-replay-${DIRECT_REQUEST_ID}}"
+mkdir -p "$OUT_DIR"
+
+CAPTURED_HEADERS_FILE="$OUT_DIR/captured-headers.tsv"
+CAPTURED_META_FILE="$OUT_DIR/captured-meta.txt"
+DIRECT_HEADERS_FILE="$OUT_DIR/direct-headers.txt"
+DIRECT_BODY_FILE="$OUT_DIR/direct-body.txt"
+META_FILE="$OUT_DIR/meta.txt"
+PAYLOAD_BYTES="$(wc -c <"$PAYLOAD_PATH" | tr -d ' ')"
+
+extract_captured_request "$CAPTURED_RESPONSE_HTML" "$CAPTURED_REQUEST_ID" "$CAPTURED_HEADERS_FILE" "$CAPTURED_META_FILE"
+
+CAPTURED_PROVIDER=''
+CAPTURED_TARGET_URL=''
+CAPTURED_PROXIED_PATH=''
+CAPTURED_ATTEMPT_NO=''
+CAPTURED_STREAM=''
+CAPTURED_BODY_BYTES=''
+while IFS='=' read -r key value; do
+  case "$key" in
+    captured_provider) CAPTURED_PROVIDER="$value" ;;
+    captured_target_url) CAPTURED_TARGET_URL="$value" ;;
+    captured_proxied_path) CAPTURED_PROXIED_PATH="$value" ;;
+    captured_attempt_no) CAPTURED_ATTEMPT_NO="$value" ;;
+    captured_stream) CAPTURED_STREAM="$value" ;;
+    captured_body_bytes) CAPTURED_BODY_BYTES="$value" ;;
+  esac
+done <"$CAPTURED_META_FILE"
+
+CAPTURED_PROVIDER_NORMALIZED="$(printf '%s' "$CAPTURED_PROVIDER" | tr '[:upper:]' '[:lower:]')"
+if [[ "$CAPTURED_PROVIDER_NORMALIZED" != 'anthropic' ]]; then
+  echo "error: captured Innies lane resolved to ${CAPTURED_PROVIDER:-unknown}; expected anthropic" >&2
+  exit 1
+fi
+
+if [[ -n "$CAPTURED_BODY_BYTES" && "$CAPTURED_BODY_BYTES" != "$PAYLOAD_BYTES" ]]; then
+  echo "error: payload bytes ($PAYLOAD_BYTES) do not match captured body bytes ($CAPTURED_BODY_BYTES)" >&2
+  exit 1
+fi
+
+DIRECT_PATH="${CAPTURED_PROXIED_PATH:-/v1/messages}"
+declare -a DIRECT_CURL_ARGS
+DIRECT_CURL_ARGS=(
+  -sS
+  -D "$DIRECT_HEADERS_FILE"
+  -o "$DIRECT_BODY_FILE"
+  -w '%{http_code}'
+  -X POST "${DIRECT_BASE_URL}${DIRECT_PATH}"
+  --data-binary "@$PAYLOAD_PATH"
+  -H "Authorization: Bearer $ACCESS_TOKEN"
+)
+
+HAVE_DIRECT_REQUEST_ID='false'
+while IFS=$'\t' read -r header_name header_value; do
+  [[ -z "$header_name" ]] && continue
+  header_name_normalized="$(printf '%s' "$header_name" | tr '[:upper:]' '[:lower:]')"
+  case "$header_name_normalized" in
+    authorization|content-length|host)
+      continue
+      ;;
+    x-request-id)
+      DIRECT_CURL_ARGS+=(-H "x-request-id: $DIRECT_REQUEST_ID")
+      HAVE_DIRECT_REQUEST_ID='true'
+      ;;
+    *)
+      DIRECT_CURL_ARGS+=(-H "${header_name}: ${header_value}")
+      ;;
+  esac
+done <"$CAPTURED_HEADERS_FILE"
+
+if [[ "$HAVE_DIRECT_REQUEST_ID" != 'true' ]]; then
+  DIRECT_CURL_ARGS+=(-H "x-request-id: $DIRECT_REQUEST_ID")
+fi
+
+DIRECT_STATUS="$(curl "${DIRECT_CURL_ARGS[@]}")"
+PROVIDER_REQUEST_ID="$(extract_header 'request-id' "$DIRECT_HEADERS_FILE")"
+if [[ -z "$PROVIDER_REQUEST_ID" ]]; then
+  PROVIDER_REQUEST_ID="$(extract_body_request_id "$DIRECT_BODY_FILE")"
+fi
+
+OUTCOME='request_failed_otherwise'
+if [[ "$DIRECT_STATUS" =~ ^2 ]]; then
+  OUTCOME='request_succeeded'
+elif [[ "$DIRECT_STATUS" == '400' ]] && grep -q '"type":"invalid_request_error"' "$DIRECT_BODY_FILE"; then
+  OUTCOME='reproduced_invalid_request_error'
+fi
+
+META_LINES=(
+  "payload_path=$PAYLOAD_PATH"
+  "payload_bytes=$PAYLOAD_BYTES"
+  "captured_response_html=$CAPTURED_RESPONSE_HTML"
+  "captured_request_id=$CAPTURED_REQUEST_ID"
+  "captured_provider=${CAPTURED_PROVIDER:-}"
+  "captured_target_url=${CAPTURED_TARGET_URL:-}"
+  "captured_proxied_path=${CAPTURED_PROXIED_PATH:-}"
+  "captured_attempt_no=${CAPTURED_ATTEMPT_NO:-}"
+  "captured_stream=${CAPTURED_STREAM:-}"
+  "captured_body_bytes=${CAPTURED_BODY_BYTES:-}"
+  "direct_request_id=$DIRECT_REQUEST_ID"
+  "direct_status=$DIRECT_STATUS"
+  "provider_request_id=${PROVIDER_REQUEST_ID:-}"
+  "outcome=$OUTCOME"
+  "direct_base_url=$DIRECT_BASE_URL"
+  "direct_path=$DIRECT_PATH"
+  "captured_headers_file=$CAPTURED_HEADERS_FILE"
+  "captured_meta_file=$CAPTURED_META_FILE"
+  "direct_headers_file=$DIRECT_HEADERS_FILE"
+  "direct_body_file=$DIRECT_BODY_FILE"
+)
+
+write_lines "$META_FILE" "${META_LINES[@]}"
+printf '%s\n' "${META_LINES[@]}"
+echo "meta_file=$META_FILE"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,6 +17,7 @@ ln -sf "${ROOT_DIR}/scripts/innies-buyer-key-create.sh" "${BIN_DIR}/innies-buyer
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-set.sh" "${BIN_DIR}/innies-buyer-preference-set"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-get.sh" "${BIN_DIR}/innies-buyer-preference-get"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-check.sh" "${BIN_DIR}/innies-buyer-preference-check"
+ln -sf "${ROOT_DIR}/scripts/innies-compat-captured-lane-replay.sh" "${BIN_DIR}/innies-compat-captured-lane-replay"
 ln -sf "${ROOT_DIR}/scripts/innies-slo-check.sh" "${BIN_DIR}/innies-slo-check"
 
 rm -f \
@@ -48,6 +49,7 @@ echo "  ${BIN_DIR}/innies-buyer-key-create -> ${ROOT_DIR}/scripts/innies-buyer-k
 echo "  ${BIN_DIR}/innies-buyer-preference-set -> ${ROOT_DIR}/scripts/innies-buyer-preference-set.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-get -> ${ROOT_DIR}/scripts/innies-buyer-preference-get.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-check -> ${ROOT_DIR}/scripts/innies-buyer-preference-check.sh"
+echo "  ${BIN_DIR}/innies-compat-captured-lane-replay -> ${ROOT_DIR}/scripts/innies-compat-captured-lane-replay.sh"
 echo "  ${BIN_DIR}/innies-slo-check -> ${ROOT_DIR}/scripts/innies-slo-check.sh"
 echo
 echo 'If command not found, add ~/.local/bin to PATH:'

--- a/scripts/tests/innies-compat-captured-lane-replay.test.sh
+++ b/scripts/tests/innies-compat-captured-lane-replay.test.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="$ROOT_DIR/scripts/innies-compat-captured-lane-replay.sh"
+TMP_DIR="$(mktemp -d)"
+PAYLOAD_PATH="$TMP_DIR/payload.json"
+CAPTURED_HTML_PATH="$TMP_DIR/response.html"
+CAPTURED_OPENAI_HTML_PATH="$TMP_DIR/response-openai.html"
+CAPTURED_MISMATCH_HTML_PATH="$TMP_DIR/response-mismatch.html"
+REQUESTS_DIR="$TMP_DIR/requests"
+OUT_DIR="$TMP_DIR/out"
+GUARD_OUT_DIR="$TMP_DIR/out-openai"
+MISMATCH_OUT_DIR="$TMP_DIR/out-mismatch"
+STDOUT_PATH="$TMP_DIR/stdout.txt"
+STDERR_PATH="$TMP_DIR/stderr.txt"
+GUARD_STDOUT_PATH="$TMP_DIR/stdout-openai.txt"
+GUARD_STDERR_PATH="$TMP_DIR/stderr-openai.txt"
+MISMATCH_STDOUT_PATH="$TMP_DIR/stdout-mismatch.txt"
+MISMATCH_STDERR_PATH="$TMP_DIR/stderr-mismatch.txt"
+mkdir -p "$REQUESTS_DIR"
+
+cleanup() {
+  if [[ -n "${SERVER_PID:-}" ]]; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+cat >"$PAYLOAD_PATH" <<'JSON'
+{"model":"claude-opus-4-6","stream":true,"max_tokens":16,"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}
+JSON
+PAYLOAD_BYTES="$(wc -c <"$PAYLOAD_PATH" | tr -d ' ')"
+
+cat >"$CAPTURED_HTML_PATH" <<LOG
+Mar 17 13:22:53 sf-prod bash[12345]: [compat-upstream-request-json-chunk] {
+Mar 17 13:22:53 sf-prod bash[12345]:   chunk_index: 0,
+Mar 17 13:22:53 sf-prod bash[12345]:   chunk_count: 1,
+Mar 17 13:22:53 sf-prod bash[12345]:   json: '{"attempt_no":1,"body_bytes":${PAYLOAD_BYTES},"credential_id":"cred_issue80","headers":{"accept":"text/event-stream","anthropic-beta":"fine-grained-tool-streaming-2025-05-14,claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14","anthropic-dangerous-direct-browser-access":"true","anthropic-version":"2023-06-01","authorization":"Bearer <redacted:108>","content-type":"application/json","user-agent":"OpenClawGateway/1.0","x-app":"cli","x-request-id":"req_issue80_captured"},"provider":"anthropic","proxied_path":"/v1/messages","request_id":"req_issue80_captured","stream":true,"target_url":"https://api.anthropic.com/v1/messages"}'
+Mar 17 13:22:53 sf-prod bash[12345]: }
+LOG
+
+cat >"$CAPTURED_OPENAI_HTML_PATH" <<LOG
+Mar 17 13:22:53 sf-prod bash[12345]: [compat-upstream-request-json-chunk] {
+Mar 17 13:22:53 sf-prod bash[12345]:   chunk_index: 0,
+Mar 17 13:22:53 sf-prod bash[12345]:   chunk_count: 1,
+Mar 17 13:22:53 sf-prod bash[12345]:   json: '{"attempt_no":1,"body_bytes":${PAYLOAD_BYTES},"credential_id":"cred_issue80","headers":{"accept":"text/event-stream","anthropic-beta":"fine-grained-tool-streaming-2025-05-14","content-type":"application/json","x-request-id":"req_issue80_openai"},"provider":"openai","proxied_path":"/v1/messages","request_id":"req_issue80_openai","stream":true,"target_url":"https://api.anthropic.com/v1/messages"}'
+Mar 17 13:22:53 sf-prod bash[12345]: }
+LOG
+
+cat >"$CAPTURED_MISMATCH_HTML_PATH" <<LOG
+Mar 17 13:22:53 sf-prod bash[12345]: [compat-upstream-request-json-chunk] {
+Mar 17 13:22:53 sf-prod bash[12345]:   chunk_index: 0,
+Mar 17 13:22:53 sf-prod bash[12345]:   chunk_count: 1,
+Mar 17 13:22:53 sf-prod bash[12345]:   json: '{"attempt_no":1,"body_bytes":999999,"credential_id":"cred_issue80","headers":{"accept":"text/event-stream","anthropic-beta":"fine-grained-tool-streaming-2025-05-14","anthropic-version":"2023-06-01","content-type":"application/json","x-request-id":"req_issue80_mismatch"},"provider":"anthropic","proxied_path":"/v1/messages","request_id":"req_issue80_mismatch","stream":true,"target_url":"https://api.anthropic.com/v1/messages"}'
+Mar 17 13:22:53 sf-prod bash[12345]: }
+LOG
+
+cat >"$TMP_DIR/mock-server.mjs" <<'NODE'
+import { createServer } from 'node:http';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const port = Number(process.env.PORT);
+const requestsDir = process.env.REQUESTS_DIR;
+mkdirSync(requestsDir, { recursive: true });
+
+const server = createServer((req, res) => {
+  const chunks = [];
+  req.on('data', (chunk) => chunks.push(chunk));
+  req.on('end', () => {
+    const body = Buffer.concat(chunks).toString('utf8');
+    const requestId = req.headers['x-request-id'] || `unknown-${Date.now()}`;
+    writeFileSync(join(requestsDir, `${requestId}.json`), JSON.stringify({
+      method: req.method,
+      url: req.url,
+      headers: req.headers,
+      body: JSON.parse(body)
+    }, null, 2));
+
+    res.statusCode = 400;
+    res.setHeader('content-type', 'application/json');
+    res.setHeader('request-id', 'req_upstream_captured_lane');
+    res.end(JSON.stringify({
+      type: 'error',
+      error: { type: 'invalid_request_error', message: 'Error' },
+      request_id: 'req_upstream_captured_lane'
+    }));
+  });
+});
+
+server.listen(port, '127.0.0.1', () => {
+  process.stdout.write(`ready:${port}\n`);
+});
+NODE
+
+PORT="$(node -e "const net=require('node:net');const s=net.createServer();s.listen(0,'127.0.0.1',()=>{const {port}=s.address();console.log(port);s.close();});")"
+PORT="$PORT" REQUESTS_DIR="$REQUESTS_DIR" node "$TMP_DIR/mock-server.mjs" >"$TMP_DIR/server.log" 2>&1 &
+SERVER_PID=$!
+
+for _ in $(seq 1 50); do
+  if grep -q '^ready:' "$TMP_DIR/server.log" 2>/dev/null; then
+    break
+  fi
+  sleep 0.1
+done
+
+if ! grep -q '^ready:' "$TMP_DIR/server.log" 2>/dev/null; then
+  echo 'server did not start'
+  cat "$TMP_DIR/server.log"
+  exit 1
+fi
+
+set +e
+INNIES_CAPTURED_RESPONSE_HTML="$CAPTURED_HTML_PATH" \
+INNIES_CAPTURED_REQUEST_ID="req_issue80_captured" \
+INNIES_REPLAY_OUT_DIR="$OUT_DIR" \
+INNIES_DIRECT_REQUEST_ID="req_issue80_direct" \
+ANTHROPIC_OAUTH_ACCESS_TOKEN="sk-ant-oat-direct-token" \
+ANTHROPIC_DIRECT_BASE_URL="http://127.0.0.1:$PORT" \
+"$SCRIPT_PATH" "$PAYLOAD_PATH" >"$STDOUT_PATH" 2>"$STDERR_PATH"
+STATUS=$?
+set -e
+
+if [[ "$STATUS" -ne 0 ]]; then
+  cat "$STDERR_PATH"
+  exit 1
+fi
+
+[[ -f "$OUT_DIR/meta.txt" ]]
+[[ -f "$OUT_DIR/captured-headers.tsv" ]]
+[[ -f "$OUT_DIR/direct-headers.txt" ]]
+[[ -f "$OUT_DIR/direct-body.txt" ]]
+
+grep -q "payload_bytes=$PAYLOAD_BYTES" "$OUT_DIR/meta.txt"
+grep -q "captured_body_bytes=$PAYLOAD_BYTES" "$OUT_DIR/meta.txt"
+grep -q 'captured_request_id=req_issue80_captured' "$OUT_DIR/meta.txt"
+grep -q 'captured_provider=anthropic' "$OUT_DIR/meta.txt"
+grep -q 'direct_request_id=req_issue80_direct' "$OUT_DIR/meta.txt"
+grep -q 'direct_status=400' "$OUT_DIR/meta.txt"
+grep -q 'provider_request_id=req_upstream_captured_lane' "$OUT_DIR/meta.txt"
+grep -q 'outcome=reproduced_invalid_request_error' "$OUT_DIR/meta.txt"
+grep -q 'meta_file=' "$STDOUT_PATH"
+
+grep -q '"authorization": "Bearer sk-ant-oat-direct-token"' "$REQUESTS_DIR/req_issue80_direct.json"
+grep -q '"anthropic-dangerous-direct-browser-access": "true"' "$REQUESTS_DIR/req_issue80_direct.json"
+grep -q '"x-app": "cli"' "$REQUESTS_DIR/req_issue80_direct.json"
+grep -q '"user-agent": "OpenClawGateway/1.0"' "$REQUESTS_DIR/req_issue80_direct.json"
+grep -q '"anthropic-beta": "fine-grained-tool-streaming-2025-05-14,claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14"' "$REQUESTS_DIR/req_issue80_direct.json"
+grep -q '"x-request-id": "req_issue80_direct"' "$REQUESTS_DIR/req_issue80_direct.json"
+
+set +e
+INNIES_CAPTURED_RESPONSE_HTML="$CAPTURED_OPENAI_HTML_PATH" \
+INNIES_CAPTURED_REQUEST_ID="req_issue80_openai" \
+INNIES_REPLAY_OUT_DIR="$GUARD_OUT_DIR" \
+INNIES_DIRECT_REQUEST_ID="req_issue80_guard" \
+ANTHROPIC_OAUTH_ACCESS_TOKEN="sk-ant-oat-direct-token" \
+ANTHROPIC_DIRECT_BASE_URL="http://127.0.0.1:$PORT" \
+"$SCRIPT_PATH" "$PAYLOAD_PATH" >"$GUARD_STDOUT_PATH" 2>"$GUARD_STDERR_PATH"
+STATUS=$?
+set -e
+
+if [[ "$STATUS" -eq 0 ]]; then
+  echo 'expected non-anthropic provider guard to fail'
+  exit 1
+fi
+
+grep -q 'error: captured Innies lane resolved to openai; expected anthropic' "$GUARD_STDERR_PATH"
+
+set +e
+INNIES_CAPTURED_RESPONSE_HTML="$CAPTURED_MISMATCH_HTML_PATH" \
+INNIES_CAPTURED_REQUEST_ID="req_issue80_mismatch" \
+INNIES_REPLAY_OUT_DIR="$MISMATCH_OUT_DIR" \
+INNIES_DIRECT_REQUEST_ID="req_issue80_mismatch" \
+ANTHROPIC_OAUTH_ACCESS_TOKEN="sk-ant-oat-direct-token" \
+ANTHROPIC_DIRECT_BASE_URL="http://127.0.0.1:$PORT" \
+"$SCRIPT_PATH" "$PAYLOAD_PATH" >"$MISMATCH_STDOUT_PATH" 2>"$MISMATCH_STDERR_PATH"
+STATUS=$?
+set -e
+
+if [[ "$STATUS" -eq 0 ]]; then
+  echo 'expected payload byte mismatch guard to fail'
+  exit 1
+fi
+
+grep -q "error: payload bytes ($PAYLOAD_BYTES) do not match captured body bytes (999999)" "$MISMATCH_STDERR_PATH"


### PR DESCRIPTION
## Summary
- add `innies-compat-captured-lane-replay`, which extracts the exact captured compat upstream headers for one request id and replays the same payload directly against Anthropic
- fail fast when the captured provider is not Anthropic or the supplied payload bytes do not match the captured first-pass body size
- wire the helper into `scripts/install.sh` and `scripts/README.md`, and cover the happy path plus both guard rails with a focused shell regression

## Test Plan
- `bash scripts/tests/innies-compat-captured-lane-replay.test.sh`
- `bash -n scripts/innies-compat-captured-lane-replay.sh scripts/tests/innies-compat-captured-lane-replay.test.sh scripts/install.sh`
- `git diff --check`

## Notes
- I did not have a live direct Anthropic OAuth token in this shell, so the verification here is the focused mock-backed shell coverage rather than a real upstream replay from this machine

Refs #80
