### PR TITLE
chore: add issue 80 compat header matrix helper

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -24,6 +24,7 @@ innies-buyer-key-create
 innies-buyer-preference-set
 innies-buyer-preference-get
 innies-buyer-preference-check
+innies-compat-header-matrix
 innies-slo-check
 ```
 
@@ -39,6 +40,7 @@ What they do:
 - `innies-buyer-preference-set`: set a buyer key preference to `Claude Code`, `Codex`, or `null`
 - `innies-buyer-preference-get`: read the current buyer key preference
 - `innies-buyer-preference-check`: run the provider-preference canary after prompting for the expected provider (`Claude Code` or `Codex`)
+- `innies-compat-header-matrix`: reconstruct a captured Anthropic compat payload from a response artifact, replay a focused direct Anthropic header matrix, and write per-case request/response artifacts plus a summary
 - `innies-slo-check`: query analytics endpoints and report Phase 1 SLO pass/fail (TTFB p95, timeout rate, success rate, fallback rate); optional arg sets the window (default `24h`); exits 0 if all SLOs pass, 1 if any fail
 
 Behavior:
@@ -79,6 +81,8 @@ Behavior:
 - non-pinned buyer traffic always gets automatic cross-provider fallback to the other provider; flipping preference flips fallback order too
 - `innies-buyer-preference-set` prints the effective preferred provider plus the automatic fallback provider before sending the update
 - `innies-buyer-preference-check` now expects and validates the two-provider plan in DB evidence mode
+- `innies-compat-header-matrix` takes a captured response HTML path plus the Innies request id, rebuilds the logged payload with the same stable JSON shape, replays five first-pass header variants against direct Anthropic, and writes `payload.json`, `summary.txt`, and per-case `*-meta.txt` / `*-headers.txt` / `*-body.txt` files under `INNIES_HEADER_MATRIX_OUT_DIR` (default `/tmp`)
+- `innies-compat-header-matrix` needs `ANTHROPIC_OAUTH_ACCESS_TOKEN` (or `CLAUDE_OAUTH_ACCESS_TOKEN`) and uses `INNIES_CALLER_ANTHROPIC_BETA` to override the default caller-beta-only case when the captured first beta is not the caller lane you want to isolate
 
 ## Env
 

--- a/scripts/innies-compat-header-matrix.sh
+++ b/scripts/innies-compat-header-matrix.sh
@@ -1,0 +1,544 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_PATH" ]]; do
+  SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+  SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"
+  [[ "$SCRIPT_PATH" != /* ]] && SCRIPT_PATH="${SCRIPT_DIR}/${SCRIPT_PATH}"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+source "${SCRIPT_DIR}/_common.sh"
+
+resolve_direct_base_url() {
+  if [[ -n "${ANTHROPIC_DIRECT_BASE_URL:-}" ]]; then
+    printf '%s' "${ANTHROPIC_DIRECT_BASE_URL%/}"
+    return
+  fi
+  if [[ -n "${ANTHROPIC_BASE_URL:-}" ]]; then
+    printf '%s' "${ANTHROPIC_BASE_URL%/}"
+    return
+  fi
+  printf '%s' 'https://api.anthropic.com'
+}
+
+extract_header() {
+  local name="$1"
+  local file="$2"
+  awk -F': ' -v header_name="$name" '
+    BEGIN { IGNORECASE = 1 }
+    tolower($1) == tolower(header_name) {
+      gsub("\r", "", $2)
+      print $2
+    }
+  ' "$file" | tail -1
+}
+
+extract_body_request_id() {
+  local file="$1"
+  sed -n 's/.*"request_id":"\([^"]*\)".*/\1/p' "$file" | head -n 1
+}
+
+redact_bearer_value() {
+  local token="$1"
+  printf 'Bearer <redacted:%s>' "${#token}"
+}
+
+write_lines() {
+  local file="$1"
+  shift
+  printf '%s\n' "$@" >"$file"
+}
+
+load_captured_request() {
+  local captured_html="$1"
+  local request_id="$2"
+  local payload_path="$3"
+
+  node - "$captured_html" "$request_id" "$payload_path" <<'NODE'
+const { createHash } = require('node:crypto');
+const fs = require('node:fs');
+
+const capturedHtmlPath = process.argv[2];
+const requestId = process.argv[3];
+const payloadPath = process.argv[4];
+
+function stableJson(value) {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableJson(item)).join(',')}]`;
+  }
+  const entries = Object.entries(value).sort(([left], [right]) => left.localeCompare(right));
+  return `{${entries.map(([key, entryValue]) => `${JSON.stringify(key)}:${stableJson(entryValue)}`).join(',')}}`;
+}
+
+function sha256Hex(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function stripLogPrefix(line) {
+  return line.replace(/^.*?\]:\s*/, '');
+}
+
+function parseJsLiteral(literal) {
+  return Function('"use strict"; return (' + literal + ');')();
+}
+
+function parseSerializedValue(text) {
+  try {
+    return JSON.parse(text);
+  } catch {}
+  return parseJsLiteral(text);
+}
+
+function parseChunkSeries(lines, startIndex, label) {
+  const parts = [];
+  let expectedChunkCount = null;
+  let index = startIndex;
+  while (index < lines.length) {
+    const header = stripLogPrefix(lines[index]);
+    if (header !== `${label} {`) break;
+    const chunkIndexLine = stripLogPrefix(lines[index + 1] ?? '');
+    const chunkCountLine = stripLogPrefix(lines[index + 2] ?? '');
+    const jsonLine = stripLogPrefix(lines[index + 3] ?? '');
+    const closeLine = stripLogPrefix(lines[index + 4] ?? '');
+    const chunkIndexMatch = chunkIndexLine.match(/^chunk_index:\s*(\d+),?$/);
+    const chunkCountMatch = chunkCountLine.match(/^chunk_count:\s*(\d+),?$/);
+    const jsonMatch = jsonLine.match(/^json:\s*(.+)$/);
+    if (!chunkIndexMatch || !chunkCountMatch || !jsonMatch || closeLine !== '}') {
+      throw new Error(`Malformed ${label} chunk near line ${index + 1}`);
+    }
+    const chunkIndex = Number(chunkIndexMatch[1]);
+    const chunkCount = Number(chunkCountMatch[1]);
+    if (expectedChunkCount === null) expectedChunkCount = chunkCount;
+    if (expectedChunkCount !== chunkCount) {
+      throw new Error(`Mismatched ${label} chunk_count near line ${index + 1}`);
+    }
+    if (chunkIndex !== parts.length) {
+      throw new Error(`Out-of-order ${label} chunk_index near line ${index + 1}`);
+    }
+    parts.push(parseJsLiteral(jsonMatch[1]));
+    index += 5;
+    if (parts.length === expectedChunkCount) {
+      return { text: parts.join(''), nextIndex: index - 1 };
+    }
+  }
+  throw new Error(`Incomplete ${label} chunk series near line ${startIndex + 1}`);
+}
+
+function collectSeries(lines, label) {
+  const values = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    if (stripLogPrefix(lines[index]) !== `${label} {`) continue;
+    const { text, nextIndex } = parseChunkSeries(lines, index, label);
+    values.push({ rawText: text, value: parseSerializedValue(text) });
+    index = nextIndex;
+  }
+  return values;
+}
+
+function skipWhitespace(rawText, index) {
+  let cursor = index;
+  while (cursor < rawText.length && /\s/.test(rawText[cursor])) {
+    cursor += 1;
+  }
+  return cursor;
+}
+
+function consumeJsonString(rawText, startIndex) {
+  let cursor = startIndex + 1;
+  let escaped = false;
+  while (cursor < rawText.length) {
+    const char = rawText[cursor];
+    if (escaped) {
+      escaped = false;
+    } else if (char === '\\\\') {
+      escaped = true;
+    } else if (char === '"') {
+      return cursor + 1;
+    }
+    cursor += 1;
+  }
+  throw new Error('Unterminated JSON string while extracting raw payload');
+}
+
+function consumeJsonValue(rawText, startIndex) {
+  let cursor = skipWhitespace(rawText, startIndex);
+  const firstChar = rawText[cursor];
+  if (firstChar === '"') {
+    return consumeJsonString(rawText, cursor);
+  }
+  if (firstChar === '{' || firstChar === '[') {
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+    for (; cursor < rawText.length; cursor += 1) {
+      const char = rawText[cursor];
+      if (inString) {
+        if (escaped) {
+          escaped = false;
+        } else if (char === '\\\\') {
+          escaped = true;
+        } else if (char === '"') {
+          inString = false;
+        }
+        continue;
+      }
+      if (char === '"') {
+        inString = true;
+        continue;
+      }
+      if (char === '{' || char === '[') {
+        depth += 1;
+        continue;
+      }
+      if (char === '}' || char === ']') {
+        depth -= 1;
+        if (depth === 0) {
+          return cursor + 1;
+        }
+      }
+    }
+    throw new Error('Unterminated JSON object/array while extracting raw payload');
+  }
+  while (cursor < rawText.length && !/[,\]}]/.test(rawText[cursor])) {
+    cursor += 1;
+  }
+  return cursor;
+}
+
+function extractTopLevelJsonValue(rawText, key) {
+  let cursor = skipWhitespace(rawText, 0);
+  if (rawText[cursor] !== '{') return null;
+  cursor += 1;
+  while (cursor < rawText.length) {
+    cursor = skipWhitespace(rawText, cursor);
+    if (rawText[cursor] === '}') return null;
+    if (rawText[cursor] !== '"') {
+      throw new Error(`Malformed JSON object while extracting ${key}`);
+    }
+    const keyEnd = consumeJsonString(rawText, cursor);
+    const parsedKey = JSON.parse(rawText.slice(cursor, keyEnd));
+    cursor = skipWhitespace(rawText, keyEnd);
+    if (rawText[cursor] !== ':') {
+      throw new Error(`Missing colon after key ${parsedKey}`);
+    }
+    cursor = skipWhitespace(rawText, cursor + 1);
+    const valueStart = cursor;
+    const valueEnd = consumeJsonValue(rawText, valueStart);
+    if (parsedKey === key) {
+      return rawText.slice(valueStart, valueEnd);
+    }
+    cursor = skipWhitespace(rawText, valueEnd);
+    if (rawText[cursor] === ',') {
+      cursor += 1;
+      continue;
+    }
+    if (rawText[cursor] === '}') {
+      return null;
+    }
+  }
+  return null;
+}
+
+function normalizeCsv(values) {
+  return [...new Set(values.filter(Boolean).map((value) => String(value).trim()).filter(Boolean))]
+    .sort()
+    .join(',');
+}
+
+const lines = fs.readFileSync(capturedHtmlPath, 'utf8').split(/\r?\n/);
+const requestPayloads = collectSeries(lines, '[/v1/messages] request-payload-json-chunk');
+const invalidRequestPayloads = collectSeries(lines, '[compat-invalid-request-payload-json-chunk]');
+const upstreamRequests = collectSeries(lines, '[compat-upstream-request-json-chunk]');
+const upstreamResponses = collectSeries(lines, '[compat-upstream-response-json-chunk]');
+
+const requestPayload = requestPayloads.find((entry) => String(entry?.value?.requestIdHeader ?? '') === requestId);
+const invalidRequestPayload = invalidRequestPayloads.find((entry) => String(entry?.value?.request_id ?? '') === requestId);
+const upstreamRequest = upstreamRequests.find((entry) => String(entry?.value?.request_id ?? '') === requestId);
+const upstreamResponse = upstreamResponses.find((entry) => String(entry?.value?.request_id ?? '') === requestId);
+
+if (!requestPayload && !invalidRequestPayload) {
+  console.error(`error: no captured payload log found for ${requestId}`);
+  process.exit(1);
+}
+if (!upstreamRequest) {
+  console.error(`error: no captured upstream request log found for ${requestId}`);
+  process.exit(1);
+}
+if (!upstreamResponse) {
+  console.error(`error: no captured upstream response log found for ${requestId}`);
+  process.exit(1);
+}
+
+const payload = invalidRequestPayload?.value?.payload ?? requestPayload?.value?.body;
+let rawPayloadText = null;
+let payloadExtractionMode = 'stable_json_fallback';
+try {
+  rawPayloadText = invalidRequestPayload
+    ? extractTopLevelJsonValue(invalidRequestPayload.rawText, 'payload')
+    : extractTopLevelJsonValue(requestPayload?.rawText ?? '', 'body');
+} catch {
+  rawPayloadText = null;
+}
+const payloadText = rawPayloadText && rawPayloadText.length > 0
+  ? rawPayloadText
+  : stableJson(payload ?? null);
+if (rawPayloadText && rawPayloadText.length > 0) {
+  payloadExtractionMode = invalidRequestPayload ? 'raw_invalid_request_payload' : 'raw_request_payload';
+}
+fs.writeFileSync(payloadPath, payloadText);
+
+const headers = upstreamRequest.value.headers && typeof upstreamRequest.value.headers === 'object' ? upstreamRequest.value.headers : {};
+const responseHeaders = upstreamResponse.value.response_headers && typeof upstreamResponse.value.response_headers === 'object'
+  ? upstreamResponse.value.response_headers
+  : {};
+const parsedBody = upstreamResponse.value.parsed_body && typeof upstreamResponse.value.parsed_body === 'object'
+  ? upstreamResponse.value.parsed_body
+  : {};
+const providerRequestId = responseHeaders['request-id']
+  ?? responseHeaders['x-request-id']
+  ?? parsedBody.request_id
+  ?? '';
+
+const values = {
+  captured_request_id: String(requestId),
+  payload_bytes: String(Buffer.byteLength(payloadText, 'utf8')),
+  payload_sha256: sha256Hex(payloadText),
+  payload_extraction_mode: payloadExtractionMode,
+  captured_body_bytes: String(upstreamRequest.value.body_bytes ?? ''),
+  captured_body_sha256: String(upstreamRequest.value.body_sha256 ?? ''),
+  payload_matches_captured_sha: String(String(upstreamRequest.value.body_sha256 ?? '') === sha256Hex(payloadText)),
+  captured_status: String(upstreamResponse.value.upstream_status ?? ''),
+  captured_provider_request_id: String(providerRequestId),
+  captured_provider: String(upstreamRequest.value.provider ?? ''),
+  captured_target_url: String(upstreamRequest.value.target_url ?? ''),
+  captured_accept: String(headers.accept ?? 'text/event-stream'),
+  captured_content_type: String(headers['content-type'] ?? 'application/json'),
+  captured_anthropic_version: String(headers['anthropic-version'] ?? '2023-06-01'),
+  captured_anthropic_beta: String(headers['anthropic-beta'] ?? ''),
+  captured_dangerous_direct_browser_access: String(headers['anthropic-dangerous-direct-browser-access'] ?? ''),
+  captured_user_agent: String(headers['user-agent'] ?? ''),
+  captured_x_app: String(headers['x-app'] ?? ''),
+  captured_request_id_header: String(headers['x-request-id'] ?? ''),
+  captured_header_names: normalizeCsv(Object.keys(headers))
+};
+
+for (const [key, value] of Object.entries(values)) {
+  process.stdout.write(`${key}=${value}\n`);
+}
+NODE
+}
+
+CAPTURED_RESPONSE_HTML="${1:-${INNIES_CAPTURED_RESPONSE_HTML:-}}"
+CAPTURED_REQUEST_ID="${2:-${INNIES_CAPTURED_REQUEST_ID:-}}"
+require_nonempty 'captured response HTML' "$CAPTURED_RESPONSE_HTML"
+require_nonempty 'captured Innies request id' "$CAPTURED_REQUEST_ID"
+
+if [[ ! -f "$CAPTURED_RESPONSE_HTML" ]]; then
+  echo "error: captured response HTML not found: $CAPTURED_RESPONSE_HTML" >&2
+  exit 1
+fi
+
+DIRECT_TOKEN="${ANTHROPIC_OAUTH_ACCESS_TOKEN:-${CLAUDE_OAUTH_ACCESS_TOKEN:-}}"
+if [[ -z "$DIRECT_TOKEN" ]]; then
+  if ! DIRECT_TOKEN="$(prompt_secret 'Anthropic OAuth access token (press Enter to cancel)')"; then
+    exit 1
+  fi
+fi
+require_nonempty 'Anthropic OAuth access token' "$DIRECT_TOKEN"
+
+DIRECT_BASE_URL="$(resolve_direct_base_url)"
+OUT_DIR="${INNIES_HEADER_MATRIX_OUT_DIR:-${TMPDIR:-/tmp}/innies-compat-header-matrix-${CAPTURED_REQUEST_ID}}"
+PAYLOAD_PATH="$OUT_DIR/payload.json"
+SUMMARY_PATH="$OUT_DIR/summary.txt"
+CAPTURED_META_PATH="$OUT_DIR/captured-meta.txt"
+mkdir -p "$OUT_DIR"
+
+CAPTURED_STATUS=''
+CAPTURED_PROVIDER_REQUEST_ID=''
+CAPTURED_PROVIDER=''
+CAPTURED_TARGET_URL=''
+CAPTURED_ACCEPT=''
+CAPTURED_CONTENT_TYPE=''
+CAPTURED_ANTHROPIC_VERSION=''
+CAPTURED_ANTHROPIC_BETA=''
+CAPTURED_DANGEROUS_DIRECT_BROWSER_ACCESS=''
+CAPTURED_USER_AGENT=''
+CAPTURED_X_APP=''
+CAPTURED_REQUEST_ID_HEADER=''
+CAPTURED_HEADER_NAMES=''
+PAYLOAD_BYTES=''
+PAYLOAD_SHA256=''
+PAYLOAD_EXTRACTION_MODE=''
+CAPTURED_BODY_BYTES=''
+CAPTURED_BODY_SHA256=''
+PAYLOAD_MATCHES_CAPTURED_SHA=''
+
+while IFS='=' read -r key value; do
+  case "$key" in
+    payload_bytes) PAYLOAD_BYTES="$value" ;;
+    payload_sha256) PAYLOAD_SHA256="$value" ;;
+    payload_extraction_mode) PAYLOAD_EXTRACTION_MODE="$value" ;;
+    captured_body_bytes) CAPTURED_BODY_BYTES="$value" ;;
+    captured_body_sha256) CAPTURED_BODY_SHA256="$value" ;;
+    payload_matches_captured_sha) PAYLOAD_MATCHES_CAPTURED_SHA="$value" ;;
+    captured_status) CAPTURED_STATUS="$value" ;;
+    captured_provider_request_id) CAPTURED_PROVIDER_REQUEST_ID="$value" ;;
+    captured_provider) CAPTURED_PROVIDER="$value" ;;
+    captured_target_url) CAPTURED_TARGET_URL="$value" ;;
+    captured_accept) CAPTURED_ACCEPT="$value" ;;
+    captured_content_type) CAPTURED_CONTENT_TYPE="$value" ;;
+    captured_anthropic_version) CAPTURED_ANTHROPIC_VERSION="$value" ;;
+    captured_anthropic_beta) CAPTURED_ANTHROPIC_BETA="$value" ;;
+    captured_dangerous_direct_browser_access) CAPTURED_DANGEROUS_DIRECT_BROWSER_ACCESS="$value" ;;
+    captured_user_agent) CAPTURED_USER_AGENT="$value" ;;
+    captured_x_app) CAPTURED_X_APP="$value" ;;
+    captured_request_id_header) CAPTURED_REQUEST_ID_HEADER="$value" ;;
+    captured_header_names) CAPTURED_HEADER_NAMES="$value" ;;
+  esac
+done < <(load_captured_request "$CAPTURED_RESPONSE_HTML" "$CAPTURED_REQUEST_ID" "$PAYLOAD_PATH")
+
+CALLER_ANTHROPIC_BETA="${INNIES_CALLER_ANTHROPIC_BETA:-${CAPTURED_ANTHROPIC_BETA%%,*}}"
+if [[ -z "$CALLER_ANTHROPIC_BETA" ]]; then
+  CALLER_ANTHROPIC_BETA="$CAPTURED_ANTHROPIC_BETA"
+fi
+
+write_lines "$CAPTURED_META_PATH" \
+  "captured_response_html=$CAPTURED_RESPONSE_HTML" \
+  "captured_request_id=$CAPTURED_REQUEST_ID" \
+  "captured_status=${CAPTURED_STATUS:-}" \
+  "captured_provider_request_id=${CAPTURED_PROVIDER_REQUEST_ID:-}" \
+  "captured_provider=${CAPTURED_PROVIDER:-}" \
+  "captured_target_url=${CAPTURED_TARGET_URL:-}" \
+  "captured_header_names=${CAPTURED_HEADER_NAMES:-}" \
+  "captured_anthropic_beta=${CAPTURED_ANTHROPIC_BETA:-}" \
+  "captured_anthropic_version=${CAPTURED_ANTHROPIC_VERSION:-}" \
+  "captured_dangerous_direct_browser_access=${CAPTURED_DANGEROUS_DIRECT_BROWSER_ACCESS:-}" \
+  "captured_user_agent=${CAPTURED_USER_AGENT:-}" \
+  "captured_x_app=${CAPTURED_X_APP:-}" \
+  "captured_request_id_header=${CAPTURED_REQUEST_ID_HEADER:-}" \
+  "payload_path=$PAYLOAD_PATH" \
+  "payload_bytes=${PAYLOAD_BYTES:-}" \
+  "payload_sha256=${PAYLOAD_SHA256:-}" \
+  "payload_extraction_mode=${PAYLOAD_EXTRACTION_MODE:-}" \
+  "captured_body_bytes=${CAPTURED_BODY_BYTES:-}" \
+  "captured_body_sha256=${CAPTURED_BODY_SHA256:-}" \
+  "payload_matches_captured_sha=${PAYLOAD_MATCHES_CAPTURED_SHA:-}"
+
+CASE_LINES=()
+
+run_case() {
+  local case_id="$1"
+  local anthropic_beta="$2"
+  local include_identity_headers="$3"
+  local include_request_id_header="$4"
+
+  local request_id_header=''
+  local dangerous_header=''
+  local user_agent_header=''
+  local x_app_header=''
+  local header_names='accept,anthropic-beta,anthropic-version,authorization,content-type'
+  local headers_file="$OUT_DIR/${case_id}-headers.txt"
+  local body_file="$OUT_DIR/${case_id}-body.txt"
+  local meta_file="$OUT_DIR/${case_id}-meta.txt"
+  local case_status
+  local provider_request_id
+  local authorization_header
+  local header_args=(
+    -H "Authorization: Bearer $DIRECT_TOKEN"
+    -H "Content-Type: $CAPTURED_CONTENT_TYPE"
+    -H "Accept: $CAPTURED_ACCEPT"
+    -H "anthropic-version: $CAPTURED_ANTHROPIC_VERSION"
+    -H "anthropic-beta: $anthropic_beta"
+  )
+
+  if [[ "$include_identity_headers" == 'true' ]]; then
+    if [[ -n "$CAPTURED_DANGEROUS_DIRECT_BROWSER_ACCESS" ]]; then
+      dangerous_header="$CAPTURED_DANGEROUS_DIRECT_BROWSER_ACCESS"
+      header_args+=(-H "anthropic-dangerous-direct-browser-access: $dangerous_header")
+      header_names="${header_names},anthropic-dangerous-direct-browser-access"
+    fi
+    if [[ -n "$CAPTURED_USER_AGENT" ]]; then
+      user_agent_header="$CAPTURED_USER_AGENT"
+      header_args+=(-H "user-agent: $user_agent_header")
+      header_names="${header_names},user-agent"
+    fi
+    if [[ -n "$CAPTURED_X_APP" ]]; then
+      x_app_header="$CAPTURED_X_APP"
+      header_args+=(-H "x-app: $x_app_header")
+      header_names="${header_names},x-app"
+    fi
+  else
+    header_args+=(-H 'user-agent:')
+  fi
+
+  if [[ "$include_request_id_header" == 'true' ]]; then
+    request_id_header="${CAPTURED_REQUEST_ID}__${case_id}"
+    header_args+=(-H "x-request-id: $request_id_header")
+    header_names="${header_names},x-request-id"
+  fi
+
+  case_status="$(curl -sS -D "$headers_file" -o "$body_file" -w '%{http_code}' \
+    -X POST "${DIRECT_BASE_URL}/v1/messages" \
+    "${header_args[@]}" \
+    --data-binary @"$PAYLOAD_PATH")"
+
+  provider_request_id="$(extract_header 'request-id' "$headers_file")"
+  if [[ -z "$provider_request_id" ]]; then
+    provider_request_id="$(extract_body_request_id "$body_file")"
+  fi
+  authorization_header="$(redact_bearer_value "$DIRECT_TOKEN")"
+
+  write_lines "$meta_file" \
+    "case_id=$case_id" \
+    "status=$case_status" \
+    "provider_request_id=${provider_request_id:-}" \
+    "target_url=${DIRECT_BASE_URL}/v1/messages" \
+    "authorization=$authorization_header" \
+    "accept=$CAPTURED_ACCEPT" \
+    "content_type=$CAPTURED_CONTENT_TYPE" \
+    "anthropic_version=$CAPTURED_ANTHROPIC_VERSION" \
+    "anthropic_beta=$anthropic_beta" \
+    "dangerous_direct_browser_access=${dangerous_header:-}" \
+    "user_agent=${user_agent_header:-}" \
+    "x_app=${x_app_header:-}" \
+    "request_id_header=${request_id_header:-}" \
+    "header_names=$header_names" \
+    "headers_file=$headers_file" \
+    "body_file=$body_file"
+
+  CASE_LINES+=("case=$case_id status=$case_status provider_request_id=${provider_request_id:-} anthropic_beta=$anthropic_beta x_app=${x_app_header:-} user_agent=${user_agent_header:-} dangerous_direct_browser_access=${dangerous_header:-} request_id_header=${request_id_header:-}")
+}
+
+run_case 'captured-baseline' "$CAPTURED_ANTHROPIC_BETA" 'true' 'true'
+run_case 'caller-beta-only' "$CALLER_ANTHROPIC_BETA" 'true' 'true'
+run_case 'identity-headers-removed' "$CAPTURED_ANTHROPIC_BETA" 'false' 'true'
+run_case 'caller-beta-only-no-identity-headers' "$CALLER_ANTHROPIC_BETA" 'false' 'true'
+run_case 'no-request-id' "$CAPTURED_ANTHROPIC_BETA" 'true' 'false'
+
+SUMMARY_LINES=(
+  "captured_response_html=$CAPTURED_RESPONSE_HTML"
+  "captured_request_id=$CAPTURED_REQUEST_ID"
+  "captured_status=${CAPTURED_STATUS:-}"
+  "captured_provider_request_id=${CAPTURED_PROVIDER_REQUEST_ID:-}"
+  "captured_provider=${CAPTURED_PROVIDER:-}"
+  "captured_target_url=${CAPTURED_TARGET_URL:-}"
+  "captured_header_names=${CAPTURED_HEADER_NAMES:-}"
+  "captured_anthropic_beta=${CAPTURED_ANTHROPIC_BETA:-}"
+  "captured_anthropic_version=${CAPTURED_ANTHROPIC_VERSION:-}"
+  "payload_path=$PAYLOAD_PATH"
+  "payload_bytes=${PAYLOAD_BYTES:-}"
+  "payload_sha256=${PAYLOAD_SHA256:-}"
+  "payload_extraction_mode=${PAYLOAD_EXTRACTION_MODE:-}"
+  "captured_body_bytes=${CAPTURED_BODY_BYTES:-}"
+  "captured_body_sha256=${CAPTURED_BODY_SHA256:-}"
+  "payload_matches_captured_sha=${PAYLOAD_MATCHES_CAPTURED_SHA:-}"
+  "case_count=${#CASE_LINES[@]}"
+)
+
+write_lines "$SUMMARY_PATH" "${SUMMARY_LINES[@]}" "${CASE_LINES[@]}"
+cat "$SUMMARY_PATH"
+printf 'summary_file=%s\n' "$SUMMARY_PATH"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,6 +18,7 @@ ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-set.sh" "${BIN_DIR}/innies-b
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-get.sh" "${BIN_DIR}/innies-buyer-preference-get"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-check.sh" "${BIN_DIR}/innies-buyer-preference-check"
 ln -sf "${ROOT_DIR}/scripts/innies-slo-check.sh" "${BIN_DIR}/innies-slo-check"
+ln -sf "${ROOT_DIR}/scripts/innies-compat-header-matrix.sh" "${BIN_DIR}/innies-compat-header-matrix"
 
 rm -f \
   "${BIN_DIR}/innies-admin" \
@@ -49,6 +50,7 @@ echo "  ${BIN_DIR}/innies-buyer-preference-set -> ${ROOT_DIR}/scripts/innies-buy
 echo "  ${BIN_DIR}/innies-buyer-preference-get -> ${ROOT_DIR}/scripts/innies-buyer-preference-get.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-check -> ${ROOT_DIR}/scripts/innies-buyer-preference-check.sh"
 echo "  ${BIN_DIR}/innies-slo-check -> ${ROOT_DIR}/scripts/innies-slo-check.sh"
+echo "  ${BIN_DIR}/innies-compat-header-matrix -> ${ROOT_DIR}/scripts/innies-compat-header-matrix.sh"
 echo
 echo 'If command not found, add ~/.local/bin to PATH:'
 echo '  export PATH="$HOME/.local/bin:$PATH"'

--- a/scripts/tests/innies-compat-header-matrix.test.sh
+++ b/scripts/tests/innies-compat-header-matrix.test.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="$ROOT_DIR/scripts/innies-compat-header-matrix.sh"
+TMP_DIR="$(mktemp -d)"
+CAPTURED_HTML="$TMP_DIR/captured-response.html"
+REQUESTS_JSON="$TMP_DIR/requests.json"
+SERVER_LOG="$TMP_DIR/server.log"
+SUMMARY_PATH="$TMP_DIR/matrix-out/summary.txt"
+PAYLOAD_PATH="$TMP_DIR/matrix-out/payload.json"
+OUTPUT_PATH="$TMP_DIR/output.txt"
+
+cleanup() {
+  if [[ -n "${SERVER_PID:-}" ]]; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+cat >"$TMP_DIR/build-fixture.mjs" <<'NODE'
+import { createHash } from 'node:crypto';
+import { writeFileSync } from 'node:fs';
+
+const htmlPath = process.argv[2];
+
+function stableJson(value) {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableJson(item)).join(',')}]`;
+  }
+  const entries = Object.entries(value).sort(([left], [right]) => left.localeCompare(right));
+  return `{${entries.map(([key, entryValue]) => `${JSON.stringify(key)}:${stableJson(entryValue)}`).join(',')}}`;
+}
+
+function emitChunks(label, value, chunkSize = 160) {
+  const json = stableJson(value);
+  const chunkCount = Math.max(1, Math.ceil(json.length / chunkSize));
+  const lines = [];
+  for (let chunkIndex = 0; chunkIndex < chunkCount; chunkIndex += 1) {
+    lines.push(`fixture]: ${label} {`);
+    lines.push(`fixture]:   chunk_index: ${chunkIndex},`);
+    lines.push(`fixture]:   chunk_count: ${chunkCount},`);
+    lines.push(`fixture]:   json: ${JSON.stringify(json.slice(chunkIndex * chunkSize, (chunkIndex + 1) * chunkSize))}`);
+    lines.push('fixture]: }');
+  }
+  return lines;
+}
+
+const requestId = 'req_issue80_matrix';
+const payload = {
+  max_tokens: 16384,
+  messages: [
+    {
+      role: 'user',
+      content: [{ type: 'text', text: 'hello from issue 80 matrix' }]
+    }
+  ],
+  model: 'claude-opus-4-6',
+  stream: true,
+  system: 'keep tools and streaming intact'
+};
+const payloadText = stableJson(payload);
+const payloadSha = createHash('sha256').update(payloadText).digest('hex');
+
+const requestPayloadLog = {
+  method: 'POST',
+  path: '/v1/messages',
+  requestIdHeader: requestId,
+  body: payload
+};
+
+const upstreamRequestLog = {
+  request_id: requestId,
+  attempt_no: 1,
+  credential_id: 'cred_issue80_matrix',
+  credential_label: 'aelix',
+  provider: 'anthropic',
+  model: 'claude-opus-4-6',
+  proxied_path: '/v1/messages',
+  target_url: 'https://api.anthropic.com/v1/messages',
+  method: 'POST',
+  stream: true,
+  headers: {
+    accept: 'text/event-stream',
+    'anthropic-beta': 'fine-grained-tool-streaming-2025-05-14,claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14',
+    'anthropic-dangerous-direct-browser-access': 'true',
+    'anthropic-version': '2023-06-01',
+    authorization: 'Bearer <redacted:108>',
+    'content-type': 'application/json',
+    'user-agent': 'OpenClawGateway/1.0',
+    'x-app': 'cli',
+    'x-request-id': requestId
+  },
+  body_bytes: Buffer.byteLength(payloadText, 'utf8'),
+  body_sha256: payloadSha
+};
+
+const upstreamResponseLog = {
+  request_id: requestId,
+  attempt_no: 1,
+  credential_id: 'cred_issue80_matrix',
+  credential_label: 'aelix',
+  provider: 'anthropic',
+  model: 'claude-opus-4-6',
+  proxied_path: '/v1/messages',
+  target_url: 'https://api.anthropic.com/v1/messages',
+  upstream_status: 400,
+  parsed_body: {
+    type: 'error',
+    error: {
+      type: 'invalid_request_error',
+      message: 'Error'
+    },
+    request_id: 'req_upstream_captured'
+  },
+  response_headers: {
+    'request-id': 'req_upstream_captured'
+  }
+};
+
+const lines = [
+  ...emitChunks('[/v1/messages] request-payload-json-chunk', requestPayloadLog),
+  ...emitChunks('[compat-upstream-request-json-chunk]', upstreamRequestLog),
+  ...emitChunks('[compat-upstream-response-json-chunk]', upstreamResponseLog)
+];
+
+writeFileSync(htmlPath, `${lines.join('\n')}\n`);
+NODE
+
+node "$TMP_DIR/build-fixture.mjs" "$CAPTURED_HTML"
+
+cat >"$TMP_DIR/server.mjs" <<'NODE'
+import { createServer } from 'node:http';
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const port = Number(process.env.PORT);
+const requestsPath = process.env.REQUESTS_PATH;
+let requestCount = 0;
+
+const server = createServer((req, res) => {
+  const chunks = [];
+  req.on('data', (chunk) => chunks.push(chunk));
+  req.on('end', () => {
+    requestCount += 1;
+    const existing = JSON.parse(readFileSync(requestsPath, 'utf8'));
+    existing.push({
+      index: requestCount,
+      method: req.method,
+      url: req.url,
+      headers: req.headers,
+      body: Buffer.concat(chunks).toString('utf8')
+    });
+    writeFileSync(requestsPath, JSON.stringify(existing, null, 2));
+
+    res.statusCode = 400;
+    res.setHeader('content-type', 'application/json');
+    res.setHeader('request-id', `req_upstream_case_${requestCount}`);
+    res.end(JSON.stringify({
+      type: 'error',
+      error: { type: 'invalid_request_error', message: 'Error' },
+      request_id: `req_upstream_case_${requestCount}`
+    }));
+  });
+});
+
+server.listen(port, '127.0.0.1', () => {
+  process.stdout.write(`ready:${port}\n`);
+});
+NODE
+
+printf '[]\n' >"$REQUESTS_JSON"
+PORT="$(node -e "const net=require('node:net');const server=net.createServer();server.listen(0,'127.0.0.1',()=>{const address=server.address();console.log(address.port);server.close();});")"
+REQUESTS_PATH="$REQUESTS_JSON" PORT="$PORT" node "$TMP_DIR/server.mjs" >"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+
+for _ in $(seq 1 50); do
+  if grep -q '^ready:' "$SERVER_LOG" 2>/dev/null; then
+    break
+  fi
+  sleep 0.1
+done
+
+if ! grep -q '^ready:' "$SERVER_LOG" 2>/dev/null; then
+  echo "server did not start"
+  cat "$SERVER_LOG"
+  exit 1
+fi
+
+ANTHROPIC_DIRECT_BASE_URL="http://127.0.0.1:$PORT" \
+ANTHROPIC_OAUTH_ACCESS_TOKEN="sk-ant-oat-test-token" \
+INNIES_HEADER_MATRIX_OUT_DIR="$TMP_DIR/matrix-out" \
+"$SCRIPT_PATH" "$CAPTURED_HTML" "req_issue80_matrix" >"$OUTPUT_PATH" 2>&1
+
+grep -q 'payload_matches_captured_sha=true' "$OUTPUT_PATH"
+grep -q 'case_count=5' "$OUTPUT_PATH"
+grep -q 'case=captured-baseline status=400 provider_request_id=req_upstream_case_1' "$OUTPUT_PATH"
+grep -q 'case=caller-beta-only status=400 provider_request_id=req_upstream_case_2' "$OUTPUT_PATH"
+grep -q 'case=identity-headers-removed status=400 provider_request_id=req_upstream_case_3' "$OUTPUT_PATH"
+grep -q 'case=caller-beta-only-no-identity-headers status=400 provider_request_id=req_upstream_case_4' "$OUTPUT_PATH"
+grep -q 'case=no-request-id status=400 provider_request_id=req_upstream_case_5' "$OUTPUT_PATH"
+
+test -f "$SUMMARY_PATH"
+test -f "$PAYLOAD_PATH"
+
+node - "$REQUESTS_JSON" "$PAYLOAD_PATH" <<'NODE'
+const fs = require('fs');
+
+const requests = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+const payload = fs.readFileSync(process.argv[3], 'utf8');
+
+if (requests.length !== 5) {
+  console.error(`expected 5 requests, saw ${requests.length}`);
+  process.exit(1);
+}
+
+const byIndex = new Map(requests.map((entry) => [entry.index, entry]));
+
+function requireHeader(index, name, expected) {
+  const actual = byIndex.get(index)?.headers?.[name];
+  if (actual !== expected) {
+    console.error(`request ${index} expected header ${name}=${expected}, got ${actual}`);
+    process.exit(1);
+  }
+}
+
+function requireMissingHeader(index, name) {
+  if (Object.prototype.hasOwnProperty.call(byIndex.get(index)?.headers ?? {}, name)) {
+    console.error(`request ${index} should not send header ${name}`);
+    process.exit(1);
+  }
+}
+
+for (const entry of requests) {
+  if (entry.body !== payload) {
+    console.error(`request ${entry.index} body mismatch`);
+    process.exit(1);
+  }
+}
+
+requireHeader(1, 'anthropic-beta', 'fine-grained-tool-streaming-2025-05-14,claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14');
+requireHeader(1, 'anthropic-dangerous-direct-browser-access', 'true');
+requireHeader(1, 'user-agent', 'OpenClawGateway/1.0');
+requireHeader(1, 'x-app', 'cli');
+requireHeader(1, 'x-request-id', 'req_issue80_matrix__captured-baseline');
+
+requireHeader(2, 'anthropic-beta', 'fine-grained-tool-streaming-2025-05-14');
+requireHeader(2, 'x-request-id', 'req_issue80_matrix__caller-beta-only');
+
+requireMissingHeader(3, 'anthropic-dangerous-direct-browser-access');
+requireMissingHeader(3, 'user-agent');
+requireMissingHeader(3, 'x-app');
+requireHeader(3, 'x-request-id', 'req_issue80_matrix__identity-headers-removed');
+
+requireHeader(4, 'anthropic-beta', 'fine-grained-tool-streaming-2025-05-14');
+requireMissingHeader(4, 'anthropic-dangerous-direct-browser-access');
+requireMissingHeader(4, 'user-agent');
+requireMissingHeader(4, 'x-app');
+requireHeader(4, 'x-request-id', 'req_issue80_matrix__caller-beta-only-no-identity-headers');
+
+requireMissingHeader(5, 'x-request-id');
+NODE


### PR DESCRIPTION
## Summary
- add `scripts/innies-compat-header-matrix.sh` so issue #80 can rebuild a captured Anthropic compat failure from prod logs and replay five first-pass header variants against direct Anthropic
- wire the helper into `scripts/install.sh` and `scripts/README.md`, and cover it with a focused shell regression test
- validate the real `response_1773768207701.html` artifact enough to confirm the captured header set and payload-exactness gap: the current artifact supports a replayable stable-JSON fallback, but not a byte-identical upstream body replay yet

## Test Plan
- `bash scripts/tests/innies-compat-header-matrix.test.sh`
- `bash -n scripts/innies-compat-header-matrix.sh scripts/tests/innies-compat-header-matrix.test.sh scripts/install.sh`
- `git diff --check origin/main...HEAD`

## Notes
- I also exercised the helper against the real issue-80 artifact `/Users/dylanvu/Downloads/response_1773768207701.html` via a local stub server to verify the extracted case set and summary output.
- A live direct Anthropic matrix run is still pending because this shell session does not have `ANTHROPIC_OAUTH_ACCESS_TOKEN` or `CLAUDE_OAUTH_ACCESS_TOKEN` loaded.

Refs #80
