### PR TITLE
chore: add issue 80 compat artifact extraction helper

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -24,6 +24,7 @@ innies-buyer-key-create
 innies-buyer-preference-set
 innies-buyer-preference-get
 innies-buyer-preference-check
+innies-compat-artifact-extract
 innies-slo-check
 ```
 
@@ -39,6 +40,7 @@ What they do:
 - `innies-buyer-preference-set`: set a buyer key preference to `Claude Code`, `Codex`, or `null`
 - `innies-buyer-preference-get`: read the current buyer key preference
 - `innies-buyer-preference-check`: run the provider-preference canary after prompting for the expected provider (`Claude Code` or `Codex`)
+- `innies-compat-artifact-extract`: extract the first-pass Anthropic compat request/response pair for one `request_id` from a saved prod HTML/log artifact, then write structured JSON files plus a summary for issue `#80` replay/diff work
 - `innies-slo-check`: query analytics endpoints and report Phase 1 SLO pass/fail (TTFB p95, timeout rate, success rate, fallback rate); optional arg sets the window (default `24h`); exits 0 if all SLOs pass, 1 if any fail
 
 Behavior:
@@ -79,6 +81,9 @@ Behavior:
 - non-pinned buyer traffic always gets automatic cross-provider fallback to the other provider; flipping preference flips fallback order too
 - `innies-buyer-preference-set` prints the effective preferred provider plus the automatic fallback provider before sending the update
 - `innies-buyer-preference-check` now expects and validates the two-provider plan in DB evidence mode
+- `innies-compat-artifact-extract` accepts either `innies-compat-artifact-extract <artifact-path> <request-id>` or the env equivalents `INNIES_CAPTURED_RESPONSE_HTML` / `INNIES_CAPTURED_LOG_PATH` plus `INNIES_CAPTURED_REQUEST_ID`
+- `innies-compat-artifact-extract` extracts the first compat upstream attempt only; it writes `ingress.json`, `upstream-request.json`, `upstream-response.json`, and `summary.txt`, plus `payload.json` / `invalid-request-payload.json` when those chunks are present in the artifact
+- `innies-compat-artifact-extract` writes to `INNIES_EXTRACT_OUT_DIR` when set, otherwise to a temp-dir bundle keyed by the request id
 
 ## Env
 

--- a/scripts/innies-compat-artifact-extract.mjs
+++ b/scripts/innies-compat-artifact-extract.mjs
@@ -1,0 +1,280 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+
+const REQUEST_PAYLOAD_LABEL = '[/v1/messages] request-payload-json-chunk';
+const UPSTREAM_REQUEST_LABEL = '[compat-upstream-request-json-chunk]';
+const UPSTREAM_RESPONSE_LABEL = '[compat-upstream-response-json-chunk]';
+const INVALID_REQUEST_PAYLOAD_LABEL = '[compat-invalid-request-payload-json-chunk]';
+
+function stripLogPrefix(line) {
+  return line.replace(/^.*?\]:\s*/, '');
+}
+
+function parseJsLiteral(literal) {
+  return Function('"use strict"; return (' + literal + ');')();
+}
+
+function parseSerializedValue(text) {
+  try {
+    return JSON.parse(text);
+  } catch {}
+  return parseJsLiteral(text);
+}
+
+function parseScalarLine(line, key) {
+  const body = stripLogPrefix(line);
+  const match = body.match(new RegExp('^' + key + ':\\s*(.+?),?$'));
+  if (!match) return undefined;
+  const raw = match[1].trim();
+  if (raw === 'undefined' || raw === 'null') return undefined;
+  return parseJsLiteral(raw);
+}
+
+function normalizeLoggedRequestBody(value) {
+  const nestedBody = value?.body;
+  if (nestedBody && typeof nestedBody === 'object' && !Array.isArray(nestedBody)) {
+    return nestedBody;
+  }
+  return value ?? null;
+}
+
+function parseChunkSeries(lines, startIndex, label) {
+  const parts = [];
+  let expectedChunkCount = null;
+  let index = startIndex;
+  while (index < lines.length) {
+    const header = stripLogPrefix(lines[index]);
+    if (header !== `${label} {`) break;
+    const chunkIndexLine = stripLogPrefix(lines[index + 1] ?? '');
+    const chunkCountLine = stripLogPrefix(lines[index + 2] ?? '');
+    const jsonLine = stripLogPrefix(lines[index + 3] ?? '');
+    const closeLine = stripLogPrefix(lines[index + 4] ?? '');
+    const chunkIndexMatch = chunkIndexLine.match(/^chunk_index:\s*(\d+),?$/);
+    const chunkCountMatch = chunkCountLine.match(/^chunk_count:\s*(\d+),?$/);
+    const jsonMatch = jsonLine.match(/^json:\s*(.+)$/);
+    if (!chunkIndexMatch || !chunkCountMatch || !jsonMatch || closeLine !== '}') {
+      throw new Error(`Malformed ${label} chunk near line ${index + 1}`);
+    }
+    const chunkIndex = Number(chunkIndexMatch[1]);
+    const chunkCount = Number(chunkCountMatch[1]);
+    if (expectedChunkCount === null) {
+      expectedChunkCount = chunkCount;
+    } else if (expectedChunkCount !== chunkCount) {
+      throw new Error(`Mismatched ${label} chunk_count near line ${index + 1}`);
+    }
+    if (chunkIndex !== parts.length) {
+      throw new Error(`Out-of-order ${label} chunk_index near line ${index + 1}`);
+    }
+    parts.push(parseJsLiteral(jsonMatch[1]));
+    index += 5;
+    if (parts.length === expectedChunkCount) {
+      const text = parts.join('');
+      return { text, value: parseSerializedValue(text), nextIndex: index - 1 };
+    }
+  }
+  throw new Error(`Incomplete ${label} chunk series near line ${startIndex + 1}`);
+}
+
+function readRequestId(value) {
+  const raw = value?.request_id ?? value?.requestId;
+  return typeof raw === 'string' && raw.length > 0 ? raw : null;
+}
+
+function readAttemptNo(value) {
+  const raw = value?.attempt_no ?? value?.attemptNo;
+  if (raw === undefined || raw === null || raw === '') return 1;
+  const numeric = Number(raw);
+  return Number.isFinite(numeric) ? numeric : 1;
+}
+
+function parseLog(logText) {
+  const lines = logText.split(/\r?\n/);
+  const requestBodies = [];
+  const upstreamRequests = [];
+  const upstreamResponses = [];
+  const invalidRequestPayloads = [];
+  let pendingIngress = {};
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const body = stripLogPrefix(line);
+    const anthropicBeta = parseScalarLine(line, 'anthropicBeta');
+    if (anthropicBeta !== undefined) {
+      pendingIngress.anthropicBeta = anthropicBeta;
+      continue;
+    }
+    const anthropicVersion = parseScalarLine(line, 'anthropicVersion');
+    if (anthropicVersion !== undefined) {
+      pendingIngress.anthropicVersion = anthropicVersion;
+      continue;
+    }
+    const requestIdHeader = parseScalarLine(line, 'requestIdHeader');
+    if (requestIdHeader !== undefined) {
+      pendingIngress.requestIdHeader = requestIdHeader;
+      continue;
+    }
+    if (body === `${REQUEST_PAYLOAD_LABEL} {`) {
+      const { value, nextIndex } = parseChunkSeries(lines, index, REQUEST_PAYLOAD_LABEL);
+      requestBodies.push({
+        line: index,
+        ingress: { ...pendingIngress },
+        value: normalizeLoggedRequestBody(value)
+      });
+      pendingIngress = {};
+      index = nextIndex;
+      continue;
+    }
+    if (body === `${UPSTREAM_REQUEST_LABEL} {`) {
+      const { value, nextIndex } = parseChunkSeries(lines, index, UPSTREAM_REQUEST_LABEL);
+      upstreamRequests.push({ line: index, value });
+      index = nextIndex;
+      continue;
+    }
+    if (body === `${UPSTREAM_RESPONSE_LABEL} {`) {
+      const { value, nextIndex } = parseChunkSeries(lines, index, UPSTREAM_RESPONSE_LABEL);
+      upstreamResponses.push({ line: index, value });
+      index = nextIndex;
+      continue;
+    }
+    if (body === `${INVALID_REQUEST_PAYLOAD_LABEL} {`) {
+      const { value, nextIndex } = parseChunkSeries(lines, index, INVALID_REQUEST_PAYLOAD_LABEL);
+      invalidRequestPayloads.push({ line: index, value });
+      index = nextIndex;
+    }
+  }
+
+  return { requestBodies, upstreamRequests, upstreamResponses, invalidRequestPayloads };
+}
+
+function findNearestPreceding(groups, line) {
+  return [...groups].reverse().find((group) => group.line < line) ?? null;
+}
+
+function findNearestInvalidPayload(groups, line, nextLine) {
+  return groups.find((group) => group.line > line && group.line < nextLine) ?? null;
+}
+
+function readProviderRequestId(responseValue) {
+  const responseHeaders = responseValue?.response_headers;
+  if (responseHeaders && typeof responseHeaders === 'object') {
+    for (const [key, value] of Object.entries(responseHeaders)) {
+      if (key.toLowerCase() === 'request-id' && typeof value === 'string' && value.length > 0) {
+        return value;
+      }
+    }
+  }
+  const parsedBodyRequestId = responseValue?.parsed_body?.request_id;
+  if (typeof parsedBodyRequestId === 'string' && parsedBodyRequestId.length > 0) {
+    return parsedBodyRequestId;
+  }
+  return '';
+}
+
+async function writeJson(filePath, value) {
+  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function main() {
+  const artifactPath = process.env.ARTIFACT_PATH;
+  const requestId = process.env.REQUEST_ID;
+  const outDir = resolve(process.env.OUT_DIR ?? '');
+
+  if (!artifactPath) {
+    throw new Error('missing ARTIFACT_PATH');
+  }
+  if (!requestId) {
+    throw new Error('missing REQUEST_ID');
+  }
+  if (!outDir) {
+    throw new Error('missing OUT_DIR');
+  }
+
+  const logText = await readFile(artifactPath, 'utf8');
+  const parsed = parseLog(logText);
+  const upstreamRequest = parsed.upstreamRequests.find((group) => {
+    return readRequestId(group.value) === requestId && readAttemptNo(group.value) === 1;
+  });
+
+  if (!upstreamRequest) {
+    throw new Error(`could not find first-pass compat upstream request for ${requestId}`);
+  }
+
+  const upstreamResponse = parsed.upstreamResponses.find((group) => {
+    return readRequestId(group.value) === requestId && readAttemptNo(group.value) === 1;
+  });
+
+  if (!upstreamResponse) {
+    throw new Error(`could not find first-pass compat upstream response for ${requestId}`);
+  }
+
+  const requestBody = findNearestPreceding(parsed.requestBodies, upstreamRequest.line);
+  const nextUpstreamLine = parsed.upstreamRequests.find((group) => group.line > upstreamRequest.line)?.line ?? Number.POSITIVE_INFINITY;
+  const invalidRequestPayload = findNearestInvalidPayload(parsed.invalidRequestPayloads, upstreamRequest.line, nextUpstreamLine);
+  const payloadAvailable = Boolean(requestBody?.value);
+  const providerRequestId = readProviderRequestId(upstreamResponse.value);
+
+  await mkdir(outDir, { recursive: true });
+
+  const ingressFile = join(outDir, 'ingress.json');
+  const payloadFile = join(outDir, 'payload.json');
+  const upstreamRequestFile = join(outDir, 'upstream-request.json');
+  const upstreamResponseFile = join(outDir, 'upstream-response.json');
+  const invalidRequestPayloadFile = join(outDir, 'invalid-request-payload.json');
+  const summaryFile = join(outDir, 'summary.txt');
+
+  await writeJson(ingressFile, {
+    requestId,
+    anthropicBeta: requestBody?.ingress?.anthropicBeta ?? null,
+    anthropicVersion: requestBody?.ingress?.anthropicVersion ?? null,
+    requestIdHeader: requestBody?.ingress?.requestIdHeader ?? null,
+    payloadAvailable
+  });
+
+  if (payloadAvailable) {
+    await writeJson(payloadFile, requestBody.value);
+  }
+  await writeJson(upstreamRequestFile, upstreamRequest.value);
+  await writeJson(upstreamResponseFile, upstreamResponse.value);
+  if (invalidRequestPayload) {
+    await writeJson(invalidRequestPayloadFile, invalidRequestPayload.value);
+  }
+
+  const summaryLines = [
+    `request_id=${requestId}`,
+    `attempt_no=1`,
+    `provider=${upstreamRequest.value?.provider ?? ''}`,
+    `proxied_path=${upstreamRequest.value?.proxied_path ?? ''}`,
+    `target_url=${upstreamRequest.value?.target_url ?? ''}`,
+    `body_bytes=${upstreamRequest.value?.body_bytes ?? ''}`,
+    `body_sha256=${upstreamRequest.value?.body_sha256 ?? ''}`,
+    `upstream_status=${upstreamResponse.value?.upstream_status ?? ''}`,
+    `provider_request_id=${providerRequestId}`,
+    `payload_available=${String(payloadAvailable)}`,
+    `ingress_anthropic_beta=${requestBody?.ingress?.anthropicBeta ?? ''}`,
+    `ingress_anthropic_version=${requestBody?.ingress?.anthropicVersion ?? ''}`,
+    `upstream_anthropic_beta=${upstreamRequest.value?.headers?.['anthropic-beta'] ?? ''}`,
+    `upstream_user_agent=${upstreamRequest.value?.headers?.['user-agent'] ?? ''}`
+  ];
+  await writeFile(summaryFile, `${summaryLines.join('\n')}\n`);
+
+  const outputLines = [
+    `request_id=${requestId}`,
+    'attempt_no=1',
+    `provider_request_id=${providerRequestId}`,
+    `payload_available=${String(payloadAvailable)}`,
+    `payload_file=${payloadAvailable ? payloadFile : ''}`,
+    `ingress_file=${ingressFile}`,
+    `upstream_request_file=${upstreamRequestFile}`,
+    `upstream_response_file=${upstreamResponseFile}`,
+    `invalid_request_payload_file=${invalidRequestPayload ? invalidRequestPayloadFile : ''}`,
+    `summary_file=${summaryFile}`,
+    `out_dir=${outDir}`
+  ];
+  process.stdout.write(`${outputLines.join('\n')}\n`);
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`error: ${message}\n`);
+  process.exit(1);
+});

--- a/scripts/innies-compat-artifact-extract.sh
+++ b/scripts/innies-compat-artifact-extract.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_PATH" ]]; do
+  SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+  SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"
+  [[ "$SCRIPT_PATH" != /* ]] && SCRIPT_PATH="${SCRIPT_DIR}/${SCRIPT_PATH}"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+source "${SCRIPT_DIR}/_common.sh"
+
+ARTIFACT_PATH="${1:-${INNIES_CAPTURED_RESPONSE_HTML:-${INNIES_CAPTURED_LOG_PATH:-}}}"
+REQUEST_ID="${2:-${INNIES_CAPTURED_REQUEST_ID:-}}"
+
+require_nonempty 'captured artifact path' "$ARTIFACT_PATH"
+require_nonempty 'captured request id' "$REQUEST_ID"
+
+if [[ ! -f "$ARTIFACT_PATH" ]]; then
+  echo "error: captured artifact file not found: $ARTIFACT_PATH" >&2
+  exit 1
+fi
+
+OUT_DIR="${INNIES_EXTRACT_OUT_DIR:-${TMPDIR:-/tmp}/innies-compat-artifact-${REQUEST_ID}}"
+
+ARTIFACT_PATH="$ARTIFACT_PATH" \
+REQUEST_ID="$REQUEST_ID" \
+OUT_DIR="$OUT_DIR" \
+node "${SCRIPT_DIR}/innies-compat-artifact-extract.mjs"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,6 +17,7 @@ ln -sf "${ROOT_DIR}/scripts/innies-buyer-key-create.sh" "${BIN_DIR}/innies-buyer
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-set.sh" "${BIN_DIR}/innies-buyer-preference-set"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-get.sh" "${BIN_DIR}/innies-buyer-preference-get"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-check.sh" "${BIN_DIR}/innies-buyer-preference-check"
+ln -sf "${ROOT_DIR}/scripts/innies-compat-artifact-extract.sh" "${BIN_DIR}/innies-compat-artifact-extract"
 ln -sf "${ROOT_DIR}/scripts/innies-slo-check.sh" "${BIN_DIR}/innies-slo-check"
 
 rm -f \
@@ -48,6 +49,7 @@ echo "  ${BIN_DIR}/innies-buyer-key-create -> ${ROOT_DIR}/scripts/innies-buyer-k
 echo "  ${BIN_DIR}/innies-buyer-preference-set -> ${ROOT_DIR}/scripts/innies-buyer-preference-set.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-get -> ${ROOT_DIR}/scripts/innies-buyer-preference-get.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-check -> ${ROOT_DIR}/scripts/innies-buyer-preference-check.sh"
+echo "  ${BIN_DIR}/innies-compat-artifact-extract -> ${ROOT_DIR}/scripts/innies-compat-artifact-extract.sh"
 echo "  ${BIN_DIR}/innies-slo-check -> ${ROOT_DIR}/scripts/innies-slo-check.sh"
 echo
 echo 'If command not found, add ~/.local/bin to PATH:'

--- a/scripts/tests/innies-compat-artifact-extract.test.sh
+++ b/scripts/tests/innies-compat-artifact-extract.test.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="$ROOT_DIR/scripts/innies-compat-artifact-extract.sh"
+TMP_DIR="$(mktemp -d)"
+FULL_ARTIFACT_PATH="$TMP_DIR/full-response.html"
+NO_PAYLOAD_ARTIFACT_PATH="$TMP_DIR/no-payload-response.html"
+OUT_DIR="$TMP_DIR/out"
+OUT_DIR_NO_PAYLOAD="$TMP_DIR/out-no-payload"
+STDOUT_PATH="$TMP_DIR/stdout.txt"
+STDERR_PATH="$TMP_DIR/stderr.txt"
+STDOUT_NO_PAYLOAD_PATH="$TMP_DIR/stdout-no-payload.txt"
+STDERR_NO_PAYLOAD_PATH="$TMP_DIR/stderr-no-payload.txt"
+STDOUT_MISSING_PATH="$TMP_DIR/stdout-missing.txt"
+STDERR_MISSING_PATH="$TMP_DIR/stderr-missing.txt"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+cat >"$FULL_ARTIFACT_PATH" <<'LOG'
+Mar 17 11:10:39 sf-prod bash[263845]: anthropicBeta: 'fine-grained-tool-streaming-2025-05-14'
+Mar 17 11:10:39 sf-prod bash[263845]: anthropicVersion: '2023-06-01'
+Mar 17 11:10:39 sf-prod bash[263845]: requestIdHeader: 'req_issue80_full'
+Mar 17 11:10:39 sf-prod bash[263845]: [/v1/messages] request-payload-json-chunk {
+Mar 17 11:10:39 sf-prod bash[263845]:   chunk_index: 0,
+Mar 17 11:10:39 sf-prod bash[263845]:   chunk_count: 1,
+Mar 17 11:10:39 sf-prod bash[263845]:   json: '{"body":{"model":"claude-opus-4-6","stream":true,"max_tokens":16,"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}}'
+Mar 17 11:10:39 sf-prod bash[263845]: }
+Mar 17 11:10:39 sf-prod bash[263845]: [compat-upstream-request-json-chunk] {
+Mar 17 11:10:39 sf-prod bash[263845]:   chunk_index: 0,
+Mar 17 11:10:39 sf-prod bash[263845]:   chunk_count: 1,
+Mar 17 11:10:39 sf-prod bash[263845]:   json: '{"attempt_no":1,"body_bytes":126,"body_sha256":"sha_issue80_full","credential_id":"cred_issue80_full","credential_label":"aelix","headers":{"accept":"text/event-stream","anthropic-beta":"fine-grained-tool-streaming-2025-05-14,claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14","anthropic-version":"2023-06-01","authorization":"Bearer <redacted:108>","content-type":"application/json","x-request-id":"req_issue80_full"},"method":"POST","model":"claude-opus-4-6","provider":"anthropic","proxied_path":"/v1/messages","request_id":"req_issue80_full","stream":true,"target_url":"https://api.anthropic.com/v1/messages"}'
+Mar 17 11:10:39 sf-prod bash[263845]: }
+Mar 17 11:10:39 sf-prod bash[263845]: [compat-upstream-response-json-chunk] {
+Mar 17 11:10:39 sf-prod bash[263845]:   chunk_index: 0,
+Mar 17 11:10:39 sf-prod bash[263845]:   chunk_count: 1,
+Mar 17 11:10:39 sf-prod bash[263845]:   json: `{"attempt_no":1,"credential_id":"cred_issue80_full","credential_label":"aelix","parsed_body":{"error":{"message":"Error","type":"invalid_request_error"},"request_id":"req_upstream_issue80_full","type":"error"},"provider":"anthropic","proxied_path":"/v1/messages","request_id":"req_issue80_full","response_headers":{"content-type":"application/json","request-id":"req_upstream_issue80_full"},"stream":true,"target_url":"https://api.anthropic.com/v1/messages","upstream_content_type":"application/json","upstream_status":400}`
+Mar 17 11:10:39 sf-prod bash[263845]: }
+Mar 17 11:10:39 sf-prod bash[263845]: [compat-invalid-request-payload-json-chunk] {
+Mar 17 11:10:39 sf-prod bash[263845]:   chunk_index: 0,
+Mar 17 11:10:39 sf-prod bash[263845]:   chunk_count: 1,
+Mar 17 11:10:39 sf-prod bash[263845]:   json: '{"model":"claude-opus-4-6","stream":true,"max_tokens":16,"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}'
+Mar 17 11:10:39 sf-prod bash[263845]: }
+LOG
+
+cat >"$NO_PAYLOAD_ARTIFACT_PATH" <<'LOG'
+Mar 17 13:22:53 sf-prod bash[269534]: [compat-upstream-request-json-chunk] {
+Mar 17 13:22:53 sf-prod bash[269534]:   chunk_index: 0,
+Mar 17 13:22:53 sf-prod bash[269534]:   chunk_count: 1,
+Mar 17 13:22:53 sf-prod bash[269534]:   json: '{"attempt_no":1,"body_bytes":398262,"body_sha256":"1717a039bed013d162eb47daead7f7eea440bccc6fb2719b9233142976e9a093","credential_id":"8aa85176-43e1-47fb-b5dd-cc22dadd48ed","credential_label":"aelix","headers":{"accept":"text/event-stream","anthropic-beta":"fine-grained-tool-streaming-2025-05-14,claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14","anthropic-dangerous-direct-browser-access":"true","anthropic-version":"2023-06-01","authorization":"Bearer <redacted:108>","content-type":"application/json","user-agent":"OpenClawGateway/1.0","x-app":"cli","x-request-id":"req_issue80_no_payload"},"method":"POST","model":"claude-opus-4-6","provider":"anthropic","proxied_path":"/v1/messages","request_id":"req_issue80_no_payload","request_shape":{"message_count":436,"tool_count":21,"thinking_present":true},"stream":true,"target_url":"https://api.anthropic.com/v1/messages"}'
+Mar 17 13:22:53 sf-prod bash[269534]: }
+Mar 17 13:22:54 sf-prod bash[269534]: [compat-upstream-response-json-chunk] {
+Mar 17 13:22:54 sf-prod bash[269534]:   chunk_index: 0,
+Mar 17 13:22:54 sf-prod bash[269534]:   chunk_count: 1,
+Mar 17 13:22:54 sf-prod bash[269534]:   json: `{"attempt_no":1,"credential_id":"8aa85176-43e1-47fb-b5dd-cc22dadd48ed","credential_label":"aelix","parsed_body":{"error":{"message":"Error","type":"invalid_request_error"},"request_id":"req_upstream_issue80_no_payload","type":"error"},"provider":"anthropic","proxied_path":"/v1/messages","request_id":"req_issue80_no_payload","response_headers":{"content-type":"application/json","request-id":"req_upstream_issue80_no_payload"},"stream":true,"target_url":"https://api.anthropic.com/v1/messages","upstream_content_type":"application/json","upstream_status":400}`
+Mar 17 13:22:54 sf-prod bash[269534]: }
+LOG
+
+set +e
+INNIES_EXTRACT_OUT_DIR="$OUT_DIR" \
+"$SCRIPT_PATH" "$FULL_ARTIFACT_PATH" "req_issue80_full" >"$STDOUT_PATH" 2>"$STDERR_PATH"
+STATUS=$?
+set -e
+
+if [[ "$STATUS" -ne 0 ]]; then
+  cat "$STDERR_PATH"
+  exit 1
+fi
+
+[[ -f "$OUT_DIR/summary.txt" ]]
+[[ -f "$OUT_DIR/ingress.json" ]]
+[[ -f "$OUT_DIR/payload.json" ]]
+[[ -f "$OUT_DIR/upstream-request.json" ]]
+[[ -f "$OUT_DIR/upstream-response.json" ]]
+[[ -f "$OUT_DIR/invalid-request-payload.json" ]]
+
+grep -q '^request_id=req_issue80_full$' "$STDOUT_PATH"
+grep -q '^attempt_no=1$' "$STDOUT_PATH"
+grep -q '^payload_available=true$' "$STDOUT_PATH"
+grep -q '^provider_request_id=req_upstream_issue80_full$' "$STDOUT_PATH"
+grep -q '^payload_file='"$OUT_DIR"'/payload.json$' "$STDOUT_PATH"
+grep -q '^summary_file='"$OUT_DIR"'/summary.txt$' "$STDOUT_PATH"
+
+grep -q '"anthropicBeta": "fine-grained-tool-streaming-2025-05-14"' "$OUT_DIR/ingress.json"
+grep -q '"model": "claude-opus-4-6"' "$OUT_DIR/payload.json"
+grep -q '"body_sha256": "sha_issue80_full"' "$OUT_DIR/upstream-request.json"
+grep -q '"request_id": "req_upstream_issue80_full"' "$OUT_DIR/upstream-response.json"
+grep -q '"messages"' "$OUT_DIR/invalid-request-payload.json"
+grep -q '^body_sha256=sha_issue80_full$' "$OUT_DIR/summary.txt"
+grep -q '^payload_available=true$' "$OUT_DIR/summary.txt"
+
+set +e
+INNIES_EXTRACT_OUT_DIR="$OUT_DIR_NO_PAYLOAD" \
+"$SCRIPT_PATH" "$NO_PAYLOAD_ARTIFACT_PATH" "req_issue80_no_payload" >"$STDOUT_NO_PAYLOAD_PATH" 2>"$STDERR_NO_PAYLOAD_PATH"
+STATUS=$?
+set -e
+
+if [[ "$STATUS" -ne 0 ]]; then
+  cat "$STDERR_NO_PAYLOAD_PATH"
+  exit 1
+fi
+
+[[ -f "$OUT_DIR_NO_PAYLOAD/summary.txt" ]]
+[[ -f "$OUT_DIR_NO_PAYLOAD/ingress.json" ]]
+[[ -f "$OUT_DIR_NO_PAYLOAD/upstream-request.json" ]]
+[[ -f "$OUT_DIR_NO_PAYLOAD/upstream-response.json" ]]
+
+if [[ -f "$OUT_DIR_NO_PAYLOAD/payload.json" ]]; then
+  echo 'did not expect payload.json when ingress payload chunks are missing'
+  exit 1
+fi
+
+grep -q '^request_id=req_issue80_no_payload$' "$STDOUT_NO_PAYLOAD_PATH"
+grep -q '^payload_available=false$' "$STDOUT_NO_PAYLOAD_PATH"
+grep -q '^provider_request_id=req_upstream_issue80_no_payload$' "$STDOUT_NO_PAYLOAD_PATH"
+grep -q '^body_sha256=1717a039bed013d162eb47daead7f7eea440bccc6fb2719b9233142976e9a093$' "$OUT_DIR_NO_PAYLOAD/summary.txt"
+grep -q '^payload_available=false$' "$OUT_DIR_NO_PAYLOAD/summary.txt"
+grep -q '"message_count": 436' "$OUT_DIR_NO_PAYLOAD/upstream-request.json"
+grep -q '"request_id": "req_upstream_issue80_no_payload"' "$OUT_DIR_NO_PAYLOAD/upstream-response.json"
+
+set +e
+"$SCRIPT_PATH" "$FULL_ARTIFACT_PATH" "req_missing_issue80" >"$STDOUT_MISSING_PATH" 2>"$STDERR_MISSING_PATH"
+STATUS=$?
+set -e
+
+if [[ "$STATUS" -eq 0 ]]; then
+  echo 'expected missing request id extraction to fail'
+  exit 1
+fi
+
+grep -q 'error: could not find first-pass compat upstream request for req_missing_issue80' "$STDERR_MISSING_PATH"


### PR DESCRIPTION
## Summary
- add `innies-compat-artifact-extract`, a focused helper that pulls the first-pass compat request/response pair for one `request_id` out of a saved prod HTML/log artifact
- write `ingress.json`, `upstream-request.json`, `upstream-response.json`, and `summary.txt`, plus `payload.json` and `invalid-request-payload.json` when those chunks are present
- wire the helper into `scripts/install.sh` and `scripts/README.md`, and cover it with a focused shell regression

## Notes
- this does not change the runtime proxy path; it turns the issue-80 saved artifacts into structured inputs for replay/diff work instead of relying on ad-hoc local parsers
- I also smoke-ran the helper against `/Users/dylanvu/Downloads/response_1773768207701.html` for `req_1773768173495_39292`; it produced `/private/tmp/issue80-artifact-extract-live` with `provider_request_id=req_011CZ93FPfDeQsWWUGBWvDHQ` and `body_sha256=1717a039bed013d162eb47daead7f7eea440bccc6fb2719b9233142976e9a093`

## Test Plan
- `bash scripts/tests/innies-compat-artifact-extract.test.sh`
- `bash -n scripts/innies-compat-artifact-extract.sh scripts/tests/innies-compat-artifact-extract.test.sh scripts/install.sh`
- `node --check scripts/innies-compat-artifact-extract.mjs`
- `git diff --check`
- `INNIES_EXTRACT_OUT_DIR=/private/tmp/issue80-artifact-extract-live scripts/innies-compat-artifact-extract.sh /Users/dylanvu/Downloads/response_1773768207701.html req_1773768173495_39292`

Refs #80
