### PR TITLE
chore: add captured anthropic lane replay helper with Claude token fallback

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -25,6 +25,7 @@ innies-buyer-preference-set
 innies-buyer-preference-get
 innies-buyer-preference-check
 innies-slo-check
+innies-compat-captured-lane-replay
 ```
 
 What they do:
@@ -40,6 +41,7 @@ What they do:
 - `innies-buyer-preference-get`: read the current buyer key preference
 - `innies-buyer-preference-check`: run the provider-preference canary after prompting for the expected provider (`Claude Code` or `Codex`)
 - `innies-slo-check`: query analytics endpoints and report Phase 1 SLO pass/fail (TTFB p95, timeout rate, success rate, fallback rate); optional arg sets the window (default `24h`); exits 0 if all SLOs pass, 1 if any fail
+- `innies-compat-captured-lane-replay`: replay the exact captured Anthropic compat first-pass header lane from a prod HTML artifact directly against Anthropic using a fresh OAuth token
 
 Behavior:
 - org id auto-uses `INNIES_ORG_ID`
@@ -79,6 +81,12 @@ Behavior:
 - non-pinned buyer traffic always gets automatic cross-provider fallback to the other provider; flipping preference flips fallback order too
 - `innies-buyer-preference-set` prints the effective preferred provider plus the automatic fallback provider before sending the update
 - `innies-buyer-preference-check` now expects and validates the two-provider plan in DB evidence mode
+- `innies-compat-captured-lane-replay` requires:
+  - a preserved `/v1/messages` payload JSON path as its first argument
+  - `INNIES_CAPTURED_RESPONSE_HTML` plus `INNIES_CAPTURED_REQUEST_ID` for the captured Innies compat artifact to replay
+  - `ANTHROPIC_OAUTH_ACCESS_TOKEN` (or `ANTHROPIC_ACCESS_TOKEN`) for the direct Anthropic request
+- `innies-compat-captured-lane-replay` preserves the captured first-pass headers except it swaps in the supplied direct bearer token, drops transport-only headers like `host` / `content-length`, and writes `captured-headers.tsv`, `direct-headers.txt`, `direct-body.txt`, and `meta.txt` under `INNIES_REPLAY_OUT_DIR`
+- `innies-compat-captured-lane-replay` fails fast if the captured upstream provider was not `anthropic`, so it cannot silently replay an OpenAI/Codex compat lane as Anthropic evidence
 
 ## Env
 
@@ -94,3 +102,13 @@ For `innies-buyer-preference-check`:
 - `DATABASE_URL` is optional, but needed for DB evidence
 - `INNIES_MODEL_ANTHROPIC` is required if you check Claude Code
 - `INNIES_MODEL_CODEX` is required if you check Codex
+
+Example for `innies-compat-captured-lane-replay`:
+
+```bash
+INNIES_CAPTURED_RESPONSE_HTML=/Users/dylanvu/Downloads/response_1773768207701.html \
+INNIES_CAPTURED_REQUEST_ID=req_1773768173495_39292 \
+ANTHROPIC_OAUTH_ACCESS_TOKEN=... \
+INNIES_REPLAY_OUT_DIR=/private/tmp/issue80-captured-lane-replay \
+innies-compat-captured-lane-replay /private/tmp/innies-issue-80-preserved-body.json
+```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -84,8 +84,9 @@ Behavior:
 - `innies-compat-captured-lane-replay` requires:
   - a preserved `/v1/messages` payload JSON path as its first argument
   - `INNIES_CAPTURED_RESPONSE_HTML` plus `INNIES_CAPTURED_REQUEST_ID` for the captured Innies compat artifact to replay
-  - `ANTHROPIC_OAUTH_ACCESS_TOKEN` (or `ANTHROPIC_ACCESS_TOKEN`) for the direct Anthropic request
+  - one of `ANTHROPIC_OAUTH_ACCESS_TOKEN`, `ANTHROPIC_ACCESS_TOKEN`, or `CLAUDE_CODE_OAUTH_TOKEN` for the direct Anthropic request
 - `innies-compat-captured-lane-replay` preserves the captured first-pass headers except it swaps in the supplied direct bearer token, drops transport-only headers like `host` / `content-length`, and writes `captured-headers.tsv`, `direct-headers.txt`, `direct-body.txt`, and `meta.txt` under `INNIES_REPLAY_OUT_DIR`
+- `innies-compat-captured-lane-replay` records `direct_access_token_source` in `meta.txt` so the issue handoff can show which direct bearer lane was actually used
 - `innies-compat-captured-lane-replay` fails fast if the captured upstream provider was not `anthropic`, so it cannot silently replay an OpenAI/Codex compat lane as Anthropic evidence
 
 ## Env
@@ -108,7 +109,7 @@ Example for `innies-compat-captured-lane-replay`:
 ```bash
 INNIES_CAPTURED_RESPONSE_HTML=/Users/dylanvu/Downloads/response_1773768207701.html \
 INNIES_CAPTURED_REQUEST_ID=req_1773768173495_39292 \
-ANTHROPIC_OAUTH_ACCESS_TOKEN=... \
+CLAUDE_CODE_OAUTH_TOKEN=... \
 INNIES_REPLAY_OUT_DIR=/private/tmp/issue80-captured-lane-replay \
 innies-compat-captured-lane-replay /private/tmp/innies-issue-80-preserved-body.json
 ```

--- a/scripts/innies-compat-captured-lane-replay.sh
+++ b/scripts/innies-compat-captured-lane-replay.sh
@@ -45,6 +45,29 @@ write_lines() {
   printf '%s\n' "$@" >"$file"
 }
 
+DIRECT_ACCESS_TOKEN_SOURCE=''
+ACCESS_TOKEN=''
+
+resolve_direct_access_token() {
+  if [[ -n "${ANTHROPIC_OAUTH_ACCESS_TOKEN:-}" ]]; then
+    DIRECT_ACCESS_TOKEN_SOURCE='anthropic_oauth_access_token'
+    ACCESS_TOKEN="${ANTHROPIC_OAUTH_ACCESS_TOKEN}"
+    return
+  fi
+  if [[ -n "${ANTHROPIC_ACCESS_TOKEN:-}" ]]; then
+    DIRECT_ACCESS_TOKEN_SOURCE='anthropic_access_token'
+    ACCESS_TOKEN="${ANTHROPIC_ACCESS_TOKEN}"
+    return
+  fi
+  if [[ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
+    DIRECT_ACCESS_TOKEN_SOURCE='claude_code_oauth_token'
+    ACCESS_TOKEN="${CLAUDE_CODE_OAUTH_TOKEN}"
+    return
+  fi
+  DIRECT_ACCESS_TOKEN_SOURCE=''
+  ACCESS_TOKEN=''
+}
+
 extract_captured_request() {
   local captured_html="$1"
   local request_id="$2"
@@ -159,7 +182,7 @@ if [[ ! -f "$CAPTURED_RESPONSE_HTML" ]]; then
 fi
 
 DIRECT_BASE_URL="$(resolve_direct_base_url)"
-ACCESS_TOKEN="${ANTHROPIC_OAUTH_ACCESS_TOKEN:-${ANTHROPIC_ACCESS_TOKEN:-}}"
+resolve_direct_access_token
 require_nonempty 'Anthropic OAuth access token' "$ACCESS_TOKEN"
 
 DIRECT_REQUEST_ID="${INNIES_DIRECT_REQUEST_ID:-req_issue80_direct_$(date -u +%Y%m%dT%H%M%SZ)}"
@@ -251,6 +274,7 @@ write_lines "$META_FILE" \
   "direct_request_id=$DIRECT_REQUEST_ID" \
   "direct_status=$DIRECT_STATUS" \
   "provider_request_id=${PROVIDER_REQUEST_ID:-}" \
+  "direct_access_token_source=${DIRECT_ACCESS_TOKEN_SOURCE:-}" \
   "direct_base_url=$DIRECT_BASE_URL" \
   "direct_path=$DIRECT_PATH" \
   "captured_headers_file=$CAPTURED_HEADERS_FILE" \

--- a/scripts/innies-compat-captured-lane-replay.sh
+++ b/scripts/innies-compat-captured-lane-replay.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_PATH" ]]; do
+  SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+  SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"
+  [[ "$SCRIPT_PATH" != /* ]] && SCRIPT_PATH="${SCRIPT_DIR}/${SCRIPT_PATH}"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+source "${SCRIPT_DIR}/_common.sh"
+
+extract_header() {
+  local name="$1"
+  local file="$2"
+  awk -F': ' -v header_name="$name" '
+    BEGIN { IGNORECASE = 1 }
+    tolower($1) == tolower(header_name) {
+      gsub("\r", "", $2)
+      print $2
+    }
+  ' "$file" | tail -1
+}
+
+extract_body_request_id() {
+  local file="$1"
+  sed -n 's/.*"request_id":"\([^"]*\)".*/\1/p' "$file" | head -n 1
+}
+
+resolve_direct_base_url() {
+  if [[ -n "${ANTHROPIC_DIRECT_BASE_URL:-}" ]]; then
+    printf '%s' "${ANTHROPIC_DIRECT_BASE_URL%/}"
+    return
+  fi
+  if [[ -n "${ANTHROPIC_BASE_URL:-}" ]]; then
+    printf '%s' "${ANTHROPIC_BASE_URL%/}"
+    return
+  fi
+  printf '%s' 'https://api.anthropic.com'
+}
+
+write_lines() {
+  local file="$1"
+  shift
+  printf '%s\n' "$@" >"$file"
+}
+
+extract_captured_request() {
+  local captured_html="$1"
+  local request_id="$2"
+  local headers_tsv="$3"
+  local meta_file="$4"
+  node - "$captured_html" "$request_id" "$headers_tsv" "$meta_file" <<'NODE'
+const fs = require('fs');
+
+const capturedHtmlPath = process.argv[2];
+const requestId = process.argv[3];
+const headersPath = process.argv[4];
+const metaPath = process.argv[5];
+
+function stripLogPrefix(line) {
+  return line.replace(/^.*?\]:\s*/, '');
+}
+
+function parseJsLiteral(literal) {
+  return Function('"use strict"; return (' + literal + ');')();
+}
+
+function parseSerializedValue(text) {
+  try {
+    return JSON.parse(text);
+  } catch {}
+  return parseJsLiteral(text);
+}
+
+function parseChunkSeries(lines, startIndex, label) {
+  const parts = [];
+  let expectedChunkCount = null;
+  let index = startIndex;
+  while (index < lines.length) {
+    const header = stripLogPrefix(lines[index]);
+    if (header !== `${label} {`) break;
+    const chunkIndexLine = stripLogPrefix(lines[index + 1] ?? '');
+    const chunkCountLine = stripLogPrefix(lines[index + 2] ?? '');
+    const jsonLine = stripLogPrefix(lines[index + 3] ?? '');
+    const closeLine = stripLogPrefix(lines[index + 4] ?? '');
+    const chunkIndexMatch = chunkIndexLine.match(/^chunk_index:\s*(\d+),?$/);
+    const chunkCountMatch = chunkCountLine.match(/^chunk_count:\s*(\d+),?$/);
+    const jsonMatch = jsonLine.match(/^json:\s*(.+)$/);
+    if (!chunkIndexMatch || !chunkCountMatch || !jsonMatch || closeLine !== '}') {
+      throw new Error(`Malformed ${label} chunk near line ${index + 1}`);
+    }
+    const chunkIndex = Number(chunkIndexMatch[1]);
+    const chunkCount = Number(chunkCountMatch[1]);
+    if (expectedChunkCount === null) expectedChunkCount = chunkCount;
+    else if (expectedChunkCount !== chunkCount) throw new Error(`Mismatched ${label} chunk_count near line ${index + 1}`);
+    if (chunkIndex !== parts.length) throw new Error(`Out-of-order ${label} chunk_index near line ${index + 1}`);
+    parts.push(parseJsLiteral(jsonMatch[1]));
+    index += 5;
+    if (parts.length === expectedChunkCount) {
+      return { text: parts.join(''), nextIndex: index - 1 };
+    }
+  }
+  throw new Error(`Incomplete ${label} chunk series near line ${startIndex + 1}`);
+}
+
+function writeMetaLine(key, value) {
+  process.stdout.write(`${key}=${String(value ?? '')}\n`);
+}
+
+const lines = fs.readFileSync(capturedHtmlPath, 'utf8').split(/\r?\n/);
+const upstreamRequests = [];
+for (let index = 0; index < lines.length; index += 1) {
+  const body = stripLogPrefix(lines[index]);
+  if (body === '[compat-upstream-request-json-chunk] {') {
+    const { text, nextIndex } = parseChunkSeries(lines, index, '[compat-upstream-request-json-chunk]');
+    upstreamRequests.push(parseSerializedValue(text));
+    index = nextIndex;
+  }
+}
+
+const request = upstreamRequests.find((value) => value?.request_id === requestId);
+if (!request) {
+  console.error(`error: no captured compat upstream request found for ${requestId}`);
+  process.exit(1);
+}
+
+const headers = request.headers && typeof request.headers === 'object' ? request.headers : {};
+const headerLines = Object.entries(headers).map(([name, value]) => `${name}\t${String(value)}`);
+fs.writeFileSync(headersPath, `${headerLines.join('\n')}\n`);
+fs.writeFileSync(metaPath, [
+  `captured_request_id=${request.request_id ?? ''}`,
+  `captured_provider=${request.provider ?? ''}`,
+  `captured_target_url=${request.target_url ?? ''}`,
+  `captured_proxied_path=${request.proxied_path ?? ''}`,
+  `captured_attempt_no=${request.attempt_no ?? ''}`,
+  `captured_stream=${String(Boolean(request.stream))}`,
+  `captured_body_bytes=${request.body_bytes ?? ''}`
+].join('\n') + '\n');
+NODE
+}
+
+PAYLOAD_PATH="${1:-${INNIES_REPLAY_PAYLOAD_PATH:-}}"
+require_nonempty 'payload path' "$PAYLOAD_PATH"
+
+if [[ ! -f "$PAYLOAD_PATH" ]]; then
+  echo "error: payload file not found: $PAYLOAD_PATH" >&2
+  exit 1
+fi
+
+CAPTURED_RESPONSE_HTML="${INNIES_CAPTURED_RESPONSE_HTML:-${INNIES_CAPTURED_LOG_PATH:-}}"
+CAPTURED_REQUEST_ID="${INNIES_CAPTURED_REQUEST_ID:-${INNIES_REQUEST_ID:-}}"
+require_nonempty 'captured response HTML' "$CAPTURED_RESPONSE_HTML"
+require_nonempty 'captured request id' "$CAPTURED_REQUEST_ID"
+
+if [[ ! -f "$CAPTURED_RESPONSE_HTML" ]]; then
+  echo "error: captured response HTML not found: $CAPTURED_RESPONSE_HTML" >&2
+  exit 1
+fi
+
+DIRECT_BASE_URL="$(resolve_direct_base_url)"
+ACCESS_TOKEN="${ANTHROPIC_OAUTH_ACCESS_TOKEN:-${ANTHROPIC_ACCESS_TOKEN:-}}"
+require_nonempty 'Anthropic OAuth access token' "$ACCESS_TOKEN"
+
+DIRECT_REQUEST_ID="${INNIES_DIRECT_REQUEST_ID:-req_issue80_direct_$(date -u +%Y%m%dT%H%M%SZ)}"
+OUT_DIR="${INNIES_REPLAY_OUT_DIR:-${TMPDIR:-/tmp}/innies-compat-captured-lane-replay-${DIRECT_REQUEST_ID}}"
+mkdir -p "$OUT_DIR"
+
+CAPTURED_HEADERS_FILE="$OUT_DIR/captured-headers.tsv"
+CAPTURED_META_FILE="$OUT_DIR/captured-meta.txt"
+DIRECT_HEADERS_FILE="$OUT_DIR/direct-headers.txt"
+DIRECT_BODY_FILE="$OUT_DIR/direct-body.txt"
+META_FILE="$OUT_DIR/meta.txt"
+
+extract_captured_request "$CAPTURED_RESPONSE_HTML" "$CAPTURED_REQUEST_ID" "$CAPTURED_HEADERS_FILE" "$CAPTURED_META_FILE"
+
+CAPTURED_PROVIDER=''
+CAPTURED_TARGET_URL=''
+CAPTURED_PROXIED_PATH=''
+CAPTURED_ATTEMPT_NO=''
+CAPTURED_STREAM=''
+CAPTURED_BODY_BYTES=''
+while IFS='=' read -r key value; do
+  case "$key" in
+    captured_provider) CAPTURED_PROVIDER="$value" ;;
+    captured_target_url) CAPTURED_TARGET_URL="$value" ;;
+    captured_proxied_path) CAPTURED_PROXIED_PATH="$value" ;;
+    captured_attempt_no) CAPTURED_ATTEMPT_NO="$value" ;;
+    captured_stream) CAPTURED_STREAM="$value" ;;
+    captured_body_bytes) CAPTURED_BODY_BYTES="$value" ;;
+  esac
+done <"$CAPTURED_META_FILE"
+
+CAPTURED_PROVIDER_NORMALIZED="$(printf '%s' "$CAPTURED_PROVIDER" | tr '[:upper:]' '[:lower:]')"
+if [[ "$CAPTURED_PROVIDER_NORMALIZED" != 'anthropic' ]]; then
+  echo "error: captured Innies lane resolved to ${CAPTURED_PROVIDER:-unknown}; expected anthropic" >&2
+  exit 1
+fi
+
+DIRECT_PATH="${CAPTURED_PROXIED_PATH:-/v1/messages}"
+DIRECT_STATUS=''
+declare -a DIRECT_CURL_ARGS
+DIRECT_CURL_ARGS=(
+  -sS
+  -D "$DIRECT_HEADERS_FILE"
+  -o "$DIRECT_BODY_FILE"
+  -w '%{http_code}'
+  -X POST "${DIRECT_BASE_URL}${DIRECT_PATH}"
+  --data-binary "@$PAYLOAD_PATH"
+  -H "Authorization: Bearer $ACCESS_TOKEN"
+)
+
+HAVE_DIRECT_REQUEST_ID='false'
+while IFS=$'\t' read -r header_name header_value; do
+  [[ -z "$header_name" ]] && continue
+  header_name_normalized="$(printf '%s' "$header_name" | tr '[:upper:]' '[:lower:]')"
+  case "$header_name_normalized" in
+    authorization|content-length|host)
+      continue
+      ;;
+    x-request-id)
+      DIRECT_CURL_ARGS+=(-H "x-request-id: $DIRECT_REQUEST_ID")
+      HAVE_DIRECT_REQUEST_ID='true'
+      ;;
+    *)
+      DIRECT_CURL_ARGS+=(-H "${header_name}: ${header_value}")
+      ;;
+  esac
+done <"$CAPTURED_HEADERS_FILE"
+
+if [[ "$HAVE_DIRECT_REQUEST_ID" != 'true' ]]; then
+  DIRECT_CURL_ARGS+=(-H "x-request-id: $DIRECT_REQUEST_ID")
+fi
+
+DIRECT_STATUS="$(curl "${DIRECT_CURL_ARGS[@]}")"
+PROVIDER_REQUEST_ID="$(extract_header 'request-id' "$DIRECT_HEADERS_FILE")"
+if [[ -z "$PROVIDER_REQUEST_ID" ]]; then
+  PROVIDER_REQUEST_ID="$(extract_body_request_id "$DIRECT_BODY_FILE")"
+fi
+
+write_lines "$META_FILE" \
+  "payload_path=$PAYLOAD_PATH" \
+  "captured_response_html=$CAPTURED_RESPONSE_HTML" \
+  "captured_request_id=$CAPTURED_REQUEST_ID" \
+  "captured_provider=${CAPTURED_PROVIDER:-}" \
+  "captured_target_url=${CAPTURED_TARGET_URL:-}" \
+  "captured_proxied_path=${CAPTURED_PROXIED_PATH:-}" \
+  "captured_attempt_no=${CAPTURED_ATTEMPT_NO:-}" \
+  "captured_stream=${CAPTURED_STREAM:-}" \
+  "captured_body_bytes=${CAPTURED_BODY_BYTES:-}" \
+  "direct_request_id=$DIRECT_REQUEST_ID" \
+  "direct_status=$DIRECT_STATUS" \
+  "provider_request_id=${PROVIDER_REQUEST_ID:-}" \
+  "direct_base_url=$DIRECT_BASE_URL" \
+  "direct_path=$DIRECT_PATH" \
+  "captured_headers_file=$CAPTURED_HEADERS_FILE" \
+  "captured_meta_file=$CAPTURED_META_FILE" \
+  "direct_headers_file=$DIRECT_HEADERS_FILE" \
+  "direct_body_file=$DIRECT_BODY_FILE"
+
+cat "$META_FILE"
+printf 'meta_file=%s\n' "$META_FILE"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,6 +18,7 @@ ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-set.sh" "${BIN_DIR}/innies-b
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-get.sh" "${BIN_DIR}/innies-buyer-preference-get"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-check.sh" "${BIN_DIR}/innies-buyer-preference-check"
 ln -sf "${ROOT_DIR}/scripts/innies-slo-check.sh" "${BIN_DIR}/innies-slo-check"
+ln -sf "${ROOT_DIR}/scripts/innies-compat-captured-lane-replay.sh" "${BIN_DIR}/innies-compat-captured-lane-replay"
 
 rm -f \
   "${BIN_DIR}/innies-admin" \
@@ -49,6 +50,7 @@ echo "  ${BIN_DIR}/innies-buyer-preference-set -> ${ROOT_DIR}/scripts/innies-buy
 echo "  ${BIN_DIR}/innies-buyer-preference-get -> ${ROOT_DIR}/scripts/innies-buyer-preference-get.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-check -> ${ROOT_DIR}/scripts/innies-buyer-preference-check.sh"
 echo "  ${BIN_DIR}/innies-slo-check -> ${ROOT_DIR}/scripts/innies-slo-check.sh"
+echo "  ${BIN_DIR}/innies-compat-captured-lane-replay -> ${ROOT_DIR}/scripts/innies-compat-captured-lane-replay.sh"
 echo
 echo 'If command not found, add ~/.local/bin to PATH:'
 echo '  export PATH="$HOME/.local/bin:$PATH"'

--- a/scripts/tests/innies-compat-captured-lane-provider-guard.test.sh
+++ b/scripts/tests/innies-compat-captured-lane-provider-guard.test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="$ROOT_DIR/scripts/innies-compat-captured-lane-replay.sh"
+TMP_DIR="$(mktemp -d)"
+PAYLOAD_PATH="$TMP_DIR/payload.json"
+CAPTURED_HTML_PATH="$TMP_DIR/response.html"
+STDOUT_PATH="$TMP_DIR/stdout.txt"
+STDERR_PATH="$TMP_DIR/stderr.txt"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+cat >"$PAYLOAD_PATH" <<'JSON'
+{"model":"claude-opus-4-6","stream":true,"max_tokens":16,"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}
+JSON
+
+cat >"$CAPTURED_HTML_PATH" <<'LOG'
+Mar 17 13:22:53 sf-prod bash[12345]: [compat-upstream-request-json-chunk] {
+Mar 17 13:22:53 sf-prod bash[12345]:   chunk_index: 0,
+Mar 17 13:22:53 sf-prod bash[12345]:   chunk_count: 1,
+Mar 17 13:22:53 sf-prod bash[12345]:   json: '{"attempt_no":1,"credential_id":"cred_issue80","headers":{"accept":"text/event-stream","authorization":"Bearer <redacted:108>","content-type":"application/json","x-request-id":"req_issue80_captured"},"provider":"openai","proxied_path":"/v1/messages","request_id":"req_issue80_captured","stream":true,"target_url":"https://chatgpt.com/backend-api/codex/responses"}'
+Mar 17 13:22:53 sf-prod bash[12345]: }
+LOG
+
+set +e
+INNIES_CAPTURED_RESPONSE_HTML="$CAPTURED_HTML_PATH" \
+INNIES_CAPTURED_REQUEST_ID="req_issue80_captured" \
+INNIES_REPLAY_OUT_DIR="$TMP_DIR/out" \
+INNIES_DIRECT_REQUEST_ID="req_issue80_direct" \
+ANTHROPIC_OAUTH_ACCESS_TOKEN="sk-ant-oat-direct-token" \
+"$SCRIPT_PATH" "$PAYLOAD_PATH" >"$STDOUT_PATH" 2>"$STDERR_PATH"
+STATUS=$?
+set -e
+
+if [[ "$STATUS" -eq 0 ]]; then
+  echo 'expected non-anthropic captured lane to fail'
+  exit 1
+fi
+
+grep -q 'error: captured Innies lane resolved to openai; expected anthropic' "$STDERR_PATH"

--- a/scripts/tests/innies-compat-captured-lane-replay-claude-env.test.sh
+++ b/scripts/tests/innies-compat-captured-lane-replay-claude-env.test.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="$ROOT_DIR/scripts/innies-compat-captured-lane-replay.sh"
+TMP_DIR="$(mktemp -d)"
+PAYLOAD_PATH="$TMP_DIR/payload.json"
+CAPTURED_HTML_PATH="$TMP_DIR/response.html"
+REQUESTS_DIR="$TMP_DIR/requests"
+OUT_DIR="$TMP_DIR/out"
+STDOUT_PATH="$TMP_DIR/stdout.txt"
+STDERR_PATH="$TMP_DIR/stderr.txt"
+mkdir -p "$REQUESTS_DIR"
+
+cleanup() {
+  if [[ -n "${SERVER_PID:-}" ]]; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+cat >"$PAYLOAD_PATH" <<'JSON'
+{"model":"claude-opus-4-6","stream":true,"max_tokens":16,"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}
+JSON
+
+cat >"$CAPTURED_HTML_PATH" <<'LOG'
+Mar 17 13:22:53 sf-prod bash[12345]: [compat-upstream-request-json-chunk] {
+Mar 17 13:22:53 sf-prod bash[12345]:   chunk_index: 0,
+Mar 17 13:22:53 sf-prod bash[12345]:   chunk_count: 1,
+Mar 17 13:22:53 sf-prod bash[12345]:   json: '{"attempt_no":1,"body_bytes":398262,"credential_id":"cred_issue80","headers":{"accept":"text/event-stream","anthropic-beta":"fine-grained-tool-streaming-2025-05-14,claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14","anthropic-dangerous-direct-browser-access":"true","anthropic-version":"2023-06-01","authorization":"Bearer <redacted:108>","content-type":"application/json","user-agent":"OpenClawGateway/1.0","x-app":"cli","x-request-id":"req_issue80_captured"},"provider":"anthropic","proxied_path":"/v1/messages","request_id":"req_issue80_captured","stream":true,"target_url":"https://api.anthropic.com/v1/messages"}'
+Mar 17 13:22:53 sf-prod bash[12345]: }
+LOG
+
+cat >"$TMP_DIR/mock-server.mjs" <<'NODE'
+import { createServer } from 'node:http';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const port = Number(process.env.PORT);
+const requestsDir = process.env.REQUESTS_DIR;
+mkdirSync(requestsDir, { recursive: true });
+
+const server = createServer((req, res) => {
+  const chunks = [];
+  req.on('data', (chunk) => chunks.push(chunk));
+  req.on('end', () => {
+    const body = Buffer.concat(chunks).toString('utf8');
+    const requestId = req.headers['x-request-id'] || `unknown-${Date.now()}`;
+    writeFileSync(join(requestsDir, `${requestId}.json`), JSON.stringify({
+      method: req.method,
+      url: req.url,
+      headers: req.headers,
+      body: JSON.parse(body)
+    }, null, 2));
+
+    res.statusCode = 400;
+    res.setHeader('content-type', 'application/json');
+    res.setHeader('request-id', 'req_upstream_captured_lane_claude_env');
+    res.end(JSON.stringify({
+      type: 'error',
+      error: { type: 'invalid_request_error', message: 'Error' },
+      request_id: 'req_upstream_captured_lane_claude_env'
+    }));
+  });
+});
+
+server.listen(port, '127.0.0.1', () => {
+  process.stdout.write(`ready:${port}\n`);
+});
+NODE
+
+PORT="$(node -e "const net=require('node:net');const s=net.createServer();s.listen(0,'127.0.0.1',()=>{const {port}=s.address();console.log(port);s.close();});")"
+PORT="$PORT" REQUESTS_DIR="$REQUESTS_DIR" node "$TMP_DIR/mock-server.mjs" >"$TMP_DIR/server.log" 2>&1 &
+SERVER_PID=$!
+
+for _ in $(seq 1 50); do
+  if grep -q '^ready:' "$TMP_DIR/server.log" 2>/dev/null; then
+    break
+  fi
+  sleep 0.1
+done
+
+if ! grep -q '^ready:' "$TMP_DIR/server.log" 2>/dev/null; then
+  echo 'server did not start'
+  cat "$TMP_DIR/server.log"
+  exit 1
+fi
+
+set +e
+INNIES_CAPTURED_RESPONSE_HTML="$CAPTURED_HTML_PATH" \
+INNIES_CAPTURED_REQUEST_ID="req_issue80_captured" \
+INNIES_REPLAY_OUT_DIR="$OUT_DIR" \
+INNIES_DIRECT_REQUEST_ID="req_issue80_direct_claude_env" \
+CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat-claude-env-token" \
+ANTHROPIC_DIRECT_BASE_URL="http://127.0.0.1:$PORT" \
+"$SCRIPT_PATH" "$PAYLOAD_PATH" >"$STDOUT_PATH" 2>"$STDERR_PATH"
+STATUS=$?
+set -e
+
+if [[ "$STATUS" -ne 0 ]]; then
+  cat "$STDERR_PATH"
+  exit 1
+fi
+
+grep -q 'direct_status=400' "$OUT_DIR/meta.txt"
+grep -q 'provider_request_id=req_upstream_captured_lane_claude_env' "$OUT_DIR/meta.txt"
+grep -q 'direct_access_token_source=claude_code_oauth_token' "$OUT_DIR/meta.txt"
+grep -q '"authorization": "Bearer sk-ant-oat-claude-env-token"' "$REQUESTS_DIR/req_issue80_direct_claude_env.json"

--- a/scripts/tests/innies-compat-captured-lane-replay.test.sh
+++ b/scripts/tests/innies-compat-captured-lane-replay.test.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="$ROOT_DIR/scripts/innies-compat-captured-lane-replay.sh"
+TMP_DIR="$(mktemp -d)"
+PAYLOAD_PATH="$TMP_DIR/payload.json"
+CAPTURED_HTML_PATH="$TMP_DIR/response.html"
+REQUESTS_DIR="$TMP_DIR/requests"
+OUT_DIR="$TMP_DIR/out"
+STDOUT_PATH="$TMP_DIR/stdout.txt"
+STDERR_PATH="$TMP_DIR/stderr.txt"
+mkdir -p "$REQUESTS_DIR"
+
+cleanup() {
+  if [[ -n "${SERVER_PID:-}" ]]; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+cat >"$PAYLOAD_PATH" <<'JSON'
+{"model":"claude-opus-4-6","stream":true,"max_tokens":16,"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}
+JSON
+
+cat >"$CAPTURED_HTML_PATH" <<'LOG'
+Mar 17 13:22:53 sf-prod bash[12345]: [compat-upstream-request-json-chunk] {
+Mar 17 13:22:53 sf-prod bash[12345]:   chunk_index: 0,
+Mar 17 13:22:53 sf-prod bash[12345]:   chunk_count: 1,
+Mar 17 13:22:53 sf-prod bash[12345]:   json: '{"attempt_no":1,"body_bytes":398262,"credential_id":"cred_issue80","headers":{"accept":"text/event-stream","anthropic-beta":"fine-grained-tool-streaming-2025-05-14,claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14","anthropic-dangerous-direct-browser-access":"true","anthropic-version":"2023-06-01","authorization":"Bearer <redacted:108>","content-type":"application/json","user-agent":"OpenClawGateway/1.0","x-app":"cli","x-request-id":"req_issue80_captured"},"provider":"anthropic","proxied_path":"/v1/messages","request_id":"req_issue80_captured","stream":true,"target_url":"https://api.anthropic.com/v1/messages"}'
+Mar 17 13:22:53 sf-prod bash[12345]: }
+LOG
+
+cat >"$TMP_DIR/mock-server.mjs" <<'NODE'
+import { createServer } from 'node:http';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const port = Number(process.env.PORT);
+const requestsDir = process.env.REQUESTS_DIR;
+mkdirSync(requestsDir, { recursive: true });
+
+const server = createServer((req, res) => {
+  const chunks = [];
+  req.on('data', (chunk) => chunks.push(chunk));
+  req.on('end', () => {
+    const body = Buffer.concat(chunks).toString('utf8');
+    const requestId = req.headers['x-request-id'] || `unknown-${Date.now()}`;
+    writeFileSync(join(requestsDir, `${requestId}.json`), JSON.stringify({
+      method: req.method,
+      url: req.url,
+      headers: req.headers,
+      body: JSON.parse(body)
+    }, null, 2));
+
+    res.statusCode = 400;
+    res.setHeader('content-type', 'application/json');
+    res.setHeader('request-id', 'req_upstream_captured_lane');
+    res.end(JSON.stringify({
+      type: 'error',
+      error: { type: 'invalid_request_error', message: 'Error' },
+      request_id: 'req_upstream_captured_lane'
+    }));
+  });
+});
+
+server.listen(port, '127.0.0.1', () => {
+  process.stdout.write(`ready:${port}\n`);
+});
+NODE
+
+PORT="$(node -e "const net=require('node:net');const s=net.createServer();s.listen(0,'127.0.0.1',()=>{const {port}=s.address();console.log(port);s.close();});")"
+PORT="$PORT" REQUESTS_DIR="$REQUESTS_DIR" node "$TMP_DIR/mock-server.mjs" >"$TMP_DIR/server.log" 2>&1 &
+SERVER_PID=$!
+
+for _ in $(seq 1 50); do
+  if grep -q '^ready:' "$TMP_DIR/server.log" 2>/dev/null; then
+    break
+  fi
+  sleep 0.1
+done
+
+if ! grep -q '^ready:' "$TMP_DIR/server.log" 2>/dev/null; then
+  echo 'server did not start'
+  cat "$TMP_DIR/server.log"
+  exit 1
+fi
+
+set +e
+INNIES_CAPTURED_RESPONSE_HTML="$CAPTURED_HTML_PATH" \
+INNIES_CAPTURED_REQUEST_ID="req_issue80_captured" \
+INNIES_REPLAY_OUT_DIR="$OUT_DIR" \
+INNIES_DIRECT_REQUEST_ID="req_issue80_direct" \
+ANTHROPIC_OAUTH_ACCESS_TOKEN="sk-ant-oat-direct-token" \
+ANTHROPIC_DIRECT_BASE_URL="http://127.0.0.1:$PORT" \
+"$SCRIPT_PATH" "$PAYLOAD_PATH" >"$STDOUT_PATH" 2>"$STDERR_PATH"
+STATUS=$?
+set -e
+
+if [[ "$STATUS" -ne 0 ]]; then
+  cat "$STDERR_PATH"
+  exit 1
+fi
+
+[[ -f "$OUT_DIR/meta.txt" ]]
+[[ -f "$OUT_DIR/captured-headers.tsv" ]]
+[[ -f "$OUT_DIR/direct-headers.txt" ]]
+[[ -f "$OUT_DIR/direct-body.txt" ]]
+
+grep -q 'captured_request_id=req_issue80_captured' "$OUT_DIR/meta.txt"
+grep -q 'captured_provider=anthropic' "$OUT_DIR/meta.txt"
+grep -q 'direct_request_id=req_issue80_direct' "$OUT_DIR/meta.txt"
+grep -q 'direct_status=400' "$OUT_DIR/meta.txt"
+grep -q 'provider_request_id=req_upstream_captured_lane' "$OUT_DIR/meta.txt"
+
+grep -q '"authorization": "Bearer sk-ant-oat-direct-token"' "$REQUESTS_DIR/req_issue80_direct.json"
+grep -q '"anthropic-dangerous-direct-browser-access": "true"' "$REQUESTS_DIR/req_issue80_direct.json"
+grep -q '"x-app": "cli"' "$REQUESTS_DIR/req_issue80_direct.json"
+grep -q '"user-agent": "OpenClawGateway/1.0"' "$REQUESTS_DIR/req_issue80_direct.json"
+grep -q '"anthropic-beta": "fine-grained-tool-streaming-2025-05-14,claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14"' "$REQUESTS_DIR/req_issue80_direct.json"
+grep -q '"x-request-id": "req_issue80_direct"' "$REQUESTS_DIR/req_issue80_direct.json"


### PR DESCRIPTION
## Summary
- add the captured Anthropic first-pass replay helper plus focused shell coverage on top of `main`
- accept `CLAUDE_CODE_OAUTH_TOKEN` in addition to the Anthropic-specific env vars when resolving the direct replay bearer
- record `direct_access_token_source` in `meta.txt` so issue-80 handoffs can show which direct bearer lane was actually used

## Test Plan
- bash scripts/tests/innies-compat-captured-lane-replay.test.sh
- bash scripts/tests/innies-compat-captured-lane-provider-guard.test.sh
- bash scripts/tests/innies-compat-captured-lane-replay-claude-env.test.sh
- bash -n scripts/innies-compat-captured-lane-replay.sh scripts/tests/innies-compat-captured-lane-replay.test.sh scripts/tests/innies-compat-captured-lane-provider-guard.test.sh scripts/tests/innies-compat-captured-lane-replay-claude-env.test.sh scripts/install.sh
- real issue artifact replayed against a mock Anthropic endpoint using `CLAUDE_CODE_OAUTH_TOKEN=...` and `/Users/dylanvu/Downloads/response_1773768207701.html`

## Notes
- supersedes the narrower `#90` helper branch by carrying the same helper forward with the native Claude token env fallback needed for operator runs
- Refs #80