### PR TITLE
chore: add compat first-pass wire diff helper

### DIFF
--- a/docs/superpowers/plans/2026-03-17-issue80-first-pass-wire-diff.md
+++ b/docs/superpowers/plans/2026-03-17-issue80-first-pass-wire-diff.md
@@ -1,0 +1,135 @@
+# Issue 80 First-Pass Wire Diff Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a reusable helper that diffs a failing Innies Anthropic first-pass request bundle against a known-good direct/OpenClaw Anthropic first-pass bundle and reports the exact header/body deltas for issue `#80`.
+
+**Architecture:** Keep the change in the `scripts/` support-tooling surface. A thin shell wrapper will validate inputs and invoke a small Node script that normalizes the two request bundles, compares exact headers plus body metadata, and writes both a human-readable summary and machine-readable diff JSON.
+
+**Tech Stack:** Bash, Node.js, JSON, shell regression tests
+
+---
+
+## References
+
+- Issue brief: `/tmp/issue80.json`
+- Existing script conventions: `/Users/dylanvu/Forge/.repos/github.com/shirtlessfounder/innies/.worktrees/worker-02-80-first-pass-wire-diff/scripts/_common.sh`
+- Real failing extracted bundle: `/private/tmp/issue80-artifact-extract-real/upstream-request.json`
+- Scripts docs: `/Users/dylanvu/Forge/.repos/github.com/shirtlessfounder/innies/.worktrees/worker-02-80-first-pass-wire-diff/scripts/README.md`
+
+## File Structure
+
+### Create
+
+- `scripts/innies-compat-wire-diff.sh`
+  - Operator entrypoint that validates bundle paths, creates an output directory, and invokes the diff engine.
+- `scripts/innies-compat-wire-diff.mjs`
+  - Normalizes the left/right request bundles and produces header/body delta artifacts plus a concise summary.
+- `scripts/tests/innies-compat-wire-diff.test.sh`
+  - Focused shell regression for matching bundles, header/body deltas, and missing-input failures.
+
+### Modify
+
+- `scripts/install.sh`
+  - Install the new helper into `~/.local/bin`.
+- `scripts/README.md`
+  - Document the helper’s purpose, inputs, and output files.
+
+## Chunk 1: Diff Helper
+
+### Task 1: Lock the operator contract with failing tests
+
+**Files:**
+- Create: `scripts/tests/innies-compat-wire-diff.test.sh`
+
+- [ ] **Step 1: Write the failing shell tests**
+
+```bash
+bash scripts/tests/innies-compat-wire-diff.test.sh
+```
+
+The tests should assert:
+- identical request bundles report `body_match=true` and no header deltas
+- changed headers/body metadata report explicit deltas in `summary.txt` and `diff.json`
+- missing request bundle paths fail fast with a clear error
+
+- [ ] **Step 2: Run the new test to verify it fails**
+
+Run: `bash scripts/tests/innies-compat-wire-diff.test.sh`
+Expected: FAIL because `scripts/innies-compat-wire-diff.sh` does not exist yet.
+
+### Task 2: Implement the diff helper and wiring
+
+**Files:**
+- Create: `scripts/innies-compat-wire-diff.sh`
+- Create: `scripts/innies-compat-wire-diff.mjs`
+- Modify: `scripts/install.sh`
+- Modify: `scripts/README.md`
+
+- [ ] **Step 1: Add the shell entrypoint**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+LEFT_BUNDLE="$1"
+RIGHT_BUNDLE="$2"
+OUT_DIR="${INNIES_WIRE_DIFF_OUT_DIR:-/tmp/innies-wire-diff}"
+
+node "${ROOT_DIR}/scripts/innies-compat-wire-diff.mjs" \
+  "$LEFT_BUNDLE" \
+  "$RIGHT_BUNDLE" \
+  "$OUT_DIR"
+```
+
+- [ ] **Step 2: Add the Node diff engine**
+
+The engine should:
+- read two request-bundle JSON files
+- normalize header names to lowercase
+- compare exact header values, missing-on-left, and missing-on-right
+- compare `body_sha256`, `body_bytes`, `method`, `target_url`, and `request_id`
+- write `summary.txt` and `diff.json`
+
+- [ ] **Step 3: Wire the helper into install/docs**
+
+Add one symlink line to `scripts/install.sh` and a concise command section to `scripts/README.md`.
+
+- [ ] **Step 4: Re-run the focused test**
+
+Run: `bash scripts/tests/innies-compat-wire-diff.test.sh`
+Expected: PASS.
+
+### Task 3: Verify with real issue-80 evidence
+
+**Files:**
+- No repo file changes
+
+- [ ] **Step 1: Syntax-check the touched scripts**
+
+Run:
+```bash
+bash -n scripts/innies-compat-wire-diff.sh scripts/tests/innies-compat-wire-diff.test.sh scripts/install.sh
+node --check scripts/innies-compat-wire-diff.mjs
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run the helper against real saved issue-80 evidence**
+
+Run:
+```bash
+INNIES_WIRE_DIFF_OUT_DIR=/private/tmp/issue80-wire-diff-smoke \
+scripts/innies-compat-wire-diff.sh \
+  /private/tmp/issue80-artifact-extract-real/upstream-request.json \
+  /private/tmp/issue80-artifact-extract-real/upstream-request.json
+```
+
+Expected: PASS with `body_match=true`, zero header deltas, and output artifacts under `/private/tmp/issue80-wire-diff-smoke`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/innies-compat-wire-diff.sh scripts/innies-compat-wire-diff.mjs scripts/tests/innies-compat-wire-diff.test.sh scripts/install.sh scripts/README.md docs/superpowers/plans/2026-03-17-issue80-first-pass-wire-diff.md
+git commit -m "chore: add compat first-pass wire diff helper"
+```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -25,6 +25,7 @@ innies-buyer-preference-set
 innies-buyer-preference-get
 innies-buyer-preference-check
 innies-slo-check
+innies-compat-wire-diff
 ```
 
 What they do:
@@ -40,6 +41,7 @@ What they do:
 - `innies-buyer-preference-get`: read the current buyer key preference
 - `innies-buyer-preference-check`: run the provider-preference canary after prompting for the expected provider (`Claude Code` or `Codex`)
 - `innies-slo-check`: query analytics endpoints and report Phase 1 SLO pass/fail (TTFB p95, timeout rate, success rate, fallback rate); optional arg sets the window (default `24h`); exits 0 if all SLOs pass, 1 if any fail
+- `innies-compat-wire-diff`: compare two captured Anthropic first-pass request bundles and report exact header/body deltas
 
 Behavior:
 - org id auto-uses `INNIES_ORG_ID`
@@ -79,6 +81,17 @@ Behavior:
 - non-pinned buyer traffic always gets automatic cross-provider fallback to the other provider; flipping preference flips fallback order too
 - `innies-buyer-preference-set` prints the effective preferred provider plus the automatic fallback provider before sending the update
 - `innies-buyer-preference-check` now expects and validates the two-provider plan in DB evidence mode
+- `innies-compat-wire-diff` accepts either JSON request-bundle files or directories containing `upstream-request.json`, `request.json`, or `direct-request.json`
+- `innies-compat-wire-diff` writes `summary.txt`, `diff.json`, and normalized left/right bundle snapshots into `INNIES_WIRE_DIFF_OUT_DIR` (or a fresh temp dir when unset)
+
+Example:
+
+```bash
+INNIES_WIRE_DIFF_OUT_DIR=/private/tmp/issue80-wire-diff \
+innies-compat-wire-diff \
+  /private/tmp/issue80-artifact-extract-real/upstream-request.json \
+  /private/tmp/known-good-direct-request.json
+```
 
 ## Env
 

--- a/scripts/innies-compat-wire-diff.mjs
+++ b/scripts/innies-compat-wire-diff.mjs
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+
+import { mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { basename, join, resolve } from 'node:path';
+
+function fail(message) {
+  console.error(`error: ${message}`);
+  process.exit(1);
+}
+
+function resolveBundlePath(inputPath) {
+  const resolvedPath = resolve(inputPath);
+
+  let stats;
+  try {
+    stats = statSync(resolvedPath);
+  } catch {
+    fail(`request bundle not found: ${resolvedPath}`);
+  }
+
+  if (stats.isFile()) {
+    return resolvedPath;
+  }
+
+  if (!stats.isDirectory()) {
+    fail(`request bundle path is neither a file nor directory: ${resolvedPath}`);
+  }
+
+  for (const candidateName of ['upstream-request.json', 'request.json', 'direct-request.json']) {
+    const candidatePath = join(resolvedPath, candidateName);
+    try {
+      if (statSync(candidatePath).isFile()) {
+        return candidatePath;
+      }
+    } catch {
+      // keep searching
+    }
+  }
+
+  fail(`no request bundle json found in directory: ${resolvedPath}`);
+}
+
+function readJson(filePath) {
+  try {
+    return JSON.parse(readFileSync(filePath, 'utf8'));
+  } catch (error) {
+    fail(`failed to read json from ${filePath}: ${error.message}`);
+  }
+}
+
+function toStringValue(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  return JSON.stringify(value);
+}
+
+function toNullableNumber(value) {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+
+  const coerced = Number(value);
+  return Number.isFinite(coerced) ? coerced : null;
+}
+
+function normalizeHeaders(headers) {
+  if (!headers || typeof headers !== 'object' || Array.isArray(headers)) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(headers)
+      .map(([name, value]) => [String(name).toLowerCase(), toStringValue(value)])
+      .sort(([leftName], [rightName]) => leftName.localeCompare(rightName))
+  );
+}
+
+function readBundle(inputPath) {
+  const bundlePath = resolveBundlePath(inputPath);
+  const raw = readJson(bundlePath);
+
+  return {
+    source_path: bundlePath,
+    source_name: basename(bundlePath),
+    method: raw.method ? toStringValue(raw.method) : null,
+    target_url: raw.target_url ? toStringValue(raw.target_url) : raw.targetUrl ? toStringValue(raw.targetUrl) : null,
+    request_id: raw.request_id ? toStringValue(raw.request_id) : raw.requestId ? toStringValue(raw.requestId) : null,
+    body_sha256: raw.body_sha256 ? toStringValue(raw.body_sha256) : raw.bodySha256 ? toStringValue(raw.bodySha256) : null,
+    body_bytes: raw.body_bytes !== undefined ? toNullableNumber(raw.body_bytes) : toNullableNumber(raw.bodyBytes),
+    headers: normalizeHeaders(raw.headers)
+  };
+}
+
+function compareScalar(leftValue, rightValue) {
+  return {
+    left: leftValue,
+    right: rightValue,
+    match: leftValue === rightValue
+  };
+}
+
+function compareHeaders(leftHeaders, rightHeaders) {
+  const changed = [];
+  const leftOnly = [];
+  const rightOnly = [];
+
+  const allHeaderNames = Array.from(
+    new Set([...Object.keys(leftHeaders), ...Object.keys(rightHeaders)])
+  ).sort((leftName, rightName) => leftName.localeCompare(rightName));
+
+  for (const headerName of allHeaderNames) {
+    const leftHas = Object.prototype.hasOwnProperty.call(leftHeaders, headerName);
+    const rightHas = Object.prototype.hasOwnProperty.call(rightHeaders, headerName);
+
+    if (leftHas && rightHas) {
+      if (leftHeaders[headerName] !== rightHeaders[headerName]) {
+        changed.push({
+          name: headerName,
+          left: leftHeaders[headerName],
+          right: rightHeaders[headerName]
+        });
+      }
+      continue;
+    }
+
+    if (leftHas) {
+      leftOnly.push({
+        name: headerName,
+        value: leftHeaders[headerName]
+      });
+      continue;
+    }
+
+    rightOnly.push({
+      name: headerName,
+      value: rightHeaders[headerName]
+    });
+  }
+
+  return { changed, leftOnly, rightOnly };
+}
+
+function maybeSummaryLine(key, values) {
+  if (values.length === 0) {
+    return null;
+  }
+
+  return `${key}=${values.join(',')}`;
+}
+
+const [, , leftInput, rightInput, outDirInput] = process.argv;
+
+if (!leftInput || !rightInput || !outDirInput) {
+  fail('expected left input, right input, and output directory arguments');
+}
+
+const outDir = resolve(outDirInput);
+mkdirSync(outDir, { recursive: true });
+
+const leftBundle = readBundle(leftInput);
+const rightBundle = readBundle(rightInput);
+const headerComparison = compareHeaders(leftBundle.headers, rightBundle.headers);
+
+const comparison = {
+  method: compareScalar(leftBundle.method, rightBundle.method),
+  target_url: compareScalar(leftBundle.target_url, rightBundle.target_url),
+  request_id: compareScalar(leftBundle.request_id, rightBundle.request_id),
+  body_sha256: compareScalar(leftBundle.body_sha256, rightBundle.body_sha256),
+  body_bytes: compareScalar(leftBundle.body_bytes, rightBundle.body_bytes),
+  headers: headerComparison
+};
+
+const bodyMatch = comparison.body_sha256.match && comparison.body_bytes.match;
+
+const summaryLines = [
+  `left_bundle=${leftBundle.source_path}`,
+  `right_bundle=${rightBundle.source_path}`,
+  `left_request_id=${leftBundle.request_id ?? ''}`,
+  `right_request_id=${rightBundle.request_id ?? ''}`,
+  `body_match=${bodyMatch}`,
+  `body_sha256_match=${comparison.body_sha256.match}`,
+  `body_bytes_match=${comparison.body_bytes.match}`,
+  `method_match=${comparison.method.match}`,
+  `target_url_match=${comparison.target_url.match}`,
+  `changed_header_count=${headerComparison.changed.length}`,
+  `left_only_header_count=${headerComparison.leftOnly.length}`,
+  `right_only_header_count=${headerComparison.rightOnly.length}`,
+  maybeSummaryLine('changed_headers', headerComparison.changed.map(({ name }) => name)),
+  maybeSummaryLine('left_only_headers', headerComparison.leftOnly.map(({ name }) => name)),
+  maybeSummaryLine('right_only_headers', headerComparison.rightOnly.map(({ name }) => name))
+].filter(Boolean);
+
+const diff = {
+  left: leftBundle,
+  right: rightBundle,
+  comparisons: comparison
+};
+
+writeFileSync(join(outDir, 'summary.txt'), `${summaryLines.join('\n')}\n`);
+writeFileSync(join(outDir, 'diff.json'), `${JSON.stringify(diff, null, 2)}\n`);
+writeFileSync(join(outDir, 'left.normalized.json'), `${JSON.stringify(leftBundle, null, 2)}\n`);
+writeFileSync(join(outDir, 'right.normalized.json'), `${JSON.stringify(rightBundle, null, 2)}\n`);
+
+console.log(`wrote ${join(outDir, 'summary.txt')}`);

--- a/scripts/innies-compat-wire-diff.sh
+++ b/scripts/innies-compat-wire-diff.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_PATH" ]]; do
+  SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+  SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"
+  [[ "$SCRIPT_PATH" != /* ]] && SCRIPT_PATH="${SCRIPT_DIR}/${SCRIPT_PATH}"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+usage() {
+  cat >&2 <<'EOF'
+usage: scripts/innies-compat-wire-diff.sh <left-request-bundle.json|dir> <right-request-bundle.json|dir>
+
+Compares two captured Anthropic first-pass request bundles and writes summary.txt plus diff.json.
+Set INNIES_WIRE_DIFF_OUT_DIR to control the output directory.
+EOF
+}
+
+if [[ $# -ne 2 ]]; then
+  usage
+  exit 1
+fi
+
+LEFT_INPUT="$1"
+RIGHT_INPUT="$2"
+
+if [[ ! -e "$LEFT_INPUT" ]]; then
+  echo "error: request bundle not found: $LEFT_INPUT" >&2
+  exit 1
+fi
+
+if [[ ! -e "$RIGHT_INPUT" ]]; then
+  echo "error: request bundle not found: $RIGHT_INPUT" >&2
+  exit 1
+fi
+
+OUT_DIR="${INNIES_WIRE_DIFF_OUT_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/innies-wire-diff.XXXXXX")}"
+mkdir -p "$OUT_DIR"
+
+node "${ROOT_DIR}/scripts/innies-compat-wire-diff.mjs" "$LEFT_INPUT" "$RIGHT_INPUT" "$OUT_DIR"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,6 +18,7 @@ ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-set.sh" "${BIN_DIR}/innies-b
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-get.sh" "${BIN_DIR}/innies-buyer-preference-get"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-check.sh" "${BIN_DIR}/innies-buyer-preference-check"
 ln -sf "${ROOT_DIR}/scripts/innies-slo-check.sh" "${BIN_DIR}/innies-slo-check"
+ln -sf "${ROOT_DIR}/scripts/innies-compat-wire-diff.sh" "${BIN_DIR}/innies-compat-wire-diff"
 
 rm -f \
   "${BIN_DIR}/innies-admin" \
@@ -49,6 +50,7 @@ echo "  ${BIN_DIR}/innies-buyer-preference-set -> ${ROOT_DIR}/scripts/innies-buy
 echo "  ${BIN_DIR}/innies-buyer-preference-get -> ${ROOT_DIR}/scripts/innies-buyer-preference-get.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-check -> ${ROOT_DIR}/scripts/innies-buyer-preference-check.sh"
 echo "  ${BIN_DIR}/innies-slo-check -> ${ROOT_DIR}/scripts/innies-slo-check.sh"
+echo "  ${BIN_DIR}/innies-compat-wire-diff -> ${ROOT_DIR}/scripts/innies-compat-wire-diff.sh"
 echo
 echo 'If command not found, add ~/.local/bin to PATH:'
 echo '  export PATH="$HOME/.local/bin:$PATH"'

--- a/scripts/tests/innies-compat-wire-diff.test.sh
+++ b/scripts/tests/innies-compat-wire-diff.test.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="${ROOT_DIR}/scripts/innies-compat-wire-diff.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file_path="$1"
+  local expected="$2"
+  if ! grep -Fq "$expected" "$file_path"; then
+    echo "expected to find: $expected" >&2
+    echo "--- ${file_path} ---" >&2
+    cat "$file_path" >&2
+    fail "missing expected content"
+  fi
+}
+
+assert_not_contains() {
+  local file_path="$1"
+  local unexpected="$2"
+  if grep -Fq "$unexpected" "$file_path"; then
+    echo "did not expect to find: $unexpected" >&2
+    echo "--- ${file_path} ---" >&2
+    cat "$file_path" >&2
+    fail "unexpected content present"
+  fi
+}
+
+assert_file_exists() {
+  local file_path="$1"
+  [[ -f "$file_path" ]] || fail "expected file to exist: $file_path"
+}
+
+make_bundle() {
+  local file_path="$1"
+  local body_bytes="$2"
+  local body_sha="$3"
+  local beta="$4"
+  local user_agent="$5"
+  local request_id="$6"
+  cat >"$file_path" <<EOF_JSON
+{
+  "method": "POST",
+  "target_url": "https://api.anthropic.com/v1/messages",
+  "request_id": "${request_id}",
+  "body_bytes": ${body_bytes},
+  "body_sha256": "${body_sha}",
+  "headers": {
+    "accept": "text/event-stream",
+    "anthropic-beta": "${beta}",
+    "anthropic-version": "2023-06-01",
+    "content-type": "application/json",
+    "user-agent": "${user_agent}",
+    "x-request-id": "${request_id}"
+  }
+}
+EOF_JSON
+}
+
+test_identical_bundles() {
+  local tmp_dir out_dir
+  tmp_dir="$(mktemp -d)"
+  out_dir="${tmp_dir}/out"
+
+  make_bundle \
+    "${tmp_dir}/left.json" \
+    398262 \
+    "1717a039bed013d162eb47daead7f7eea440bccc6fb2719b9233142976e9a093" \
+    "fine-grained-tool-streaming-2025-05-14" \
+    "OpenClawGateway/1.0" \
+    "req_left"
+  cp "${tmp_dir}/left.json" "${tmp_dir}/right.json"
+
+  INNIES_WIRE_DIFF_OUT_DIR="$out_dir" "$SCRIPT_PATH" "${tmp_dir}/left.json" "${tmp_dir}/right.json"
+
+  assert_file_exists "${out_dir}/summary.txt"
+  assert_file_exists "${out_dir}/diff.json"
+  assert_contains "${out_dir}/summary.txt" "body_match=true"
+  assert_contains "${out_dir}/summary.txt" "body_bytes_match=true"
+  assert_contains "${out_dir}/summary.txt" "changed_header_count=0"
+  assert_contains "${out_dir}/summary.txt" "left_only_header_count=0"
+  assert_contains "${out_dir}/summary.txt" "right_only_header_count=0"
+  assert_not_contains "${out_dir}/summary.txt" "changed_headers="
+}
+
+test_symlink_invocation() {
+  local tmp_dir out_dir symlink_dir symlink_path
+  tmp_dir="$(mktemp -d)"
+  out_dir="${tmp_dir}/out"
+  symlink_dir="${tmp_dir}/bin"
+  symlink_path="${symlink_dir}/innies-compat-wire-diff"
+
+  mkdir -p "$symlink_dir"
+
+  make_bundle \
+    "${tmp_dir}/left.json" \
+    398262 \
+    "1717a039bed013d162eb47daead7f7eea440bccc6fb2719b9233142976e9a093" \
+    "fine-grained-tool-streaming-2025-05-14" \
+    "OpenClawGateway/1.0" \
+    "req_left"
+  cp "${tmp_dir}/left.json" "${tmp_dir}/right.json"
+  ln -sf "$SCRIPT_PATH" "$symlink_path"
+
+  INNIES_WIRE_DIFF_OUT_DIR="$out_dir" "$symlink_path" "${tmp_dir}/left.json" "${tmp_dir}/right.json"
+
+  assert_contains "${out_dir}/summary.txt" "body_match=true"
+}
+
+test_detects_deltas() {
+  local tmp_dir out_dir
+  tmp_dir="$(mktemp -d)"
+  out_dir="${tmp_dir}/out"
+
+  make_bundle \
+    "${tmp_dir}/left.json" \
+    398262 \
+    "1717a039bed013d162eb47daead7f7eea440bccc6fb2719b9233142976e9a093" \
+    "fine-grained-tool-streaming-2025-05-14,oauth-2025-04-20" \
+    "OpenClawGateway/1.0" \
+    "req_left"
+  make_bundle \
+    "${tmp_dir}/right.json" \
+    398999 \
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+    "fine-grained-tool-streaming-2025-05-14" \
+    "Claude/1.0" \
+    "req_right"
+
+  jq 'del(.headers["x-request-id"]) | .headers["x-extra-direct"] = "true"' \
+    "${tmp_dir}/right.json" > "${tmp_dir}/right-mutated.json"
+  mv "${tmp_dir}/right-mutated.json" "${tmp_dir}/right.json"
+
+  INNIES_WIRE_DIFF_OUT_DIR="$out_dir" "$SCRIPT_PATH" "${tmp_dir}/left.json" "${tmp_dir}/right.json"
+
+  assert_contains "${out_dir}/summary.txt" "body_match=false"
+  assert_contains "${out_dir}/summary.txt" "body_bytes_match=false"
+  assert_contains "${out_dir}/summary.txt" "changed_header_count=2"
+  assert_contains "${out_dir}/summary.txt" "left_only_header_count=1"
+  assert_contains "${out_dir}/summary.txt" "right_only_header_count=1"
+  assert_contains "${out_dir}/summary.txt" "changed_headers=anthropic-beta,user-agent"
+  assert_contains "${out_dir}/summary.txt" "left_only_headers=x-request-id"
+  assert_contains "${out_dir}/summary.txt" "right_only_headers=x-extra-direct"
+  assert_contains "${out_dir}/diff.json" "\"body_sha256\""
+  assert_contains "${out_dir}/diff.json" "\"x-extra-direct\""
+}
+
+test_missing_input_fails() {
+  local tmp_dir stderr_file
+  tmp_dir="$(mktemp -d)"
+  stderr_file="${tmp_dir}/stderr.txt"
+
+  if "$SCRIPT_PATH" "${tmp_dir}/missing-left.json" "${tmp_dir}/missing-right.json" 2>"${stderr_file}"; then
+    fail "expected missing-input invocation to fail"
+  fi
+
+  assert_contains "${stderr_file}" "error: request bundle not found"
+}
+
+test_identical_bundles
+test_symlink_invocation
+test_detects_deltas
+test_missing_input_fails
+
+echo "PASS: innies-compat-wire-diff"


### PR DESCRIPTION
## Summary
- add `innies-compat-wire-diff`, a focused helper that compares two captured Anthropic first-pass request bundles and reports exact header/body deltas for issue `#80`
- accept either direct JSON bundle paths or extracted bundle directories, and write `summary.txt`, `diff.json`, plus normalized left/right snapshots for operator follow-up
- wire the helper into `scripts/install.sh` and `scripts/README.md`, with focused shell coverage including the installed-symlink invocation path

## Test Plan
- `bash scripts/tests/innies-compat-wire-diff.test.sh`
- `bash -n scripts/innies-compat-wire-diff.sh scripts/tests/innies-compat-wire-diff.test.sh scripts/install.sh`
- `node --check scripts/innies-compat-wire-diff.mjs`
- `git diff --check`
- `INNIES_WIRE_DIFF_OUT_DIR=/private/tmp/issue80-wire-diff-smoke scripts/innies-compat-wire-diff.sh /private/tmp/issue80-artifact-extract-real/upstream-request.json /private/tmp/issue80-artifact-extract-real/upstream-request.json`

Refs #80
