### PR TITLE
chore: add compat first-pass bundle diff helper

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -25,6 +25,7 @@ innies-buyer-preference-set
 innies-buyer-preference-get
 innies-buyer-preference-check
 innies-slo-check
+innies-compat-first-pass-bundle-diff
 ```
 
 What they do:
@@ -40,6 +41,7 @@ What they do:
 - `innies-buyer-preference-get`: read the current buyer key preference
 - `innies-buyer-preference-check`: run the provider-preference canary after prompting for the expected provider (`Claude Code` or `Codex`)
 - `innies-slo-check`: query analytics endpoints and report Phase 1 SLO pass/fail (TTFB p95, timeout rate, success rate, fallback rate); optional arg sets the window (default `24h`); exits 0 if all SLOs pass, 1 if any fail
+- `innies-compat-first-pass-bundle-diff`: compare extracted compat first-pass bundles and write exact header/body deltas for the current issue-80 wire-diff path
 
 Behavior:
 - org id auto-uses `INNIES_ORG_ID`
@@ -73,6 +75,9 @@ Behavior:
 - `innies-token-usage-refresh` lists unexpired Claude credentials in `active|paused|maxed`, plus expired Claude OAuth credentials that still have a stored refresh token (shown as `expired`) so you can recover them manually
 - `innies-token-usage-refresh` also needs `INNIES_ADMIN_API_KEY` (or prompts for it) because it calls the admin API provider-usage refresh endpoint directly
 - `innies-token-usage-refresh` bypasses in-memory usage-fetch backoff and prints both parsed 5h / 7d usage plus the raw Anthropic payload
+- `innies-compat-first-pass-bundle-diff` accepts either:
+  - one extracted bundle directory to compare `ingress.json` vs `upstream-request.json`
+  - or two bundle specs, where directories default to `#upstream` and explicit `#ingress` / `#upstream` selectors override that
 - `label` maps to API field `debugLabel`
 - set/get preference accept either the buyer-key UUID or the live buyer key value; live-key lookup uses `DATABASE_URL`
 - script-side default provider display for `null` preference follows `BUYER_PROVIDER_PREFERENCE_DEFAULT` (legacy alias `INNIES_BUYER_PROVIDER_PREFERENCE_DEFAULT` also works)

--- a/scripts/innies-compat-first-pass-bundle-diff.mjs
+++ b/scripts/innies-compat-first-pass-bundle-diff.mjs
@@ -1,0 +1,328 @@
+import { createHash } from 'node:crypto';
+import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { basename, dirname, join, resolve } from 'node:path';
+
+function usage() {
+  throw new Error(
+    'usage: node innies-compat-first-pass-bundle-diff.mjs <left-spec> <right-spec> <out-dir>'
+  );
+}
+
+function parseSpec(spec) {
+  const suffixes = ['#ingress', '#upstream'];
+  for (const suffix of suffixes) {
+    if (spec.endsWith(suffix)) {
+      return {
+        raw: spec,
+        path: spec.slice(0, -suffix.length),
+        selector: suffix.slice(1)
+      };
+    }
+  }
+  return { raw: spec, path: spec, selector: null };
+}
+
+function parseSummary(text) {
+  const result = {};
+  for (const line of text.split(/\r?\n/)) {
+    if (!line || !line.includes('=')) continue;
+    const index = line.indexOf('=');
+    const key = line.slice(0, index);
+    const value = line.slice(index + 1);
+    result[key] = value;
+  }
+  return result;
+}
+
+function stableStringify(value) {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(',')}]`;
+  }
+  const entries = Object.keys(value)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`);
+  return `{${entries.join(',')}}`;
+}
+
+function sha256(text) {
+  return createHash('sha256').update(text).digest('hex');
+}
+
+async function readJson(filePath) {
+  return JSON.parse(await readFile(filePath, 'utf8'));
+}
+
+async function readOptionalJson(filePath) {
+  try {
+    return await readJson(filePath);
+  } catch (error) {
+    if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function readOptionalText(filePath) {
+  try {
+    return await readFile(filePath, 'utf8');
+  } catch (error) {
+    if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+      return null;
+    }
+    throw error;
+  }
+}
+
+function compareValues(left, right, path = '', diffs = [], limit = 25) {
+  if (diffs.length >= limit) return diffs;
+
+  if (stableStringify(left) === stableStringify(right)) {
+    return diffs;
+  }
+
+  const leftIsObject = left !== null && typeof left === 'object';
+  const rightIsObject = right !== null && typeof right === 'object';
+
+  if (!leftIsObject || !rightIsObject || Array.isArray(left) !== Array.isArray(right)) {
+    diffs.push(path || '/');
+    return diffs;
+  }
+
+  if (Array.isArray(left) && Array.isArray(right)) {
+    const maxLength = Math.max(left.length, right.length);
+    for (let index = 0; index < maxLength; index += 1) {
+      compareValues(left[index], right[index], `${path}/${index}`, diffs, limit);
+      if (diffs.length >= limit) break;
+    }
+    return diffs;
+  }
+
+  const keys = [...new Set([...Object.keys(left), ...Object.keys(right)])].sort();
+  for (const key of keys) {
+    compareValues(left[key], right[key], `${path}/${key}`, diffs, limit);
+    if (diffs.length >= limit) break;
+  }
+  return diffs;
+}
+
+function normalizeHeaders(headers) {
+  const normalized = {};
+  for (const [key, value] of Object.entries(headers ?? {})) {
+    if (value === null || value === undefined || value === '') continue;
+    normalized[String(key).toLowerCase()] = String(value);
+  }
+  return normalized;
+}
+
+async function loadDirectoryBundle(directoryPath, selector) {
+  const summary = parseSummary((await readOptionalText(join(directoryPath, 'summary.txt'))) ?? '');
+  const payload = await readOptionalJson(join(directoryPath, 'payload.json'));
+  const labelBase = basename(directoryPath);
+
+  if (selector === 'ingress') {
+    const ingress = await readJson(join(directoryPath, 'ingress.json'));
+    return {
+      label: `${labelBase}#ingress`,
+      sourcePath: directoryPath,
+      kind: 'ingress',
+      requestId: ingress.requestId ?? summary.request_id ?? '',
+      method: '',
+      targetUrl: summary.target_url ?? '',
+      headers: normalizeHeaders({
+        'anthropic-beta': ingress.anthropicBeta ?? '',
+        'anthropic-version': ingress.anthropicVersion ?? '',
+        'x-request-id': ingress.requestIdHeader ?? ''
+      }),
+      bodyBytes: summary.body_bytes ?? '',
+      bodySha256:
+        summary.body_sha256 ??
+        (payload === null ? '' : sha256(stableStringify(payload))),
+      payload
+    };
+  }
+
+  const upstreamRequest = await readJson(join(directoryPath, 'upstream-request.json'));
+  return {
+    label: `${labelBase}#upstream`,
+    sourcePath: directoryPath,
+    kind: 'upstream',
+    requestId: upstreamRequest.request_id ?? summary.request_id ?? '',
+    method: upstreamRequest.method ?? '',
+    targetUrl: upstreamRequest.target_url ?? summary.target_url ?? '',
+    headers: normalizeHeaders(upstreamRequest.headers ?? {}),
+    bodyBytes: String(upstreamRequest.body_bytes ?? summary.body_bytes ?? ''),
+    bodySha256:
+      upstreamRequest.body_sha256 ??
+      summary.body_sha256 ??
+      (payload === null ? '' : sha256(stableStringify(payload))),
+    payload
+  };
+}
+
+async function loadFileBundle(filePath, selector) {
+  const value = await readJson(filePath);
+  const fileName = basename(filePath);
+  const parentDirectory = dirname(filePath);
+  const payload = await readOptionalJson(join(parentDirectory, 'payload.json'));
+
+  const inferredSelector =
+    selector ??
+    (fileName === 'ingress.json' ? 'ingress' : 'upstream');
+
+  if (inferredSelector === 'ingress') {
+    return {
+      label: `${basename(parentDirectory)}#ingress`,
+      sourcePath: filePath,
+      kind: 'ingress',
+      requestId: value.requestId ?? '',
+      method: '',
+      targetUrl: '',
+      headers: normalizeHeaders({
+        'anthropic-beta': value.anthropicBeta ?? '',
+        'anthropic-version': value.anthropicVersion ?? '',
+        'x-request-id': value.requestIdHeader ?? ''
+      }),
+      bodyBytes: '',
+      bodySha256: payload === null ? '' : sha256(stableStringify(payload)),
+      payload
+    };
+  }
+
+  return {
+    label: `${basename(parentDirectory)}#upstream`,
+    sourcePath: filePath,
+    kind: 'upstream',
+    requestId: value.request_id ?? '',
+    method: value.method ?? '',
+    targetUrl: value.target_url ?? '',
+    headers: normalizeHeaders(value.headers ?? {}),
+    bodyBytes: String(value.body_bytes ?? ''),
+    bodySha256:
+      value.body_sha256 ??
+      (payload === null ? '' : sha256(stableStringify(payload))),
+    payload
+  };
+}
+
+async function loadBundle(specText) {
+  const spec = parseSpec(specText);
+  const resolvedPath = resolve(spec.path);
+  const fileStat = await stat(resolvedPath);
+  if (fileStat.isDirectory()) {
+    return loadDirectoryBundle(resolvedPath, spec.selector ?? 'upstream');
+  }
+  return loadFileBundle(resolvedPath, spec.selector);
+}
+
+function joinList(values) {
+  return values.length === 0 ? '' : values.join(',');
+}
+
+function buildHeaderDiff(leftHeaders, rightHeaders) {
+  const leftKeys = Object.keys(leftHeaders).sort();
+  const rightKeys = Object.keys(rightHeaders).sort();
+  const onlyLeft = leftKeys.filter((key) => !(key in rightHeaders));
+  const onlyRight = rightKeys.filter((key) => !(key in leftHeaders));
+  const mismatches = leftKeys
+    .filter((key) => key in rightHeaders)
+    .filter((key) => leftHeaders[key] !== rightHeaders[key]);
+  return { onlyLeft, onlyRight, mismatches };
+}
+
+function buildHeaderDiffText(left, right, diff) {
+  const lines = [];
+  for (const key of diff.onlyLeft) {
+    lines.push(`only_in_left ${key}: ${left.headers[key]}`);
+  }
+  for (const key of diff.onlyRight) {
+    lines.push(`only_in_right ${key}: ${right.headers[key]}`);
+  }
+  for (const key of diff.mismatches) {
+    lines.push(`mismatch ${key}`);
+    lines.push(`  left: ${left.headers[key]}`);
+    lines.push(`  right: ${right.headers[key]}`);
+  }
+  if (lines.length === 0) {
+    lines.push('headers match');
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+function buildBodyDiff(left, right) {
+  if (left.payload === null || right.payload === null) {
+    return {
+      payloadCompareStatus: 'unavailable',
+      payloadCanonicalEqual: '',
+      text: 'payload comparison unavailable\n'
+    };
+  }
+
+  const leftCanonical = stableStringify(left.payload);
+  const rightCanonical = stableStringify(right.payload);
+  if (leftCanonical === rightCanonical) {
+    return {
+      payloadCompareStatus: 'available',
+      payloadCanonicalEqual: 'true',
+      text: 'payload canonical json matches\n'
+    };
+  }
+
+  const paths = compareValues(left.payload, right.payload);
+  const lines = ['payload canonical json differs', ...paths.map((path) => `  ${path}`)];
+  return {
+    payloadCompareStatus: 'available',
+    payloadCanonicalEqual: 'false',
+    text: `${lines.join('\n')}\n`
+  };
+}
+
+async function main() {
+  const [, , leftSpec, rightSpec, outDirArg] = process.argv;
+  if (!leftSpec || !rightSpec || !outDirArg) {
+    usage();
+  }
+
+  const outDir = resolve(outDirArg);
+  const [left, right] = await Promise.all([loadBundle(leftSpec), loadBundle(rightSpec)]);
+  const headerDiff = buildHeaderDiff(left.headers, right.headers);
+  const bodyDiff = buildBodyDiff(left, right);
+
+  await mkdir(outDir, { recursive: true });
+
+  const summaryLines = [
+    `left_label=${left.label}`,
+    `right_label=${right.label}`,
+    `left_source=${left.sourcePath}`,
+    `right_source=${right.sourcePath}`,
+    `left_request_id=${left.requestId}`,
+    `right_request_id=${right.requestId}`,
+    `left_method=${left.method}`,
+    `right_method=${right.method}`,
+    `body_bytes_left=${left.bodyBytes}`,
+    `body_bytes_right=${right.bodyBytes}`,
+    `body_sha256_left=${left.bodySha256}`,
+    `body_sha256_right=${right.bodySha256}`,
+    `header_only_in_left=${joinList(headerDiff.onlyLeft)}`,
+    `header_only_in_right=${joinList(headerDiff.onlyRight)}`,
+    `header_value_mismatches=${joinList(headerDiff.mismatches)}`,
+    `payload_compare_status=${bodyDiff.payloadCompareStatus}`,
+    `payload_canonical_equal=${bodyDiff.payloadCanonicalEqual}`
+  ];
+
+  await Promise.all([
+    writeFile(join(outDir, 'summary.txt'), `${summaryLines.join('\n')}\n`),
+    writeFile(join(outDir, 'header-diff.txt'), buildHeaderDiffText(left, right, headerDiff)),
+    writeFile(join(outDir, 'body-diff.txt'), bodyDiff.text),
+    writeFile(join(outDir, 'normalized-left.json'), `${JSON.stringify(left, null, 2)}\n`),
+    writeFile(join(outDir, 'normalized-right.json'), `${JSON.stringify(right, null, 2)}\n`)
+  ]);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/scripts/innies-compat-first-pass-bundle-diff.sh
+++ b/scripts/innies-compat-first-pass-bundle-diff.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_PATH" ]]; do
+  SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+  SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"
+  [[ "$SCRIPT_PATH" != /* ]] && SCRIPT_PATH="${SCRIPT_DIR}/${SCRIPT_PATH}"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+
+usage() {
+  cat >&2 <<'EOF'
+usage:
+  innies-compat-first-pass-bundle-diff.sh <artifact-bundle-dir>
+  innies-compat-first-pass-bundle-diff.sh <left-bundle-or-json[#ingress|#upstream]> <right-bundle-or-json[#ingress|#upstream]>
+
+single-arg mode compares <bundle>/ingress.json against <bundle>/upstream-request.json.
+two-arg mode compares the two supplied bundle specs. Directories default to #upstream.
+EOF
+  exit 1
+}
+
+if [[ "$#" -ne 1 && "$#" -ne 2 ]]; then
+  usage
+fi
+
+if [[ "$#" -eq 1 ]]; then
+  LEFT_SPEC="$1#ingress"
+  RIGHT_SPEC="$1#upstream"
+else
+  LEFT_SPEC="$1"
+  RIGHT_SPEC="$2"
+fi
+
+OUT_DIR="${INNIES_DIFF_OUT_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/innies-compat-first-pass-bundle-diff.XXXXXX")}"
+mkdir -p "$OUT_DIR"
+
+node "$SCRIPT_DIR/innies-compat-first-pass-bundle-diff.mjs" "$LEFT_SPEC" "$RIGHT_SPEC" "$OUT_DIR"
+
+echo "wrote diff artifacts to $OUT_DIR"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,6 +18,7 @@ ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-set.sh" "${BIN_DIR}/innies-b
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-get.sh" "${BIN_DIR}/innies-buyer-preference-get"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-check.sh" "${BIN_DIR}/innies-buyer-preference-check"
 ln -sf "${ROOT_DIR}/scripts/innies-slo-check.sh" "${BIN_DIR}/innies-slo-check"
+ln -sf "${ROOT_DIR}/scripts/innies-compat-first-pass-bundle-diff.sh" "${BIN_DIR}/innies-compat-first-pass-bundle-diff"
 
 rm -f \
   "${BIN_DIR}/innies-admin" \
@@ -49,6 +50,7 @@ echo "  ${BIN_DIR}/innies-buyer-preference-set -> ${ROOT_DIR}/scripts/innies-buy
 echo "  ${BIN_DIR}/innies-buyer-preference-get -> ${ROOT_DIR}/scripts/innies-buyer-preference-get.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-check -> ${ROOT_DIR}/scripts/innies-buyer-preference-check.sh"
 echo "  ${BIN_DIR}/innies-slo-check -> ${ROOT_DIR}/scripts/innies-slo-check.sh"
+echo "  ${BIN_DIR}/innies-compat-first-pass-bundle-diff -> ${ROOT_DIR}/scripts/innies-compat-first-pass-bundle-diff.sh"
 echo
 echo 'If command not found, add ~/.local/bin to PATH:'
 echo '  export PATH="$HOME/.local/bin:$PATH"'

--- a/scripts/tests/innies-compat-first-pass-bundle-diff.test.sh
+++ b/scripts/tests/innies-compat-first-pass-bundle-diff.test.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="$ROOT_DIR/scripts/innies-compat-first-pass-bundle-diff.sh"
+TMP_DIR="$(mktemp -d)"
+SINGLE_OUT_DIR="$TMP_DIR/single-out"
+DOUBLE_OUT_DIR="$TMP_DIR/double-out"
+SINGLE_STDOUT="$TMP_DIR/single-stdout.txt"
+SINGLE_STDERR="$TMP_DIR/single-stderr.txt"
+DOUBLE_STDOUT="$TMP_DIR/double-stdout.txt"
+DOUBLE_STDERR="$TMP_DIR/double-stderr.txt"
+BUNDLE_DIR="$TMP_DIR/issue80-bundle"
+DIRECT_DIR="$TMP_DIR/direct-bundle"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$BUNDLE_DIR" "$DIRECT_DIR"
+
+cat >"$BUNDLE_DIR/ingress.json" <<'JSON'
+{
+  "requestId": "req_issue80_ingress",
+  "anthropicBeta": "fine-grained-tool-streaming-2025-05-14",
+  "anthropicVersion": "2023-06-01",
+  "requestIdHeader": null,
+  "payloadAvailable": true
+}
+JSON
+
+cat >"$BUNDLE_DIR/payload.json" <<'JSON'
+{
+  "model": "claude-opus-4-6",
+  "stream": true,
+  "max_tokens": 16,
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        {
+          "type": "text",
+          "text": "hi"
+        }
+      ]
+    }
+  ]
+}
+JSON
+
+cat >"$BUNDLE_DIR/upstream-request.json" <<'JSON'
+{
+  "attempt_no": 1,
+  "body_bytes": 121,
+  "body_sha256": "sha-bundle-upstream",
+  "headers": {
+    "accept": "text/event-stream",
+    "anthropic-beta": "fine-grained-tool-streaming-2025-05-14,claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14",
+    "anthropic-dangerous-direct-browser-access": "true",
+    "anthropic-version": "2023-06-01",
+    "authorization": "Bearer <redacted>",
+    "content-type": "application/json",
+    "user-agent": "OpenClawGateway/1.0",
+    "x-app": "cli",
+    "x-request-id": "req_issue80_upstream"
+  },
+  "method": "POST",
+  "provider": "anthropic",
+  "request_id": "req_issue80_upstream",
+  "target_url": "https://api.anthropic.com/v1/messages"
+}
+JSON
+
+cat >"$BUNDLE_DIR/summary.txt" <<'EOF'
+request_id=req_issue80_upstream
+attempt_no=1
+provider=anthropic
+proxied_path=/v1/messages
+target_url=https://api.anthropic.com/v1/messages
+body_bytes=121
+body_sha256=sha-bundle-upstream
+upstream_status=400
+provider_request_id=req_upstream_failure
+payload_available=true
+ingress_anthropic_beta=fine-grained-tool-streaming-2025-05-14
+ingress_anthropic_version=2023-06-01
+upstream_anthropic_beta=fine-grained-tool-streaming-2025-05-14,claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14
+upstream_user_agent=OpenClawGateway/1.0
+EOF
+
+cat >"$DIRECT_DIR/payload.json" <<'JSON'
+{
+  "messages": [
+    {
+      "content": [
+        {
+          "text": "hi",
+          "type": "text"
+        }
+      ],
+      "role": "user"
+    }
+  ],
+  "max_tokens": 16,
+  "model": "claude-opus-4-6",
+  "stream": true
+}
+JSON
+
+cat >"$DIRECT_DIR/upstream-request.json" <<'JSON'
+{
+  "attempt_no": 1,
+  "body_bytes": 121,
+  "body_sha256": "sha-direct",
+  "headers": {
+    "accept": "text/event-stream",
+    "anthropic-beta": "fine-grained-tool-streaming-2025-05-14",
+    "anthropic-dangerous-direct-browser-access": "true",
+    "anthropic-version": "2023-06-01",
+    "authorization": "Bearer <redacted>",
+    "content-type": "application/json",
+    "user-agent": "OpenClawGateway/1.0",
+    "x-app": "cli"
+  },
+  "method": "POST",
+  "provider": "anthropic",
+  "request_id": "req_direct_good",
+  "target_url": "https://api.anthropic.com/v1/messages"
+}
+JSON
+
+set +e
+INNIES_DIFF_OUT_DIR="$SINGLE_OUT_DIR" \
+"$SCRIPT_PATH" "$BUNDLE_DIR" >"$SINGLE_STDOUT" 2>"$SINGLE_STDERR"
+STATUS=$?
+set -e
+
+if [[ "$STATUS" -ne 0 ]]; then
+  cat "$SINGLE_STDERR"
+  exit 1
+fi
+
+[[ -f "$SINGLE_OUT_DIR/summary.txt" ]]
+[[ -f "$SINGLE_OUT_DIR/header-diff.txt" ]]
+[[ -f "$SINGLE_OUT_DIR/body-diff.txt" ]]
+
+grep -q '^left_label=issue80-bundle#ingress$' "$SINGLE_OUT_DIR/summary.txt"
+grep -q '^right_label=issue80-bundle#upstream$' "$SINGLE_OUT_DIR/summary.txt"
+grep -q '^header_only_in_right=accept,anthropic-dangerous-direct-browser-access,authorization,content-type,user-agent,x-app,x-request-id$' "$SINGLE_OUT_DIR/summary.txt"
+grep -q '^header_value_mismatches=anthropic-beta$' "$SINGLE_OUT_DIR/summary.txt"
+grep -q '^payload_canonical_equal=true$' "$SINGLE_OUT_DIR/summary.txt"
+grep -q '^body_sha256_left=sha-bundle-upstream$' "$SINGLE_OUT_DIR/summary.txt"
+grep -q '^body_sha256_right=sha-bundle-upstream$' "$SINGLE_OUT_DIR/summary.txt"
+grep -q 'left: fine-grained-tool-streaming-2025-05-14$' "$SINGLE_OUT_DIR/header-diff.txt"
+grep -q 'right: fine-grained-tool-streaming-2025-05-14,claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14$' "$SINGLE_OUT_DIR/header-diff.txt"
+grep -q '^payload canonical json matches$' "$SINGLE_OUT_DIR/body-diff.txt"
+
+set +e
+INNIES_DIFF_OUT_DIR="$DOUBLE_OUT_DIR" \
+"$SCRIPT_PATH" "$BUNDLE_DIR#upstream" "$DIRECT_DIR" >"$DOUBLE_STDOUT" 2>"$DOUBLE_STDERR"
+STATUS=$?
+set -e
+
+if [[ "$STATUS" -ne 0 ]]; then
+  cat "$DOUBLE_STDERR"
+  exit 1
+fi
+
+grep -q '^left_label=issue80-bundle#upstream$' "$DOUBLE_OUT_DIR/summary.txt"
+grep -q '^right_label=direct-bundle#upstream$' "$DOUBLE_OUT_DIR/summary.txt"
+grep -q '^header_only_in_left=x-request-id$' "$DOUBLE_OUT_DIR/summary.txt"
+grep -q '^header_value_mismatches=anthropic-beta$' "$DOUBLE_OUT_DIR/summary.txt"
+grep -q '^body_sha256_left=sha-bundle-upstream$' "$DOUBLE_OUT_DIR/summary.txt"
+grep -q '^body_sha256_right=sha-direct$' "$DOUBLE_OUT_DIR/summary.txt"
+grep -q '^payload_canonical_equal=true$' "$DOUBLE_OUT_DIR/summary.txt"


### PR DESCRIPTION
## Summary
- add `scripts/innies-compat-first-pass-bundle-diff` plus a small Node normalizer so issue-80 bundle comparisons stop relying on ad hoc local parsing
- support single-bundle `ingress.json` vs `upstream-request.json` diffs and two-bundle comparisons with explicit `#ingress` / `#upstream` selectors for future direct/OpenClaw captures
- wire the helper into `scripts/install.sh` / `scripts/README.md` and cover it with a focused shell regression

## Test Plan
- `bash scripts/tests/innies-compat-first-pass-bundle-diff.test.sh`
- `bash -n scripts/innies-compat-first-pass-bundle-diff.sh scripts/tests/innies-compat-first-pass-bundle-diff.test.sh scripts/install.sh`
- `node --check scripts/innies-compat-first-pass-bundle-diff.mjs`
- `git diff --check HEAD~1..HEAD`
- `INNIES_DIFF_OUT_DIR=/private/tmp/issue80-first-pass-bundle-diff-real-postcommit scripts/innies-compat-first-pass-bundle-diff.sh /private/tmp/issue80-artifact-extract-real`

## Notes
- the post-commit smoke run against `/private/tmp/issue80-artifact-extract-real` reported `payload_canonical_equal=true`, identical `body_bytes=398262`, and identical `body_sha256=1717a039bed013d162eb47daead7f7eea440bccc6fb2719b9233142976e9a093`
- that same smoke run reduced the current Innies-side first-pass delta to one header-value mismatch (`anthropic-beta`) plus right-only upstream headers: `accept`, `anthropic-dangerous-direct-browser-access`, `authorization`, `content-type`, `user-agent`, `x-app`, and `x-request-id`
- this is support tooling for the issue-80 exact wire-diff lane; it does not change the runtime proxy path or weaken tools / thinking / streaming behavior

Refs #80
