### PR TITLE
chore: add issue 80 direct request bundle helper

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -24,6 +24,7 @@ innies-buyer-key-create
 innies-buyer-preference-set
 innies-buyer-preference-get
 innies-buyer-preference-check
+innies-compat-direct-request-bundle
 innies-slo-check
 ```
 
@@ -39,6 +40,7 @@ What they do:
 - `innies-buyer-preference-set`: set a buyer key preference to `Claude Code`, `Codex`, or `null`
 - `innies-buyer-preference-get`: read the current buyer key preference
 - `innies-buyer-preference-check`: run the provider-preference canary after prompting for the expected provider (`Claude Code` or `Codex`)
+- `innies-compat-direct-request-bundle`: replay a payload directly against Anthropic with an exact first-pass header TSV and write a reusable request/response bundle for issue-80 wire diffs
 - `innies-slo-check`: query analytics endpoints and report Phase 1 SLO pass/fail (TTFB p95, timeout rate, success rate, fallback rate); optional arg sets the window (default `24h`); exits 0 if all SLOs pass, 1 if any fail
 
 Behavior:
@@ -79,6 +81,7 @@ Behavior:
 - non-pinned buyer traffic always gets automatic cross-provider fallback to the other provider; flipping preference flips fallback order too
 - `innies-buyer-preference-set` prints the effective preferred provider plus the automatic fallback provider before sending the update
 - `innies-buyer-preference-check` now expects and validates the two-provider plan in DB evidence mode
+- `innies-compat-direct-request-bundle` accepts a payload JSON path plus a TSV file of exact direct headers (`name<TAB>value`), replays that body to Anthropic, redacts auth on disk, and writes `payload.json`, `direct-request.json`, `upstream-request.json`, `direct-response.json`, `upstream-response.json`, `response-headers.txt`, `response-body.txt`, and `summary.txt`
 
 ## Env
 

--- a/scripts/innies-compat-direct-request-bundle.sh
+++ b/scripts/innies-compat-direct-request-bundle.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_PATH" ]]; do
+  SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+  SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"
+  [[ "$SCRIPT_PATH" != /* ]] && SCRIPT_PATH="${SCRIPT_DIR}/${SCRIPT_PATH}"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+source "${SCRIPT_DIR}/_common.sh"
+
+resolve_direct_base_url() {
+  if [[ -n "${ANTHROPIC_DIRECT_BASE_URL:-}" ]]; then
+    printf '%s' "${ANTHROPIC_DIRECT_BASE_URL%/}"
+    return
+  fi
+  if [[ -n "${ANTHROPIC_BASE_URL:-}" ]]; then
+    printf '%s' "${ANTHROPIC_BASE_URL%/}"
+    return
+  fi
+  printf '%s' 'https://api.anthropic.com'
+}
+
+resolve_access_token() {
+  if [[ -n "${ANTHROPIC_OAUTH_ACCESS_TOKEN:-}" ]]; then
+    printf '%s\t%s' "${ANTHROPIC_OAUTH_ACCESS_TOKEN}" 'anthropic_oauth_access_token'
+    return
+  fi
+  if [[ -n "${ANTHROPIC_ACCESS_TOKEN:-}" ]]; then
+    printf '%s\t%s' "${ANTHROPIC_ACCESS_TOKEN}" 'anthropic_access_token'
+    return
+  fi
+  if [[ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
+    printf '%s\t%s' "${CLAUDE_CODE_OAUTH_TOKEN}" 'claude_code_oauth_token'
+    return
+  fi
+  echo 'error: missing Anthropic OAuth access token (set ANTHROPIC_OAUTH_ACCESS_TOKEN, ANTHROPIC_ACCESS_TOKEN, or CLAUDE_CODE_OAUTH_TOKEN)' >&2
+  exit 1
+}
+
+extract_header_value() {
+  local name="$1"
+  local file="$2"
+  awk -F'\t' -v target="$name" '
+    BEGIN { IGNORECASE = 1 }
+    tolower($1) == tolower(target) {
+      print $2
+    }
+  ' "$file" | tail -1
+}
+
+extract_response_header() {
+  local name="$1"
+  local file="$2"
+  awk -F': ' -v header_name="$name" '
+    BEGIN { IGNORECASE = 1 }
+    tolower($1) == tolower(header_name) {
+      gsub("\r", "", $2)
+      print $2
+    }
+  ' "$file" | tail -1
+}
+
+extract_body_request_id() {
+  local file="$1"
+  sed -n 's/.*"request_id":"\([^"]*\)".*/\1/p' "$file" | head -n 1
+}
+
+write_summary() {
+  local file="$1"
+  shift
+  printf '%s\n' "$@" >"$file"
+}
+
+PAYLOAD_PATH="${1:-${INNIES_DIRECT_PAYLOAD_PATH:-}}"
+HEADERS_TSV_PATH="${2:-${INNIES_DIRECT_HEADERS_TSV:-}}"
+require_nonempty 'payload path' "$PAYLOAD_PATH"
+require_nonempty 'headers tsv path' "$HEADERS_TSV_PATH"
+
+if [[ ! -f "$PAYLOAD_PATH" ]]; then
+  echo "error: payload file not found: $PAYLOAD_PATH" >&2
+  exit 1
+fi
+
+if [[ ! -f "$HEADERS_TSV_PATH" ]]; then
+  echo "error: headers TSV file not found: $HEADERS_TSV_PATH" >&2
+  exit 1
+fi
+
+DIRECT_BASE_URL="$(resolve_direct_base_url)"
+DIRECT_PATH="${INNIES_DIRECT_PATH:-/v1/messages}"
+TARGET_URL="${DIRECT_BASE_URL}${DIRECT_PATH}"
+
+TOKEN_AND_SOURCE="$(resolve_access_token)"
+ACCESS_TOKEN="${TOKEN_AND_SOURCE%%$'\t'*}"
+DIRECT_ACCESS_TOKEN_SOURCE="${TOKEN_AND_SOURCE#*$'\t'}"
+
+DIRECT_REQUEST_ID="${INNIES_DIRECT_REQUEST_ID:-req_issue80_direct_$(date -u +%Y%m%dT%H%M%SZ)}"
+OUT_DIR="${INNIES_DIRECT_BUNDLE_OUT_DIR:-${TMPDIR:-/tmp}/innies-compat-direct-request-bundle-${DIRECT_REQUEST_ID}}"
+mkdir -p "$OUT_DIR"
+
+REQUEST_HEADERS_TSV="$OUT_DIR/request-headers.tsv"
+RESPONSE_HEADERS_FILE="$OUT_DIR/response-headers.txt"
+RESPONSE_BODY_FILE="$OUT_DIR/response-body.txt"
+PAYLOAD_BYTES="$(wc -c <"$PAYLOAD_PATH" | tr -d '[:space:]')"
+PAYLOAD_SHA256="$(openssl dgst -sha256 -r "$PAYLOAD_PATH" | awk '{print $1}')"
+
+declare -a DIRECT_CURL_ARGS
+DIRECT_CURL_ARGS=(
+  -sS
+  -D "$RESPONSE_HEADERS_FILE"
+  -o "$RESPONSE_BODY_FILE"
+  -w '%{http_code}'
+  -X POST "$TARGET_URL"
+  --data-binary "@$PAYLOAD_PATH"
+)
+
+printf 'authorization\tBearer <redacted>\n' >"$REQUEST_HEADERS_TSV"
+have_request_id='false'
+while IFS=$'\t' read -r header_name header_value; do
+  [[ -z "$header_name" ]] && continue
+  header_name="$(trim "$header_name")"
+  header_value="$(trim "${header_value:-}")"
+  [[ -z "$header_name" ]] && continue
+
+  header_name_normalized="$(printf '%s' "$header_name" | tr '[:upper:]' '[:lower:]')"
+  case "$header_name_normalized" in
+    authorization|content-length|host)
+      continue
+      ;;
+    x-request-id)
+      header_value="$DIRECT_REQUEST_ID"
+      have_request_id='true'
+      ;;
+  esac
+
+  DIRECT_CURL_ARGS+=(-H "${header_name_normalized}: ${header_value}")
+  printf '%s\t%s\n' "$header_name_normalized" "$header_value" >>"$REQUEST_HEADERS_TSV"
+done <"$HEADERS_TSV_PATH"
+
+if [[ "$have_request_id" != 'true' ]]; then
+  DIRECT_CURL_ARGS+=(-H "x-request-id: $DIRECT_REQUEST_ID")
+  printf 'x-request-id\t%s\n' "$DIRECT_REQUEST_ID" >>"$REQUEST_HEADERS_TSV"
+fi
+
+DIRECT_CURL_ARGS+=(-H "authorization: Bearer $ACCESS_TOKEN")
+DIRECT_STATUS="$(curl "${DIRECT_CURL_ARGS[@]}")"
+PROVIDER_REQUEST_ID="$(extract_response_header 'request-id' "$RESPONSE_HEADERS_FILE")"
+if [[ -z "$PROVIDER_REQUEST_ID" ]]; then
+  PROVIDER_REQUEST_ID="$(extract_body_request_id "$RESPONSE_BODY_FILE")"
+fi
+
+node - "$PAYLOAD_PATH" "$REQUEST_HEADERS_TSV" "$RESPONSE_HEADERS_FILE" "$RESPONSE_BODY_FILE" "$OUT_DIR" "$DIRECT_REQUEST_ID" "$TARGET_URL" "$PAYLOAD_BYTES" "$PAYLOAD_SHA256" "$DIRECT_STATUS" "$PROVIDER_REQUEST_ID" <<'NODE'
+const fs = require('fs');
+const path = require('path');
+
+const [
+  payloadPath,
+  requestHeadersTsvPath,
+  responseHeadersPath,
+  responseBodyPath,
+  outDir,
+  requestId,
+  targetUrl,
+  payloadBytes,
+  payloadSha256,
+  directStatus,
+  providerRequestId
+] = process.argv.slice(2);
+
+function readHeadersTsv(filePath) {
+  const headers = {};
+  const text = fs.readFileSync(filePath, 'utf8');
+  for (const line of text.split(/\r?\n/)) {
+    if (!line) continue;
+    const parts = line.split('\t');
+    const name = String(parts[0] ?? '').trim().toLowerCase();
+    const value = String(parts.slice(1).join('\t') ?? '').trim();
+    if (!name) continue;
+    headers[name] = value;
+  }
+  return headers;
+}
+
+function readResponseHeaders(filePath) {
+  const headers = {};
+  const text = fs.readFileSync(filePath, 'utf8');
+  for (const line of text.split(/\r?\n/)) {
+    if (!line || !line.includes(':')) continue;
+    const index = line.indexOf(':');
+    const name = line.slice(0, index).trim().toLowerCase();
+    const value = line.slice(index + 1).trim();
+    if (!name) continue;
+    headers[name] = value;
+  }
+  return headers;
+}
+
+const payloadText = fs.readFileSync(payloadPath, 'utf8');
+const payload = JSON.parse(payloadText);
+const requestHeaders = readHeadersTsv(requestHeadersTsvPath);
+const responseHeaders = readResponseHeaders(responseHeadersPath);
+const responseBodyText = fs.readFileSync(responseBodyPath, 'utf8');
+
+let responseBodyJson = null;
+try {
+  responseBodyJson = JSON.parse(responseBodyText);
+} catch {}
+
+const requestRecord = {
+  provider: 'anthropic',
+  request_id: requestId,
+  method: 'POST',
+  target_url: targetUrl,
+  headers: requestHeaders,
+  body_bytes: Number(payloadBytes),
+  body_sha256: payloadSha256,
+  stream: Boolean(payload.stream)
+};
+
+const responseRecord = {
+  request_id: requestId,
+  status: Number(directStatus),
+  provider_request_id: providerRequestId,
+  headers: responseHeaders,
+  body_json: responseBodyJson,
+  body_text: responseBodyText
+};
+
+fs.writeFileSync(path.join(outDir, 'payload.json'), `${JSON.stringify(payload, null, 2)}\n`);
+fs.writeFileSync(path.join(outDir, 'direct-request.json'), `${JSON.stringify(requestRecord, null, 2)}\n`);
+fs.writeFileSync(path.join(outDir, 'upstream-request.json'), `${JSON.stringify(requestRecord, null, 2)}\n`);
+fs.writeFileSync(path.join(outDir, 'direct-response.json'), `${JSON.stringify(responseRecord, null, 2)}\n`);
+fs.writeFileSync(path.join(outDir, 'upstream-response.json'), `${JSON.stringify(responseRecord, null, 2)}\n`);
+NODE
+
+SUMMARY_FILE="$OUT_DIR/summary.txt"
+SUMMARY_LINES=(
+  "request_id=$DIRECT_REQUEST_ID"
+  "target_url=$TARGET_URL"
+  "body_bytes=$PAYLOAD_BYTES"
+  "body_sha256=$PAYLOAD_SHA256"
+  "direct_status=$DIRECT_STATUS"
+  "provider_request_id=${PROVIDER_REQUEST_ID:-}"
+  "direct_access_token_source=$DIRECT_ACCESS_TOKEN_SOURCE"
+  "anthropic_beta=$(extract_header_value 'anthropic-beta' "$REQUEST_HEADERS_TSV")"
+  "anthropic_version=$(extract_header_value 'anthropic-version' "$REQUEST_HEADERS_TSV")"
+  "user_agent=$(extract_header_value 'user-agent' "$REQUEST_HEADERS_TSV")"
+  "x_app=$(extract_header_value 'x-app' "$REQUEST_HEADERS_TSV")"
+  "request_headers_tsv=$REQUEST_HEADERS_TSV"
+  "response_headers_file=$RESPONSE_HEADERS_FILE"
+  "response_body_file=$RESPONSE_BODY_FILE"
+)
+write_summary "$SUMMARY_FILE" "${SUMMARY_LINES[@]}"
+printf '%s\n' "${SUMMARY_LINES[@]}"
+echo "summary_file=$SUMMARY_FILE"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,6 +17,7 @@ ln -sf "${ROOT_DIR}/scripts/innies-buyer-key-create.sh" "${BIN_DIR}/innies-buyer
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-set.sh" "${BIN_DIR}/innies-buyer-preference-set"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-get.sh" "${BIN_DIR}/innies-buyer-preference-get"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-check.sh" "${BIN_DIR}/innies-buyer-preference-check"
+ln -sf "${ROOT_DIR}/scripts/innies-compat-direct-request-bundle.sh" "${BIN_DIR}/innies-compat-direct-request-bundle"
 ln -sf "${ROOT_DIR}/scripts/innies-slo-check.sh" "${BIN_DIR}/innies-slo-check"
 
 rm -f \
@@ -48,6 +49,7 @@ echo "  ${BIN_DIR}/innies-buyer-key-create -> ${ROOT_DIR}/scripts/innies-buyer-k
 echo "  ${BIN_DIR}/innies-buyer-preference-set -> ${ROOT_DIR}/scripts/innies-buyer-preference-set.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-get -> ${ROOT_DIR}/scripts/innies-buyer-preference-get.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-check -> ${ROOT_DIR}/scripts/innies-buyer-preference-check.sh"
+echo "  ${BIN_DIR}/innies-compat-direct-request-bundle -> ${ROOT_DIR}/scripts/innies-compat-direct-request-bundle.sh"
 echo "  ${BIN_DIR}/innies-slo-check -> ${ROOT_DIR}/scripts/innies-slo-check.sh"
 echo
 echo 'If command not found, add ~/.local/bin to PATH:'

--- a/scripts/tests/innies-compat-direct-request-bundle.test.sh
+++ b/scripts/tests/innies-compat-direct-request-bundle.test.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="$ROOT_DIR/scripts/innies-compat-direct-request-bundle.sh"
+TMP_DIR="$(mktemp -d)"
+PAYLOAD_PATH="$TMP_DIR/payload.json"
+HEADERS_TSV_PATH="$TMP_DIR/direct-headers.tsv"
+REQUESTS_DIR="$TMP_DIR/requests"
+OUT_DIR="$TMP_DIR/out"
+STDOUT_PATH="$TMP_DIR/stdout.txt"
+STDERR_PATH="$TMP_DIR/stderr.txt"
+
+cleanup() {
+  if [[ -n "${SERVER_PID:-}" ]]; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$REQUESTS_DIR"
+
+cat >"$PAYLOAD_PATH" <<'JSON'
+{"model":"claude-opus-4-6","stream":true,"max_tokens":32,"messages":[{"role":"user","content":[{"type":"text","text":"hello from direct bundle test"}]}]}
+JSON
+
+cat >"$HEADERS_TSV_PATH" <<'TSV'
+accept	text/event-stream
+anthropic-beta	fine-grained-tool-streaming-2025-05-14
+anthropic-dangerous-direct-browser-access	true
+anthropic-version	2023-06-01
+content-type	application/json
+user-agent	OpenClawGateway/1.0
+x-app	cli
+x-request-id	req_known_good_original
+TSV
+
+cat >"$TMP_DIR/mock-server.mjs" <<'NODE'
+import { createServer } from 'node:http';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const port = Number(process.env.PORT);
+const requestsDir = process.env.REQUESTS_DIR;
+mkdirSync(requestsDir, { recursive: true });
+
+const server = createServer((req, res) => {
+  const chunks = [];
+  req.on('data', (chunk) => chunks.push(chunk));
+  req.on('end', () => {
+    const bodyBuffer = Buffer.concat(chunks);
+    const requestId = String(req.headers['x-request-id'] ?? `unknown-${Date.now()}`);
+    writeFileSync(join(requestsDir, `${requestId}.json`), JSON.stringify({
+      method: req.method,
+      url: req.url,
+      headers: req.headers,
+      bodyText: bodyBuffer.toString('utf8'),
+      bodyBytes: bodyBuffer.length
+    }, null, 2));
+
+    res.statusCode = 200;
+    res.setHeader('content-type', 'application/json');
+    res.setHeader('request-id', 'req_direct_bundle_provider');
+    res.end(JSON.stringify({
+      id: 'msg_direct_bundle_ok',
+      type: 'message',
+      role: 'assistant',
+      content: [{ type: 'text', text: 'ok' }],
+      stop_reason: 'end_turn'
+    }));
+  });
+});
+
+server.listen(port, '127.0.0.1', () => {
+  process.stdout.write(`ready:${port}\n`);
+});
+NODE
+
+PORT="$(node -e "const net=require('node:net');const s=net.createServer();s.listen(0,'127.0.0.1',()=>{const {port}=s.address();console.log(port);s.close();});")"
+PORT="$PORT" REQUESTS_DIR="$REQUESTS_DIR" node "$TMP_DIR/mock-server.mjs" >"$TMP_DIR/server.log" 2>&1 &
+SERVER_PID=$!
+
+for _ in $(seq 1 50); do
+  if grep -q '^ready:' "$TMP_DIR/server.log" 2>/dev/null; then
+    break
+  fi
+  sleep 0.1
+done
+
+if ! grep -q '^ready:' "$TMP_DIR/server.log" 2>/dev/null; then
+  echo 'server did not start' >&2
+  cat "$TMP_DIR/server.log" >&2
+  exit 1
+fi
+
+set +e
+CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat-claude-fallback" \
+ANTHROPIC_DIRECT_BASE_URL="http://127.0.0.1:$PORT" \
+INNIES_DIRECT_REQUEST_ID="req_issue80_direct_bundle" \
+INNIES_DIRECT_BUNDLE_OUT_DIR="$OUT_DIR" \
+"$SCRIPT_PATH" "$PAYLOAD_PATH" "$HEADERS_TSV_PATH" >"$STDOUT_PATH" 2>"$STDERR_PATH"
+STATUS=$?
+set -e
+
+if [[ "$STATUS" -ne 0 ]]; then
+  cat "$STDERR_PATH" >&2
+  exit 1
+fi
+
+[[ -f "$OUT_DIR/payload.json" ]]
+[[ -f "$OUT_DIR/direct-request.json" ]]
+[[ -f "$OUT_DIR/upstream-request.json" ]]
+[[ -f "$OUT_DIR/direct-response.json" ]]
+[[ -f "$OUT_DIR/upstream-response.json" ]]
+[[ -f "$OUT_DIR/response-headers.txt" ]]
+[[ -f "$OUT_DIR/response-body.txt" ]]
+[[ -f "$OUT_DIR/summary.txt" ]]
+
+node - "$OUT_DIR" "$REQUESTS_DIR" "$PAYLOAD_PATH" <<'NODE'
+const fs = require('fs');
+const path = require('path');
+const outDir = process.argv[2];
+const requestsDir = process.argv[3];
+const payloadPath = process.argv[4];
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function readSummary(filePath) {
+  const entries = {};
+  for (const line of fs.readFileSync(filePath, 'utf8').trim().split(/\r?\n/)) {
+    const index = line.indexOf('=');
+    if (index === -1) continue;
+    entries[line.slice(0, index)] = line.slice(index + 1);
+  }
+  return entries;
+}
+
+const payload = readJson(path.join(outDir, 'payload.json'));
+const directRequest = readJson(path.join(outDir, 'direct-request.json'));
+const upstreamRequest = readJson(path.join(outDir, 'upstream-request.json'));
+const directResponse = readJson(path.join(outDir, 'direct-response.json'));
+const upstreamResponse = readJson(path.join(outDir, 'upstream-response.json'));
+const capturedRequest = readJson(path.join(requestsDir, 'req_issue80_direct_bundle.json'));
+const payloadBytes = fs.statSync(payloadPath).size;
+const summary = readSummary(path.join(outDir, 'summary.txt'));
+
+if (payload.model !== 'claude-opus-4-6') throw new Error('payload.json missing model');
+if (directRequest.request_id !== 'req_issue80_direct_bundle') throw new Error('direct request id mismatch');
+if (upstreamRequest.request_id !== 'req_issue80_direct_bundle') throw new Error('upstream request id mismatch');
+if (directRequest.body_bytes !== payloadBytes) throw new Error('body bytes mismatch');
+if (summary.request_id !== 'req_issue80_direct_bundle') throw new Error('summary request id mismatch');
+if (summary.direct_status !== '200') throw new Error('summary direct status mismatch');
+if (summary.provider_request_id !== 'req_direct_bundle_provider') throw new Error('summary provider request id mismatch');
+if (summary.direct_access_token_source !== 'claude_code_oauth_token') throw new Error('token source mismatch');
+if (directRequest.headers.authorization !== 'Bearer <redacted>') throw new Error('request bundle should redact auth');
+if (directRequest.headers['x-request-id'] !== 'req_issue80_direct_bundle') throw new Error('request bundle x-request-id mismatch');
+if (directRequest.headers['anthropic-beta'] !== 'fine-grained-tool-streaming-2025-05-14') throw new Error('request bundle beta mismatch');
+if (directRequest.headers['user-agent'] !== 'OpenClawGateway/1.0') throw new Error('request bundle user-agent mismatch');
+if (directRequest.headers['x-app'] !== 'cli') throw new Error('request bundle x-app mismatch');
+if (capturedRequest.headers.authorization !== 'Bearer sk-ant-oat-claude-fallback') throw new Error('upstream auth token mismatch');
+if (capturedRequest.headers['x-request-id'] !== 'req_issue80_direct_bundle') throw new Error('upstream request id mismatch');
+if (capturedRequest.headers['anthropic-beta'] !== 'fine-grained-tool-streaming-2025-05-14') throw new Error('upstream beta mismatch');
+if (capturedRequest.headers['anthropic-dangerous-direct-browser-access'] !== 'true') throw new Error('identity header missing');
+if (capturedRequest.bodyBytes !== payloadBytes) throw new Error('upstream payload bytes mismatch');
+if (directResponse.status !== 200) throw new Error('direct response status mismatch');
+if (upstreamResponse.status !== 200) throw new Error('upstream response status mismatch');
+if (directResponse.provider_request_id !== 'req_direct_bundle_provider') throw new Error('direct response request id mismatch');
+NODE
+
+grep -q 'summary_file=' "$STDOUT_PATH"


### PR DESCRIPTION
## Summary
- add `scripts/innies-compat-direct-request-bundle`, which replays a payload directly against Anthropic with an exact first-pass header TSV and writes a reusable request/response bundle for issue-80 wire diffs
- redact auth on disk while preserving the live upstream request, and record token-source/request metadata in `summary.txt`
- wire the helper into `scripts/install.sh` / `scripts/README.md` and cover the Claude-token fallback path with focused shell regression

## Test Plan
- `bash scripts/tests/innies-compat-direct-request-bundle.test.sh`
- `bash -n scripts/innies-compat-direct-request-bundle.sh scripts/tests/innies-compat-direct-request-bundle.test.sh scripts/install.sh`
- `git diff --check`

## Notes
- this does not change the runtime proxy path; it adds the missing known-good direct bundle capture lane for issue-80 evidence gathering
- this workstation still does not have a live Anthropic bearer exported, so verification is mock-backed rather than a real upstream replay from this shell
- the helper writes `payload.json`, `direct-request.json`, `upstream-request.json`, `direct-response.json`, `upstream-response.json`, `response-headers.txt`, `response-body.txt`, and `summary.txt` so the existing issue-80 diff lane can compare a known-good direct bundle against the failing compat first pass

Refs #80
