### PR TITLE
chore: add issue 80 direct request bundle helper

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -25,6 +25,7 @@ innies-buyer-preference-set
 innies-buyer-preference-get
 innies-buyer-preference-check
 innies-slo-check
+innies-compat-direct-request-bundle
 ```
 
 What they do:
@@ -40,6 +41,7 @@ What they do:
 - `innies-buyer-preference-get`: read the current buyer key preference
 - `innies-buyer-preference-check`: run the provider-preference canary after prompting for the expected provider (`Claude Code` or `Codex`)
 - `innies-slo-check`: query analytics endpoints and report Phase 1 SLO pass/fail (TTFB p95, timeout rate, success rate, fallback rate); optional arg sets the window (default `24h`); exits 0 if all SLOs pass, 1 if any fail
+- `innies-compat-direct-request-bundle`: replay one captured Anthropic first pass directly and emit normalized `captured-upstream-request.json`, `direct-request.json`, and `direct-response.json` bundles for issue `#80` wire diff work
 
 Behavior:
 - org id auto-uses `INNIES_ORG_ID`
@@ -73,6 +75,12 @@ Behavior:
 - `innies-token-usage-refresh` lists unexpired Claude credentials in `active|paused|maxed`, plus expired Claude OAuth credentials that still have a stored refresh token (shown as `expired`) so you can recover them manually
 - `innies-token-usage-refresh` also needs `INNIES_ADMIN_API_KEY` (or prompts for it) because it calls the admin API provider-usage refresh endpoint directly
 - `innies-token-usage-refresh` bypasses in-memory usage-fetch backoff and prints both parsed 5h / 7d usage plus the raw Anthropic payload
+- `innies-compat-direct-request-bundle` needs:
+  - a payload path argument (typically the preserved issue payload json)
+  - `INNIES_CAPTURED_RESPONSE_HTML` and `INNIES_CAPTURED_REQUEST_ID` so it can extract the failing Innies first-pass request bundle
+  - one of `ANTHROPIC_OAUTH_ACCESS_TOKEN`, `ANTHROPIC_ACCESS_TOKEN`, or `CLAUDE_CODE_OAUTH_TOKEN` for the direct replay bearer
+  - optional `ANTHROPIC_DIRECT_BASE_URL` when you want to point the direct replay at a stub or alternate endpoint
+- `innies-compat-direct-request-bundle` writes a bundle directory containing the extracted failing request, the normalized direct replay request/response json, the raw response headers/body, and a `meta.txt` summary
 - `label` maps to API field `debugLabel`
 - set/get preference accept either the buyer-key UUID or the live buyer key value; live-key lookup uses `DATABASE_URL`
 - script-side default provider display for `null` preference follows `BUYER_PROVIDER_PREFERENCE_DEFAULT` (legacy alias `INNIES_BUYER_PROVIDER_PREFERENCE_DEFAULT` also works)

--- a/scripts/innies-compat-direct-request-bundle.mjs
+++ b/scripts/innies-compat-direct-request-bundle.mjs
@@ -1,0 +1,350 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+function fail(message) {
+  console.error(`error: ${message}`);
+  process.exit(1);
+}
+
+function stripLogPrefix(line) {
+  return line.replace(/^.*?\]:\s*/, '');
+}
+
+function decodeJsStringLiteral(literal) {
+  if (literal.length < 2) {
+    throw new Error('empty string literal');
+  }
+
+  const quote = literal[0];
+  if ((quote !== '\'' && quote !== '"') || literal.at(-1) !== quote) {
+    throw new Error(`unsupported string literal: ${literal.slice(0, 32)}`);
+  }
+
+  let result = '';
+  for (let index = 1; index < literal.length - 1; index += 1) {
+    const char = literal[index];
+    if (char !== '\\') {
+      result += char;
+      continue;
+    }
+
+    index += 1;
+    if (index >= literal.length - 1) {
+      throw new Error('unterminated escape sequence');
+    }
+
+    const escape = literal[index];
+    switch (escape) {
+      case '\'':
+      case '"':
+      case '\\':
+      case '/':
+        result += escape;
+        break;
+      case 'b':
+        result += '\b';
+        break;
+      case 'f':
+        result += '\f';
+        break;
+      case 'n':
+        result += '\n';
+        break;
+      case 'r':
+        result += '\r';
+        break;
+      case 't':
+        result += '\t';
+        break;
+      case 'v':
+        result += '\v';
+        break;
+      case '0':
+        result += '\0';
+        break;
+      case 'x': {
+        const hex = literal.slice(index + 1, index + 3);
+        if (!/^[0-9a-fA-F]{2}$/.test(hex)) {
+          throw new Error(`invalid hex escape: \\x${hex}`);
+        }
+        result += String.fromCharCode(Number.parseInt(hex, 16));
+        index += 2;
+        break;
+      }
+      case 'u': {
+        if (literal[index + 1] === '{') {
+          const endIndex = literal.indexOf('}', index + 2);
+          if (endIndex === -1) {
+            throw new Error('unterminated unicode escape');
+          }
+          const hex = literal.slice(index + 2, endIndex);
+          if (!/^[0-9a-fA-F]+$/.test(hex)) {
+            throw new Error(`invalid unicode escape: \\u{${hex}}`);
+          }
+          result += String.fromCodePoint(Number.parseInt(hex, 16));
+          index = endIndex;
+          break;
+        }
+
+        const hex = literal.slice(index + 1, index + 5);
+        if (!/^[0-9a-fA-F]{4}$/.test(hex)) {
+          throw new Error(`invalid unicode escape: \\u${hex}`);
+        }
+        result += String.fromCharCode(Number.parseInt(hex, 16));
+        index += 4;
+        break;
+      }
+      default:
+        throw new Error(`unsupported escape sequence: \\${escape}`);
+    }
+  }
+
+  return result;
+}
+
+function decodeChunkValue(rawValue) {
+  try {
+    const parsed = JSON.parse(rawValue);
+    if (typeof parsed === 'string') {
+      return parsed;
+    }
+  } catch {
+    // fall through to the single-quoted log format
+  }
+
+  return decodeJsStringLiteral(rawValue);
+}
+
+function parseChunkSeries(lines, startIndex, label) {
+  const parts = [];
+  let expectedChunkCount = null;
+  let index = startIndex;
+
+  while (index < lines.length) {
+    const header = stripLogPrefix(lines[index]);
+    if (header !== `${label} {`) {
+      break;
+    }
+
+    const chunkIndexLine = stripLogPrefix(lines[index + 1] ?? '');
+    const chunkCountLine = stripLogPrefix(lines[index + 2] ?? '');
+    const jsonLine = stripLogPrefix(lines[index + 3] ?? '');
+    const closeLine = stripLogPrefix(lines[index + 4] ?? '');
+    const chunkIndexMatch = chunkIndexLine.match(/^chunk_index:\s*(\d+),?$/);
+    const chunkCountMatch = chunkCountLine.match(/^chunk_count:\s*(\d+),?$/);
+    const jsonMatch = jsonLine.match(/^json:\s*(.+)$/);
+
+    if (!chunkIndexMatch || !chunkCountMatch || !jsonMatch || closeLine !== '}') {
+      throw new Error(`malformed ${label} chunk near line ${index + 1}`);
+    }
+
+    const chunkIndex = Number(chunkIndexMatch[1]);
+    const chunkCount = Number(chunkCountMatch[1]);
+    if (expectedChunkCount === null) {
+      expectedChunkCount = chunkCount;
+    } else if (expectedChunkCount !== chunkCount) {
+      throw new Error(`mismatched ${label} chunk_count near line ${index + 1}`);
+    }
+
+    if (chunkIndex !== parts.length) {
+      throw new Error(`out-of-order ${label} chunk_index near line ${index + 1}`);
+    }
+
+    parts.push(decodeChunkValue(jsonMatch[1]));
+    index += 5;
+
+    if (parts.length === expectedChunkCount) {
+      return { text: parts.join(''), nextIndex: index - 1 };
+    }
+  }
+
+  throw new Error(`incomplete ${label} chunk series near line ${startIndex + 1}`);
+}
+
+function normalizeHeaders(headers) {
+  if (!headers || typeof headers !== 'object' || Array.isArray(headers)) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(headers).map(([name, value]) => [String(name), String(value)])
+  );
+}
+
+function parseCapturedRequest(htmlPath, requestId) {
+  const lines = readFileSync(htmlPath, 'utf8').split(/\r?\n/);
+  const label = '[compat-upstream-request-json-chunk]';
+
+  for (let index = 0; index < lines.length; index += 1) {
+    if (stripLogPrefix(lines[index]) !== `${label} {`) {
+      continue;
+    }
+
+    const { text, nextIndex } = parseChunkSeries(lines, index, label);
+    index = nextIndex;
+
+    let parsed;
+    try {
+      parsed = JSON.parse(text);
+    } catch (error) {
+      throw new Error(`failed to parse ${label} json: ${error.message}`);
+    }
+
+    if (String(parsed?.request_id ?? '') !== requestId) {
+      continue;
+    }
+
+    return {
+      ...parsed,
+      headers: normalizeHeaders(parsed.headers)
+    };
+  }
+
+  throw new Error(`no captured compat upstream request found for ${requestId}`);
+}
+
+function sha256Hex(text) {
+  return createHash('sha256').update(text).digest('hex');
+}
+
+function parseRawResponse(headersPath, bodyPath, statusText, providerRequestId) {
+  const headersText = readFileSync(headersPath, 'utf8');
+  const bodyText = readFileSync(bodyPath, 'utf8');
+  const headers = {};
+
+  for (const line of headersText.split(/\r?\n/)) {
+    const separatorIndex = line.indexOf(':');
+    if (separatorIndex === -1) {
+      continue;
+    }
+    const name = line.slice(0, separatorIndex).trim().toLowerCase();
+    const value = line.slice(separatorIndex + 1).trim();
+    if (!name) {
+      continue;
+    }
+    headers[name] = value;
+  }
+
+  let parsedBody = null;
+  try {
+    parsedBody = JSON.parse(bodyText);
+  } catch {
+    parsedBody = null;
+  }
+
+  return {
+    status: Number(statusText),
+    provider_request_id: providerRequestId || '',
+    content_type: headers['content-type'] ?? '',
+    body_sha256: sha256Hex(bodyText),
+    body_bytes: Buffer.byteLength(bodyText, 'utf8'),
+    request_id: String(parsedBody?.request_id ?? ''),
+    error_type: String(parsedBody?.error?.type ?? ''),
+    error_message: String(parsedBody?.error?.message ?? '')
+  };
+}
+
+function buildDirectRequestBundle(capturedRequest, payloadText, targetUrl, directRequestId) {
+  const headers = { ...capturedRequest.headers };
+  headers.authorization = 'Bearer <redacted>';
+  headers['x-request-id'] = directRequestId;
+
+  return {
+    method: 'POST',
+    target_url: targetUrl,
+    request_id: directRequestId,
+    body_sha256: sha256Hex(payloadText),
+    body_bytes: Buffer.byteLength(payloadText, 'utf8'),
+    headers
+  };
+}
+
+function writeJson(filePath, value) {
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function extractCapturedCommand(htmlPath, requestId, outDirInput) {
+  const outDir = resolve(outDirInput);
+  mkdirSync(outDir, { recursive: true });
+
+  const capturedRequest = parseCapturedRequest(htmlPath, requestId);
+  writeJson(join(outDir, 'captured-upstream-request.json'), capturedRequest);
+  writeFileSync(
+    join(outDir, 'captured-headers.tsv'),
+    `${Object.entries(capturedRequest.headers).map(([name, value]) => `${name}\t${value}`).join('\n')}\n`
+  );
+  writeFileSync(
+    join(outDir, 'captured-meta.txt'),
+    [
+      `captured_request_id=${capturedRequest.request_id ?? ''}`,
+      `captured_provider=${capturedRequest.provider ?? ''}`,
+      `captured_target_url=${capturedRequest.target_url ?? ''}`,
+      `captured_proxied_path=${capturedRequest.proxied_path ?? ''}`,
+      `captured_attempt_no=${capturedRequest.attempt_no ?? ''}`,
+      `captured_stream=${String(Boolean(capturedRequest.stream))}`,
+      `captured_body_bytes=${capturedRequest.body_bytes ?? ''}`,
+      `captured_body_sha256=${capturedRequest.body_sha256 ?? ''}`
+    ].join('\n') + '\n'
+  );
+}
+
+function writeDirectBundleCommand(
+  capturedRequestPath,
+  payloadPath,
+  targetUrl,
+  directRequestId,
+  directHeadersPath,
+  directBodyPath,
+  directStatus,
+  providerRequestId,
+  outDirInput
+) {
+  const outDir = resolve(outDirInput);
+  mkdirSync(outDir, { recursive: true });
+
+  const capturedRequest = JSON.parse(readFileSync(capturedRequestPath, 'utf8'));
+  const payloadText = readFileSync(payloadPath, 'utf8');
+  const directRequest = buildDirectRequestBundle(capturedRequest, payloadText, targetUrl, directRequestId);
+  const directResponse = parseRawResponse(directHeadersPath, directBodyPath, directStatus, providerRequestId);
+
+  writeJson(join(outDir, 'direct-request.json'), directRequest);
+  writeJson(join(outDir, 'direct-response.json'), directResponse);
+}
+
+const [command, ...args] = process.argv.slice(2);
+
+try {
+  switch (command) {
+    case 'extract-captured':
+      if (args.length !== 3) {
+        fail('usage: extract-captured <captured-html> <request-id> <out-dir>');
+      }
+      extractCapturedCommand(args[0], args[1], args[2]);
+      break;
+    case 'write-direct-bundle':
+      if (args.length !== 9) {
+        fail(
+          'usage: write-direct-bundle <captured-request-json> <payload-path> <target-url> <direct-request-id> <direct-headers-path> <direct-body-path> <direct-status> <provider-request-id> <out-dir>'
+        );
+      }
+      writeDirectBundleCommand(
+        args[0],
+        args[1],
+        args[2],
+        args[3],
+        args[4],
+        args[5],
+        args[6],
+        args[7],
+        args[8]
+      );
+      break;
+    default:
+      fail('expected command: extract-captured | write-direct-bundle');
+  }
+} catch (error) {
+  fail(error instanceof Error ? error.message : String(error));
+}

--- a/scripts/innies-compat-direct-request-bundle.sh
+++ b/scripts/innies-compat-direct-request-bundle.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_PATH" ]]; do
+  SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+  SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"
+  [[ "$SCRIPT_PATH" != /* ]] && SCRIPT_PATH="${SCRIPT_DIR}/${SCRIPT_PATH}"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+source "${SCRIPT_DIR}/_common.sh"
+
+usage() {
+  cat >&2 <<'EOF'
+usage: scripts/innies-compat-direct-request-bundle.sh <payload.json>
+
+Replays a captured Anthropic first pass directly and emits normalized captured/direct request bundles.
+
+Required env:
+- INNIES_CAPTURED_RESPONSE_HTML
+- INNIES_CAPTURED_REQUEST_ID
+
+Optional env:
+- INNIES_DIRECT_BUNDLE_OUT_DIR
+- INNIES_DIRECT_REQUEST_ID
+- ANTHROPIC_DIRECT_BASE_URL
+- ANTHROPIC_BASE_URL
+- ANTHROPIC_OAUTH_ACCESS_TOKEN
+- ANTHROPIC_ACCESS_TOKEN
+- CLAUDE_CODE_OAUTH_TOKEN
+EOF
+}
+
+extract_header() {
+  local name="$1"
+  local file="$2"
+  awk -F': ' -v header_name="$name" '
+    BEGIN { IGNORECASE = 1 }
+    tolower($1) == tolower(header_name) {
+      gsub("\r", "", $2)
+      print $2
+    }
+  ' "$file" | tail -1
+}
+
+extract_body_request_id() {
+  local file="$1"
+  sed -n 's/.*"request_id":"\([^"]*\)".*/\1/p' "$file" | head -n 1
+}
+
+resolve_direct_base_url() {
+  if [[ -n "${ANTHROPIC_DIRECT_BASE_URL:-}" ]]; then
+    printf '%s' "${ANTHROPIC_DIRECT_BASE_URL%/}"
+    return
+  fi
+  if [[ -n "${ANTHROPIC_BASE_URL:-}" ]]; then
+    printf '%s' "${ANTHROPIC_BASE_URL%/}"
+    return
+  fi
+  printf '%s' 'https://api.anthropic.com'
+}
+
+write_lines() {
+  local file="$1"
+  shift
+  printf '%s\n' "$@" >"$file"
+}
+
+DIRECT_ACCESS_TOKEN_SOURCE=''
+ACCESS_TOKEN=''
+
+resolve_direct_access_token() {
+  if [[ -n "${ANTHROPIC_OAUTH_ACCESS_TOKEN:-}" ]]; then
+    DIRECT_ACCESS_TOKEN_SOURCE='anthropic_oauth_access_token'
+    ACCESS_TOKEN="${ANTHROPIC_OAUTH_ACCESS_TOKEN}"
+    return
+  fi
+  if [[ -n "${ANTHROPIC_ACCESS_TOKEN:-}" ]]; then
+    DIRECT_ACCESS_TOKEN_SOURCE='anthropic_access_token'
+    ACCESS_TOKEN="${ANTHROPIC_ACCESS_TOKEN}"
+    return
+  fi
+  if [[ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
+    DIRECT_ACCESS_TOKEN_SOURCE='claude_code_oauth_token'
+    ACCESS_TOKEN="${CLAUDE_CODE_OAUTH_TOKEN}"
+    return
+  fi
+  DIRECT_ACCESS_TOKEN_SOURCE=''
+  ACCESS_TOKEN=''
+}
+
+PAYLOAD_PATH="${1:-${INNIES_REPLAY_PAYLOAD_PATH:-}}"
+if [[ $# -gt 1 ]]; then
+  usage
+  exit 1
+fi
+require_nonempty 'payload path' "$PAYLOAD_PATH"
+
+if [[ ! -f "$PAYLOAD_PATH" ]]; then
+  echo "error: payload file not found: $PAYLOAD_PATH" >&2
+  exit 1
+fi
+
+CAPTURED_RESPONSE_HTML="${INNIES_CAPTURED_RESPONSE_HTML:-${INNIES_CAPTURED_LOG_PATH:-}}"
+CAPTURED_REQUEST_ID="${INNIES_CAPTURED_REQUEST_ID:-${INNIES_REQUEST_ID:-}}"
+require_nonempty 'captured response HTML' "$CAPTURED_RESPONSE_HTML"
+require_nonempty 'captured request id' "$CAPTURED_REQUEST_ID"
+
+if [[ ! -f "$CAPTURED_RESPONSE_HTML" ]]; then
+  echo "error: captured response HTML not found: $CAPTURED_RESPONSE_HTML" >&2
+  exit 1
+fi
+
+DIRECT_BASE_URL="$(resolve_direct_base_url)"
+resolve_direct_access_token
+require_nonempty 'Anthropic OAuth access token' "$ACCESS_TOKEN"
+
+DIRECT_REQUEST_ID="${INNIES_DIRECT_REQUEST_ID:-req_issue80_direct_$(date -u +%Y%m%dT%H%M%SZ)}"
+OUT_DIR="${INNIES_DIRECT_BUNDLE_OUT_DIR:-${TMPDIR:-/tmp}/innies-compat-direct-request-bundle-${DIRECT_REQUEST_ID}}"
+mkdir -p "$OUT_DIR"
+
+CAPTURED_HEADERS_FILE="$OUT_DIR/captured-headers.tsv"
+CAPTURED_META_FILE="$OUT_DIR/captured-meta.txt"
+CAPTURED_REQUEST_JSON="$OUT_DIR/captured-upstream-request.json"
+DIRECT_HEADERS_FILE="$OUT_DIR/direct-headers.txt"
+DIRECT_BODY_FILE="$OUT_DIR/direct-body.txt"
+META_FILE="$OUT_DIR/meta.txt"
+
+node "${SCRIPT_DIR}/innies-compat-direct-request-bundle.mjs" \
+  extract-captured \
+  "$CAPTURED_RESPONSE_HTML" \
+  "$CAPTURED_REQUEST_ID" \
+  "$OUT_DIR"
+
+CAPTURED_PROVIDER=''
+CAPTURED_TARGET_URL=''
+CAPTURED_PROXIED_PATH=''
+CAPTURED_ATTEMPT_NO=''
+CAPTURED_STREAM=''
+CAPTURED_BODY_BYTES=''
+CAPTURED_BODY_SHA256=''
+while IFS='=' read -r key value; do
+  case "$key" in
+    captured_provider) CAPTURED_PROVIDER="$value" ;;
+    captured_target_url) CAPTURED_TARGET_URL="$value" ;;
+    captured_proxied_path) CAPTURED_PROXIED_PATH="$value" ;;
+    captured_attempt_no) CAPTURED_ATTEMPT_NO="$value" ;;
+    captured_stream) CAPTURED_STREAM="$value" ;;
+    captured_body_bytes) CAPTURED_BODY_BYTES="$value" ;;
+    captured_body_sha256) CAPTURED_BODY_SHA256="$value" ;;
+  esac
+done <"$CAPTURED_META_FILE"
+
+CAPTURED_PROVIDER_NORMALIZED="$(printf '%s' "$CAPTURED_PROVIDER" | tr '[:upper:]' '[:lower:]')"
+if [[ "$CAPTURED_PROVIDER_NORMALIZED" != 'anthropic' ]]; then
+  echo "error: captured Innies lane resolved to ${CAPTURED_PROVIDER:-unknown}; expected anthropic" >&2
+  exit 1
+fi
+
+DIRECT_PATH="${CAPTURED_PROXIED_PATH:-/v1/messages}"
+DIRECT_TARGET_URL="${DIRECT_BASE_URL}${DIRECT_PATH}"
+DIRECT_STATUS=''
+declare -a DIRECT_CURL_ARGS
+DIRECT_CURL_ARGS=(
+  -sS
+  -D "$DIRECT_HEADERS_FILE"
+  -o "$DIRECT_BODY_FILE"
+  -w '%{http_code}'
+  -X POST "$DIRECT_TARGET_URL"
+  --data-binary "@$PAYLOAD_PATH"
+  -H "Authorization: Bearer $ACCESS_TOKEN"
+)
+
+HAVE_DIRECT_REQUEST_ID='false'
+while IFS=$'\t' read -r header_name header_value; do
+  [[ -z "$header_name" ]] && continue
+  header_name_normalized="$(printf '%s' "$header_name" | tr '[:upper:]' '[:lower:]')"
+  case "$header_name_normalized" in
+    authorization|content-length|host)
+      continue
+      ;;
+    x-request-id)
+      DIRECT_CURL_ARGS+=(-H "x-request-id: $DIRECT_REQUEST_ID")
+      HAVE_DIRECT_REQUEST_ID='true'
+      ;;
+    *)
+      DIRECT_CURL_ARGS+=(-H "${header_name}: ${header_value}")
+      ;;
+  esac
+done <"$CAPTURED_HEADERS_FILE"
+
+if [[ "$HAVE_DIRECT_REQUEST_ID" != 'true' ]]; then
+  DIRECT_CURL_ARGS+=(-H "x-request-id: $DIRECT_REQUEST_ID")
+fi
+
+DIRECT_STATUS="$(curl "${DIRECT_CURL_ARGS[@]}")"
+PROVIDER_REQUEST_ID="$(extract_header 'request-id' "$DIRECT_HEADERS_FILE")"
+if [[ -z "$PROVIDER_REQUEST_ID" ]]; then
+  PROVIDER_REQUEST_ID="$(extract_body_request_id "$DIRECT_BODY_FILE")"
+fi
+
+node "${SCRIPT_DIR}/innies-compat-direct-request-bundle.mjs" \
+  write-direct-bundle \
+  "$CAPTURED_REQUEST_JSON" \
+  "$PAYLOAD_PATH" \
+  "$DIRECT_TARGET_URL" \
+  "$DIRECT_REQUEST_ID" \
+  "$DIRECT_HEADERS_FILE" \
+  "$DIRECT_BODY_FILE" \
+  "$DIRECT_STATUS" \
+  "$PROVIDER_REQUEST_ID" \
+  "$OUT_DIR"
+
+write_lines "$META_FILE" \
+  "payload_path=$PAYLOAD_PATH" \
+  "captured_response_html=$CAPTURED_RESPONSE_HTML" \
+  "captured_request_id=$CAPTURED_REQUEST_ID" \
+  "captured_provider=${CAPTURED_PROVIDER:-}" \
+  "captured_target_url=${CAPTURED_TARGET_URL:-}" \
+  "captured_proxied_path=${CAPTURED_PROXIED_PATH:-}" \
+  "captured_attempt_no=${CAPTURED_ATTEMPT_NO:-}" \
+  "captured_stream=${CAPTURED_STREAM:-}" \
+  "captured_body_bytes=${CAPTURED_BODY_BYTES:-}" \
+  "captured_body_sha256=${CAPTURED_BODY_SHA256:-}" \
+  "direct_request_id=$DIRECT_REQUEST_ID" \
+  "direct_status=$DIRECT_STATUS" \
+  "provider_request_id=${PROVIDER_REQUEST_ID:-}" \
+  "direct_access_token_source=${DIRECT_ACCESS_TOKEN_SOURCE:-}" \
+  "direct_base_url=$DIRECT_BASE_URL" \
+  "direct_target_url=$DIRECT_TARGET_URL" \
+  "captured_headers_file=$CAPTURED_HEADERS_FILE" \
+  "captured_meta_file=$CAPTURED_META_FILE" \
+  "captured_request_json=$CAPTURED_REQUEST_JSON" \
+  "direct_headers_file=$DIRECT_HEADERS_FILE" \
+  "direct_body_file=$DIRECT_BODY_FILE" \
+  "direct_request_json=$OUT_DIR/direct-request.json" \
+  "direct_response_json=$OUT_DIR/direct-response.json"
+
+cat "$META_FILE"
+printf 'meta_file=%s\n' "$META_FILE"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,6 +18,7 @@ ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-set.sh" "${BIN_DIR}/innies-b
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-get.sh" "${BIN_DIR}/innies-buyer-preference-get"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-check.sh" "${BIN_DIR}/innies-buyer-preference-check"
 ln -sf "${ROOT_DIR}/scripts/innies-slo-check.sh" "${BIN_DIR}/innies-slo-check"
+ln -sf "${ROOT_DIR}/scripts/innies-compat-direct-request-bundle.sh" "${BIN_DIR}/innies-compat-direct-request-bundle"
 
 rm -f \
   "${BIN_DIR}/innies-admin" \
@@ -49,6 +50,7 @@ echo "  ${BIN_DIR}/innies-buyer-preference-set -> ${ROOT_DIR}/scripts/innies-buy
 echo "  ${BIN_DIR}/innies-buyer-preference-get -> ${ROOT_DIR}/scripts/innies-buyer-preference-get.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-check -> ${ROOT_DIR}/scripts/innies-buyer-preference-check.sh"
 echo "  ${BIN_DIR}/innies-slo-check -> ${ROOT_DIR}/scripts/innies-slo-check.sh"
+echo "  ${BIN_DIR}/innies-compat-direct-request-bundle -> ${ROOT_DIR}/scripts/innies-compat-direct-request-bundle.sh"
 echo
 echo 'If command not found, add ~/.local/bin to PATH:'
 echo '  export PATH="$HOME/.local/bin:$PATH"'

--- a/scripts/tests/innies-compat-direct-request-bundle.test.sh
+++ b/scripts/tests/innies-compat-direct-request-bundle.test.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="$ROOT_DIR/scripts/innies-compat-direct-request-bundle.sh"
+TMP_DIR="$(mktemp -d)"
+PAYLOAD_PATH="$TMP_DIR/payload.json"
+CAPTURED_HTML_PATH="$TMP_DIR/response.html"
+REQUESTS_DIR="$TMP_DIR/requests"
+OUT_DIR="$TMP_DIR/out"
+STDOUT_PATH="$TMP_DIR/stdout.txt"
+STDERR_PATH="$TMP_DIR/stderr.txt"
+mkdir -p "$REQUESTS_DIR"
+
+cleanup() {
+  if [[ -n "${SERVER_PID:-}" ]]; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+cat >"$PAYLOAD_PATH" <<'JSON'
+{"model":"claude-opus-4-6","stream":true,"max_tokens":16,"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}],"thinking":{"type":"enabled","budget_tokens":1024}}
+JSON
+
+PAYLOAD_SHA="$(openssl dgst -sha256 -r "$PAYLOAD_PATH" | awk '{print $1}')"
+PAYLOAD_BYTES="$(wc -c <"$PAYLOAD_PATH" | tr -d '[:space:]')"
+
+cat >"$CAPTURED_HTML_PATH" <<LOG
+Mar 17 17:27:57 sf-prod bash[12345]: [compat-upstream-request-json-chunk] {
+Mar 17 17:27:57 sf-prod bash[12345]:   chunk_index: 0,
+Mar 17 17:27:57 sf-prod bash[12345]:   chunk_count: 1,
+Mar 17 17:27:57 sf-prod bash[12345]:   json: '{"attempt_no":1,"body_bytes":${PAYLOAD_BYTES},"body_sha256":"${PAYLOAD_SHA}","credential_id":"cred_issue80","headers":{"accept":"text/event-stream","anthropic-beta":"fine-grained-tool-streaming-2025-05-14,claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14","anthropic-dangerous-direct-browser-access":"true","anthropic-version":"2023-06-01","authorization":"Bearer <redacted:108>","content-type":"application/json","user-agent":"OpenClawGateway/1.0","x-app":"cli","x-request-id":"req_issue80_captured"},"provider":"anthropic","proxied_path":"/v1/messages","request_id":"req_issue80_captured","stream":true,"target_url":"https://api.anthropic.com/v1/messages"}'
+Mar 17 17:27:57 sf-prod bash[12345]: }
+LOG
+
+cat >"$TMP_DIR/mock-server.mjs" <<'NODE'
+import { createServer } from 'node:http';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const port = Number(process.env.PORT);
+const requestsDir = process.env.REQUESTS_DIR;
+mkdirSync(requestsDir, { recursive: true });
+
+const server = createServer((req, res) => {
+  const chunks = [];
+  req.on('data', (chunk) => chunks.push(chunk));
+  req.on('end', () => {
+    const body = Buffer.concat(chunks).toString('utf8');
+    const requestId = req.headers['x-request-id'] || `unknown-${Date.now()}`;
+    writeFileSync(join(requestsDir, `${requestId}.json`), JSON.stringify({
+      method: req.method,
+      url: req.url,
+      headers: req.headers,
+      body: JSON.parse(body)
+    }, null, 2));
+
+    res.statusCode = 400;
+    res.setHeader('content-type', 'application/json');
+    res.setHeader('request-id', 'req_upstream_issue80_direct');
+    res.end(JSON.stringify({
+      type: 'error',
+      error: { type: 'invalid_request_error', message: 'Error' },
+      request_id: 'req_upstream_issue80_direct'
+    }));
+  });
+});
+
+server.listen(port, '127.0.0.1', () => {
+  process.stdout.write(`ready:${port}\n`);
+});
+NODE
+
+PORT="$(node -e "const net=require('node:net');const server=net.createServer();server.listen(0,'127.0.0.1',()=>{console.log(server.address().port);server.close();});")"
+PORT="$PORT" REQUESTS_DIR="$REQUESTS_DIR" node "$TMP_DIR/mock-server.mjs" >"$TMP_DIR/server.log" 2>&1 &
+SERVER_PID=$!
+
+for _ in $(seq 1 50); do
+  if grep -q '^ready:' "$TMP_DIR/server.log" 2>/dev/null; then
+    break
+  fi
+  sleep 0.1
+done
+
+if ! grep -q '^ready:' "$TMP_DIR/server.log" 2>/dev/null; then
+  echo 'server did not start' >&2
+  cat "$TMP_DIR/server.log" >&2
+  exit 1
+fi
+
+set +e
+INNIES_CAPTURED_RESPONSE_HTML="$CAPTURED_HTML_PATH" \
+INNIES_CAPTURED_REQUEST_ID="req_issue80_captured" \
+INNIES_DIRECT_BUNDLE_OUT_DIR="$OUT_DIR" \
+INNIES_DIRECT_REQUEST_ID="req_issue80_direct" \
+ANTHROPIC_OAUTH_ACCESS_TOKEN="sk-ant-oat-direct-token" \
+ANTHROPIC_DIRECT_BASE_URL="http://127.0.0.1:$PORT" \
+"$SCRIPT_PATH" "$PAYLOAD_PATH" >"$STDOUT_PATH" 2>"$STDERR_PATH"
+STATUS=$?
+set -e
+
+if [[ "$STATUS" -ne 0 ]]; then
+  cat "$STDERR_PATH" >&2
+  exit 1
+fi
+
+[[ -f "$OUT_DIR/captured-upstream-request.json" ]]
+[[ -f "$OUT_DIR/direct-request.json" ]]
+[[ -f "$OUT_DIR/direct-response.json" ]]
+[[ -f "$OUT_DIR/direct-headers.txt" ]]
+[[ -f "$OUT_DIR/direct-body.txt" ]]
+[[ -f "$OUT_DIR/meta.txt" ]]
+
+node - "$OUT_DIR/captured-upstream-request.json" "$PAYLOAD_SHA" "$PAYLOAD_BYTES" <<'NODE'
+const fs = require('node:fs');
+
+const bundlePath = process.argv[2];
+const expectedSha = process.argv[3];
+const expectedBytes = Number(process.argv[4]);
+const bundle = JSON.parse(fs.readFileSync(bundlePath, 'utf8'));
+
+if (bundle.request_id !== 'req_issue80_captured') throw new Error(`unexpected captured request_id: ${bundle.request_id}`);
+if (bundle.provider !== 'anthropic') throw new Error(`unexpected provider: ${bundle.provider}`);
+if (bundle.body_sha256 !== expectedSha) throw new Error(`unexpected captured body_sha256: ${bundle.body_sha256}`);
+if (bundle.body_bytes !== expectedBytes) throw new Error(`unexpected captured body_bytes: ${bundle.body_bytes}`);
+if (bundle.headers['user-agent'] !== 'OpenClawGateway/1.0') throw new Error(`unexpected captured user-agent: ${bundle.headers['user-agent']}`);
+NODE
+
+node - "$OUT_DIR/direct-request.json" "$PAYLOAD_SHA" "$PAYLOAD_BYTES" <<'NODE'
+const fs = require('node:fs');
+
+const bundlePath = process.argv[2];
+const expectedSha = process.argv[3];
+const expectedBytes = Number(process.argv[4]);
+const bundle = JSON.parse(fs.readFileSync(bundlePath, 'utf8'));
+
+if (bundle.request_id !== 'req_issue80_direct') throw new Error(`unexpected direct request_id: ${bundle.request_id}`);
+if (bundle.method !== 'POST') throw new Error(`unexpected method: ${bundle.method}`);
+if (!bundle.target_url.startsWith('http://127.0.0.1:') || !bundle.target_url.endsWith('/v1/messages')) {
+  throw new Error(`unexpected target_url: ${bundle.target_url}`);
+}
+if (bundle.body_sha256 !== expectedSha) throw new Error(`unexpected direct body_sha256: ${bundle.body_sha256}`);
+if (bundle.body_bytes !== expectedBytes) throw new Error(`unexpected direct body_bytes: ${bundle.body_bytes}`);
+if (bundle.headers.authorization !== 'Bearer <redacted>') throw new Error(`unexpected authorization: ${bundle.headers.authorization}`);
+if (bundle.headers['x-request-id'] !== 'req_issue80_direct') throw new Error(`unexpected x-request-id: ${bundle.headers['x-request-id']}`);
+if (bundle.headers['anthropic-beta'] !== 'fine-grained-tool-streaming-2025-05-14,claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14') {
+  throw new Error(`unexpected anthropic-beta: ${bundle.headers['anthropic-beta']}`);
+}
+if (bundle.headers['user-agent'] !== 'OpenClawGateway/1.0') throw new Error(`unexpected direct user-agent: ${bundle.headers['user-agent']}`);
+NODE
+
+node - "$OUT_DIR/direct-response.json" <<'NODE'
+const fs = require('node:fs');
+
+const bundle = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+if (bundle.status !== 400) throw new Error(`unexpected status: ${bundle.status}`);
+if (bundle.provider_request_id !== 'req_upstream_issue80_direct') {
+  throw new Error(`unexpected provider_request_id: ${bundle.provider_request_id}`);
+}
+if (bundle.error_type !== 'invalid_request_error') throw new Error(`unexpected error_type: ${bundle.error_type}`);
+NODE
+
+grep -q 'direct_request_id=req_issue80_direct' "$OUT_DIR/meta.txt"
+grep -q 'direct_status=400' "$OUT_DIR/meta.txt"
+grep -q 'provider_request_id=req_upstream_issue80_direct' "$OUT_DIR/meta.txt"
+grep -q 'direct_access_token_source=anthropic_oauth_access_token' "$OUT_DIR/meta.txt"
+grep -q '"authorization": "Bearer sk-ant-oat-direct-token"' "$REQUESTS_DIR/req_issue80_direct.json"
+grep -q '"x-request-id": "req_issue80_direct"' "$REQUESTS_DIR/req_issue80_direct.json"


### PR DESCRIPTION
## Summary
- add `innies-compat-direct-request-bundle`, which extracts one failing Anthropic compat first-pass request from a saved artifact, replays the same payload directly, and emits normalized `captured-upstream-request.json`, `direct-request.json`, and `direct-response.json` bundles
- keep the extracted bundle path safe by decoding logged chunk strings without `Function(...)`, and redact the stored direct authorization header while still sending the real bearer on the replay request
- wire the helper into `scripts/install.sh` and `scripts/README.md`, with focused shell coverage against a mock Anthropic endpoint

## Test Plan
- `bash scripts/tests/innies-compat-direct-request-bundle.test.sh`
- `bash -n scripts/innies-compat-direct-request-bundle.sh scripts/tests/innies-compat-direct-request-bundle.test.sh scripts/install.sh`
- `node --check scripts/innies-compat-direct-request-bundle.mjs`
- `git diff --check`
- `TMP_HOME="$(mktemp -d)" && HOME="$TMP_HOME" bash scripts/install.sh >/tmp/innies-install-smoke.out && test -L "$TMP_HOME/.local/bin/innies-compat-direct-request-bundle"`

Refs #80