### PR TITLE
chore: add direct Anthropic bundle capture helper

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -25,6 +25,7 @@ innies-buyer-preference-set
 innies-buyer-preference-get
 innies-buyer-preference-check
 innies-slo-check
+innies-compat-direct-bundle-capture
 ```
 
 What they do:
@@ -40,6 +41,7 @@ What they do:
 - `innies-buyer-preference-get`: read the current buyer key preference
 - `innies-buyer-preference-check`: run the provider-preference canary after prompting for the expected provider (`Claude Code` or `Codex`)
 - `innies-slo-check`: query analytics endpoints and report Phase 1 SLO pass/fail (TTFB p95, timeout rate, success rate, fallback rate); optional arg sets the window (default `24h`); exits 0 if all SLOs pass, 1 if any fail
+- `innies-compat-direct-bundle-capture`: send one direct Anthropic `/v1/messages` request and persist a reusable first-pass bundle (`payload.json`, `upstream-request.json`, `upstream-response.json`, raw response artifacts, and `summary.txt`) for issue-80 diff work
 
 Behavior:
 - org id auto-uses `INNIES_ORG_ID`
@@ -79,6 +81,9 @@ Behavior:
 - non-pinned buyer traffic always gets automatic cross-provider fallback to the other provider; flipping preference flips fallback order too
 - `innies-buyer-preference-set` prints the effective preferred provider plus the automatic fallback provider before sending the update
 - `innies-buyer-preference-check` now expects and validates the two-provider plan in DB evidence mode
+- `innies-compat-direct-bundle-capture` accepts `ANTHROPIC_OAUTH_ACCESS_TOKEN`, `ANTHROPIC_ACCESS_TOKEN`, or `CLAUDE_CODE_OAUTH_TOKEN`; defaults to the known-good OpenClaw-style identity lane (`anthropic-dangerous-direct-browser-access: true`, `x-app: cli`, `user-agent: OpenClawGateway/1.0`) but can disable that lane with `INNIES_DIRECT_INCLUDE_IDENTITY_HEADERS=false`
+- `innies-compat-direct-bundle-capture` writes a redacted request bundle plus raw response headers/body so the output can be diffed without leaking the live bearer token into the saved artifacts
+- `innies-compat-direct-bundle-capture` optionally enforces `INNIES_DIRECT_EXPECTED_BODY_BYTES` and/or `INNIES_DIRECT_EXPECTED_BODY_SHA256` before it sends anything, so body-held-constant replays fail fast on drifted payload files
 
 ## Env
 

--- a/scripts/innies-compat-direct-bundle-capture.sh
+++ b/scripts/innies-compat-direct-bundle-capture.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_PATH" ]]; do
+  SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+  SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"
+  [[ "$SCRIPT_PATH" != /* ]] && SCRIPT_PATH="${SCRIPT_DIR}/${SCRIPT_PATH}"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+source "${SCRIPT_DIR}/_common.sh"
+
+extract_header() {
+  local name="$1"
+  local file="$2"
+  awk -F': ' -v header_name="$name" '
+    BEGIN { IGNORECASE = 1 }
+    tolower($1) == tolower(header_name) {
+      gsub("\r", "", $2)
+      print $2
+    }
+  ' "$file" | tail -1
+}
+
+extract_body_request_id() {
+  local file="$1"
+  sed -n 's/.*"request_id":"\([^"]*\)".*/\1/p' "$file" | head -n 1
+}
+
+resolve_direct_base_url() {
+  if [[ -n "${ANTHROPIC_DIRECT_BASE_URL:-}" ]]; then
+    printf '%s' "${ANTHROPIC_DIRECT_BASE_URL%/}"
+    return
+  fi
+  if [[ -n "${ANTHROPIC_BASE_URL:-}" ]]; then
+    printf '%s' "${ANTHROPIC_BASE_URL%/}"
+    return
+  fi
+  printf '%s' 'https://api.anthropic.com'
+}
+
+normalize_bool() {
+  local value
+  value="$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')"
+  case "$value" in
+    ''|1|true|yes|on)
+      printf 'true'
+      ;;
+    0|false|no|off)
+      printf 'false'
+      ;;
+    *)
+      echo "error: invalid boolean value: ${1:-}" >&2
+      exit 1
+      ;;
+  esac
+}
+
+resolve_access_token() {
+  if [[ -n "${ANTHROPIC_OAUTH_ACCESS_TOKEN:-}" ]]; then
+    ACCESS_TOKEN="$ANTHROPIC_OAUTH_ACCESS_TOKEN"
+    ACCESS_TOKEN_SOURCE='anthropic_oauth_access_token'
+    return
+  fi
+  if [[ -n "${ANTHROPIC_ACCESS_TOKEN:-}" ]]; then
+    ACCESS_TOKEN="$ANTHROPIC_ACCESS_TOKEN"
+    ACCESS_TOKEN_SOURCE='anthropic_access_token'
+    return
+  fi
+  if [[ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
+    ACCESS_TOKEN="$CLAUDE_CODE_OAUTH_TOKEN"
+    ACCESS_TOKEN_SOURCE='claude_code_oauth_token'
+    return
+  fi
+  echo 'error: missing Anthropic OAuth access token' >&2
+  exit 1
+}
+
+sha256_file() {
+  openssl dgst -sha256 -r "$1" | awk '{print $1}'
+}
+
+PAYLOAD_PATH="${1:-${INNIES_REPLAY_PAYLOAD_PATH:-}}"
+require_nonempty 'payload path' "$PAYLOAD_PATH"
+
+if [[ ! -f "$PAYLOAD_PATH" ]]; then
+  echo "error: payload file not found: $PAYLOAD_PATH" >&2
+  exit 1
+fi
+
+resolve_access_token
+
+DIRECT_BASE_URL="$(resolve_direct_base_url)"
+DIRECT_PATH="${INNIES_DIRECT_PATH:-/v1/messages}"
+TARGET_URL="${DIRECT_BASE_URL}${DIRECT_PATH}"
+REQUEST_ID="${INNIES_DIRECT_REQUEST_ID:-req_issue80_direct_capture_$(date -u +%Y%m%dT%H%M%SZ)}"
+OUT_DIR="${INNIES_DIRECT_CAPTURE_OUT_DIR:-${TMPDIR:-/tmp}/innies-compat-direct-bundle-capture-${REQUEST_ID}}"
+mkdir -p "$OUT_DIR"
+
+ANTHROPIC_VERSION="${INNIES_DIRECT_ANTHROPIC_VERSION:-${INNIES_ANTHROPIC_VERSION:-2023-06-01}}"
+ANTHROPIC_BETA="${INNIES_DIRECT_ANTHROPIC_BETA:-${INNIES_CALLER_ANTHROPIC_BETA:-fine-grained-tool-streaming-2025-05-14}}"
+ACCEPT_HEADER="${INNIES_DIRECT_ACCEPT:-text/event-stream}"
+INCLUDE_IDENTITY_HEADERS="$(normalize_bool "${INNIES_DIRECT_INCLUDE_IDENTITY_HEADERS:-true}")"
+USER_AGENT="${INNIES_DIRECT_USER_AGENT:-OpenClawGateway/1.0}"
+X_APP="${INNIES_DIRECT_X_APP:-cli}"
+
+PAYLOAD_COPY_PATH="$OUT_DIR/payload.json"
+UPSTREAM_REQUEST_PATH="$OUT_DIR/upstream-request.json"
+UPSTREAM_RESPONSE_PATH="$OUT_DIR/upstream-response.json"
+RESPONSE_HEADERS_PATH="$OUT_DIR/response-headers.txt"
+RESPONSE_BODY_PATH="$OUT_DIR/response-body.txt"
+SUMMARY_PATH="$OUT_DIR/summary.txt"
+
+cp "$PAYLOAD_PATH" "$PAYLOAD_COPY_PATH"
+PAYLOAD_BYTES="$(wc -c <"$PAYLOAD_PATH" | tr -d ' ')"
+PAYLOAD_SHA256="$(sha256_file "$PAYLOAD_PATH")"
+EXPECTED_BODY_BYTES="${INNIES_DIRECT_EXPECTED_BODY_BYTES:-}"
+EXPECTED_BODY_SHA256="${INNIES_DIRECT_EXPECTED_BODY_SHA256:-}"
+
+if [[ -n "$EXPECTED_BODY_BYTES" && "$PAYLOAD_BYTES" != "$EXPECTED_BODY_BYTES" ]]; then
+  echo "error: payload bytes ($PAYLOAD_BYTES) do not match expected body bytes ($EXPECTED_BODY_BYTES)" >&2
+  exit 1
+fi
+
+if [[ -n "$EXPECTED_BODY_SHA256" && "$PAYLOAD_SHA256" != "$EXPECTED_BODY_SHA256" ]]; then
+  echo "error: payload sha256 ($PAYLOAD_SHA256) does not match expected body sha256 ($EXPECTED_BODY_SHA256)" >&2
+  exit 1
+fi
+
+declare -a CURL_ARGS
+CURL_ARGS=(
+  -sS
+  -D "$RESPONSE_HEADERS_PATH"
+  -o "$RESPONSE_BODY_PATH"
+  -w '%{http_code}'
+  -X POST "$TARGET_URL"
+  -H "Authorization: Bearer $ACCESS_TOKEN"
+  -H 'Content-Type: application/json'
+  -H "Accept: $ACCEPT_HEADER"
+  -H "anthropic-version: $ANTHROPIC_VERSION"
+  -H "anthropic-beta: $ANTHROPIC_BETA"
+  -H "x-request-id: $REQUEST_ID"
+  --data-binary "@$PAYLOAD_PATH"
+)
+
+if [[ "$INCLUDE_IDENTITY_HEADERS" == 'true' ]]; then
+  CURL_ARGS+=(
+    -H 'anthropic-dangerous-direct-browser-access: true'
+    -H "x-app: $X_APP"
+    -H "user-agent: $USER_AGENT"
+  )
+else
+  CURL_ARGS+=(-H 'user-agent:')
+fi
+
+DIRECT_STATUS="$(curl "${CURL_ARGS[@]}")"
+PROVIDER_REQUEST_ID="$(extract_header 'request-id' "$RESPONSE_HEADERS_PATH")"
+if [[ -z "$PROVIDER_REQUEST_ID" ]]; then
+  PROVIDER_REQUEST_ID="$(extract_body_request_id "$RESPONSE_BODY_PATH")"
+fi
+RESPONSE_CONTENT_TYPE="$(extract_header 'content-type' "$RESPONSE_HEADERS_PATH")"
+RESPONSE_SHA256="$(sha256_file "$RESPONSE_BODY_PATH")"
+
+SUMMARY_USER_AGENT=''
+SUMMARY_X_APP=''
+if [[ "$INCLUDE_IDENTITY_HEADERS" == 'true' ]]; then
+  SUMMARY_USER_AGENT="$USER_AGENT"
+  SUMMARY_X_APP="$X_APP"
+fi
+
+REQUEST_ID="$REQUEST_ID" \
+TARGET_URL="$TARGET_URL" \
+PAYLOAD_BYTES="$PAYLOAD_BYTES" \
+PAYLOAD_SHA256="$PAYLOAD_SHA256" \
+ANTHROPIC_VERSION="$ANTHROPIC_VERSION" \
+ANTHROPIC_BETA="$ANTHROPIC_BETA" \
+ACCEPT_HEADER="$ACCEPT_HEADER" \
+INCLUDE_IDENTITY_HEADERS="$INCLUDE_IDENTITY_HEADERS" \
+USER_AGENT="$USER_AGENT" \
+X_APP="$X_APP" \
+UPSTREAM_REQUEST_PATH="$UPSTREAM_REQUEST_PATH" \
+UPSTREAM_RESPONSE_PATH="$UPSTREAM_RESPONSE_PATH" \
+RESPONSE_BODY_PATH="$RESPONSE_BODY_PATH" \
+DIRECT_STATUS="$DIRECT_STATUS" \
+PROVIDER_REQUEST_ID="$PROVIDER_REQUEST_ID" \
+RESPONSE_CONTENT_TYPE="$RESPONSE_CONTENT_TYPE" \
+node <<'NODE'
+const fs = require('node:fs');
+const crypto = require('node:crypto');
+
+function sha256(text) {
+  return crypto.createHash('sha256').update(text).digest('hex');
+}
+
+const requestHeaders = {
+  accept: process.env.ACCEPT_HEADER,
+  'anthropic-beta': process.env.ANTHROPIC_BETA,
+  'anthropic-version': process.env.ANTHROPIC_VERSION,
+  authorization: 'Bearer <redacted>',
+  'content-type': 'application/json',
+  'x-request-id': process.env.REQUEST_ID
+};
+
+if (process.env.INCLUDE_IDENTITY_HEADERS === 'true') {
+  requestHeaders['anthropic-dangerous-direct-browser-access'] = 'true';
+  requestHeaders['x-app'] = process.env.X_APP;
+  requestHeaders['user-agent'] = process.env.USER_AGENT;
+}
+
+const responseBodyText = fs.readFileSync(process.env.RESPONSE_BODY_PATH, 'utf8');
+let parsedBody = null;
+let bodyPreview = null;
+try {
+  parsedBody = JSON.parse(responseBodyText);
+} catch {
+  bodyPreview = responseBodyText.slice(0, 1024);
+}
+
+const upstreamRequest = {
+  attempt_no: 1,
+  body_bytes: Number(process.env.PAYLOAD_BYTES),
+  body_sha256: process.env.PAYLOAD_SHA256,
+  headers: requestHeaders,
+  method: 'POST',
+  provider: 'anthropic',
+  request_id: process.env.REQUEST_ID,
+  target_url: process.env.TARGET_URL
+};
+
+const upstreamResponse = {
+  attempt_no: 1,
+  request_id: process.env.REQUEST_ID,
+  upstream_status: Number(process.env.DIRECT_STATUS),
+  provider_request_id: process.env.PROVIDER_REQUEST_ID,
+  content_type: process.env.RESPONSE_CONTENT_TYPE,
+  body_sha256: sha256(responseBodyText),
+  parsed_body: parsedBody,
+  body_preview: bodyPreview
+};
+
+fs.writeFileSync(process.env.UPSTREAM_REQUEST_PATH, `${JSON.stringify(upstreamRequest, null, 2)}\n`);
+fs.writeFileSync(process.env.UPSTREAM_RESPONSE_PATH, `${JSON.stringify(upstreamResponse, null, 2)}\n`);
+NODE
+
+SUMMARY_LINES=(
+  "request_id=$REQUEST_ID"
+  'provider=anthropic'
+  "target_url=$TARGET_URL"
+  "body_bytes=$PAYLOAD_BYTES"
+  "body_sha256=$PAYLOAD_SHA256"
+  "upstream_status=$DIRECT_STATUS"
+  "provider_request_id=${PROVIDER_REQUEST_ID:-}"
+  "payload_available=true"
+  "direct_access_token_source=$ACCESS_TOKEN_SOURCE"
+  "upstream_anthropic_beta=$ANTHROPIC_BETA"
+  "upstream_anthropic_version=$ANTHROPIC_VERSION"
+  "upstream_accept=$ACCEPT_HEADER"
+  "upstream_user_agent=$SUMMARY_USER_AGENT"
+  "upstream_x_app=$SUMMARY_X_APP"
+  "response_content_type=${RESPONSE_CONTENT_TYPE:-}"
+  "response_body_sha256=$RESPONSE_SHA256"
+  "payload_path=$PAYLOAD_COPY_PATH"
+  "upstream_request_path=$UPSTREAM_REQUEST_PATH"
+  "upstream_response_path=$UPSTREAM_RESPONSE_PATH"
+  "response_headers_path=$RESPONSE_HEADERS_PATH"
+  "response_body_path=$RESPONSE_BODY_PATH"
+)
+
+printf '%s\n' "${SUMMARY_LINES[@]}" >"$SUMMARY_PATH"
+cat "$SUMMARY_PATH"
+printf 'summary_file=%s\n' "$SUMMARY_PATH"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,6 +18,7 @@ ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-set.sh" "${BIN_DIR}/innies-b
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-get.sh" "${BIN_DIR}/innies-buyer-preference-get"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-check.sh" "${BIN_DIR}/innies-buyer-preference-check"
 ln -sf "${ROOT_DIR}/scripts/innies-slo-check.sh" "${BIN_DIR}/innies-slo-check"
+ln -sf "${ROOT_DIR}/scripts/innies-compat-direct-bundle-capture.sh" "${BIN_DIR}/innies-compat-direct-bundle-capture"
 
 rm -f \
   "${BIN_DIR}/innies-admin" \
@@ -49,6 +50,7 @@ echo "  ${BIN_DIR}/innies-buyer-preference-set -> ${ROOT_DIR}/scripts/innies-buy
 echo "  ${BIN_DIR}/innies-buyer-preference-get -> ${ROOT_DIR}/scripts/innies-buyer-preference-get.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-check -> ${ROOT_DIR}/scripts/innies-buyer-preference-check.sh"
 echo "  ${BIN_DIR}/innies-slo-check -> ${ROOT_DIR}/scripts/innies-slo-check.sh"
+echo "  ${BIN_DIR}/innies-compat-direct-bundle-capture -> ${ROOT_DIR}/scripts/innies-compat-direct-bundle-capture.sh"
 echo
 echo 'If command not found, add ~/.local/bin to PATH:'
 echo '  export PATH="$HOME/.local/bin:$PATH"'

--- a/scripts/tests/innies-compat-direct-bundle-capture.test.sh
+++ b/scripts/tests/innies-compat-direct-bundle-capture.test.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="$ROOT_DIR/scripts/innies-compat-direct-bundle-capture.sh"
+TMP_DIR="$(mktemp -d)"
+PAYLOAD_PATH="$TMP_DIR/payload.json"
+REQUESTS_DIR="$TMP_DIR/requests"
+OUT_DIR="$TMP_DIR/out"
+STDOUT_PATH="$TMP_DIR/stdout.txt"
+STDERR_PATH="$TMP_DIR/stderr.txt"
+OUT_DIR_NO_IDENTITY="$TMP_DIR/out-no-identity"
+STDOUT_NO_IDENTITY="$TMP_DIR/stdout-no-identity.txt"
+STDERR_NO_IDENTITY="$TMP_DIR/stderr-no-identity.txt"
+mkdir -p "$REQUESTS_DIR"
+
+cleanup() {
+  if [[ -n "${SERVER_PID:-}" ]]; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+cat >"$PAYLOAD_PATH" <<'JSON'
+{"model":"claude-opus-4-6","stream":true,"max_tokens":16,"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}
+JSON
+
+cat >"$TMP_DIR/mock-server.mjs" <<'NODE'
+import { createServer } from 'node:http';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { join } from 'node:path';
+
+const port = Number(process.env.PORT);
+const requestsDir = process.env.REQUESTS_DIR;
+mkdirSync(requestsDir, { recursive: true });
+
+function sha256(text) {
+  return createHash('sha256').update(text).digest('hex');
+}
+
+const server = createServer((req, res) => {
+  const chunks = [];
+  req.on('data', (chunk) => chunks.push(chunk));
+  req.on('end', () => {
+    const body = Buffer.concat(chunks).toString('utf8');
+    const requestId = req.headers['x-request-id'] || `unknown-${Date.now()}`;
+    writeFileSync(join(requestsDir, `${requestId}.json`), JSON.stringify({
+      method: req.method,
+      url: req.url,
+      headers: req.headers,
+      body: JSON.parse(body),
+      bodyBytes: Buffer.byteLength(body),
+      bodySha256: sha256(body)
+    }, null, 2));
+
+    const responseBody = {
+      id: `msg_${requestId}`,
+      type: 'message',
+      request_id: `req_provider_${requestId}`
+    };
+    res.statusCode = 200;
+    res.setHeader('content-type', 'application/json');
+    res.setHeader('request-id', responseBody.request_id);
+    res.end(JSON.stringify(responseBody));
+  });
+});
+
+server.listen(port, '127.0.0.1', () => {
+  process.stdout.write(`ready:${port}\n`);
+});
+NODE
+
+PORT="$(node -e "const net=require('node:net');const s=net.createServer();s.listen(0,'127.0.0.1',()=>{const {port}=s.address();console.log(port);s.close();});")"
+PORT="$PORT" REQUESTS_DIR="$REQUESTS_DIR" node "$TMP_DIR/mock-server.mjs" >"$TMP_DIR/server.log" 2>&1 &
+SERVER_PID=$!
+
+for _ in $(seq 1 50); do
+  if grep -q '^ready:' "$TMP_DIR/server.log" 2>/dev/null; then
+    break
+  fi
+  sleep 0.1
+done
+
+if ! grep -q '^ready:' "$TMP_DIR/server.log" 2>/dev/null; then
+  echo 'server did not start'
+  cat "$TMP_DIR/server.log"
+  exit 1
+fi
+
+set +e
+CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat-claude-token" \
+ANTHROPIC_DIRECT_BASE_URL="http://127.0.0.1:$PORT" \
+INNIES_DIRECT_CAPTURE_OUT_DIR="$OUT_DIR" \
+INNIES_DIRECT_REQUEST_ID="req_issue80_direct_capture" \
+"$SCRIPT_PATH" "$PAYLOAD_PATH" >"$STDOUT_PATH" 2>"$STDERR_PATH"
+STATUS=$?
+set -e
+
+if [[ "$STATUS" -ne 0 ]]; then
+  cat "$STDERR_PATH"
+  exit 1
+fi
+
+[[ -f "$OUT_DIR/payload.json" ]]
+[[ -f "$OUT_DIR/upstream-request.json" ]]
+[[ -f "$OUT_DIR/upstream-response.json" ]]
+[[ -f "$OUT_DIR/response-headers.txt" ]]
+[[ -f "$OUT_DIR/response-body.txt" ]]
+[[ -f "$OUT_DIR/summary.txt" ]]
+
+grep -q '^request_id=req_issue80_direct_capture$' "$OUT_DIR/summary.txt"
+grep -q '^provider=anthropic$' "$OUT_DIR/summary.txt"
+grep -q '^direct_access_token_source=claude_code_oauth_token$' "$OUT_DIR/summary.txt"
+grep -q '^upstream_status=200$' "$OUT_DIR/summary.txt"
+grep -q '^provider_request_id=req_provider_req_issue80_direct_capture$' "$OUT_DIR/summary.txt"
+grep -q '^upstream_user_agent=OpenClawGateway/1.0$' "$OUT_DIR/summary.txt"
+grep -q '^upstream_x_app=cli$' "$OUT_DIR/summary.txt"
+grep -q '^upstream_anthropic_beta=fine-grained-tool-streaming-2025-05-14$' "$OUT_DIR/summary.txt"
+
+grep -q '"authorization": "Bearer <redacted>"' "$OUT_DIR/upstream-request.json"
+grep -q '"request_id": "req_issue80_direct_capture"' "$OUT_DIR/upstream-request.json"
+grep -q '"request_id": "req_issue80_direct_capture"' "$OUT_DIR/upstream-response.json"
+grep -q '"upstream_status": 200' "$OUT_DIR/upstream-response.json"
+grep -q '"provider_request_id": "req_provider_req_issue80_direct_capture"' "$OUT_DIR/upstream-response.json"
+
+grep -q '"authorization": "Bearer sk-ant-oat-claude-token"' "$REQUESTS_DIR/req_issue80_direct_capture.json"
+grep -q '"anthropic-dangerous-direct-browser-access": "true"' "$REQUESTS_DIR/req_issue80_direct_capture.json"
+grep -q '"x-app": "cli"' "$REQUESTS_DIR/req_issue80_direct_capture.json"
+grep -q '"user-agent": "OpenClawGateway/1.0"' "$REQUESTS_DIR/req_issue80_direct_capture.json"
+grep -q '"anthropic-beta": "fine-grained-tool-streaming-2025-05-14"' "$REQUESTS_DIR/req_issue80_direct_capture.json"
+
+set +e
+ANTHROPIC_OAUTH_ACCESS_TOKEN="sk-ant-oat-direct-token" \
+ANTHROPIC_DIRECT_BASE_URL="http://127.0.0.1:$PORT" \
+INNIES_DIRECT_CAPTURE_OUT_DIR="$OUT_DIR_NO_IDENTITY" \
+INNIES_DIRECT_REQUEST_ID="req_issue80_direct_capture_no_identity" \
+INNIES_DIRECT_INCLUDE_IDENTITY_HEADERS="false" \
+INNIES_DIRECT_ANTHROPIC_BETA="fine-grained-tool-streaming-2025-05-14,oauth-2025-04-20" \
+"$SCRIPT_PATH" "$PAYLOAD_PATH" >"$STDOUT_NO_IDENTITY" 2>"$STDERR_NO_IDENTITY"
+STATUS=$?
+set -e
+
+if [[ "$STATUS" -ne 0 ]]; then
+  cat "$STDERR_NO_IDENTITY"
+  exit 1
+fi
+
+grep -q '^direct_access_token_source=anthropic_oauth_access_token$' "$OUT_DIR_NO_IDENTITY/summary.txt"
+grep -q '^upstream_anthropic_beta=fine-grained-tool-streaming-2025-05-14,oauth-2025-04-20$' "$OUT_DIR_NO_IDENTITY/summary.txt"
+
+if grep -q 'anthropic-dangerous-direct-browser-access' "$REQUESTS_DIR/req_issue80_direct_capture_no_identity.json"; then
+  echo 'identity-disabled capture should not send anthropic-dangerous-direct-browser-access'
+  exit 1
+fi
+
+if grep -q '"x-app"' "$REQUESTS_DIR/req_issue80_direct_capture_no_identity.json"; then
+  echo 'identity-disabled capture should not send x-app'
+  exit 1
+fi
+
+if grep -q '"user-agent"' "$REQUESTS_DIR/req_issue80_direct_capture_no_identity.json"; then
+  echo 'identity-disabled capture should not send user-agent'
+  exit 1
+fi
+
+grep -q '"anthropic-beta": "fine-grained-tool-streaming-2025-05-14,oauth-2025-04-20"' "$REQUESTS_DIR/req_issue80_direct_capture_no_identity.json"
+
+set +e
+ANTHROPIC_OAUTH_ACCESS_TOKEN="sk-ant-oat-direct-token" \
+ANTHROPIC_DIRECT_BASE_URL="http://127.0.0.1:$PORT" \
+INNIES_DIRECT_REQUEST_ID="req_issue80_direct_capture_guard" \
+INNIES_DIRECT_EXPECTED_BODY_BYTES="999" \
+"$SCRIPT_PATH" "$PAYLOAD_PATH" >"$TMP_DIR/stdout-guard.txt" 2>"$TMP_DIR/stderr-guard.txt"
+STATUS=$?
+set -e
+
+if [[ "$STATUS" -eq 0 ]]; then
+  echo 'expected byte guard run to fail'
+  exit 1
+fi
+
+grep -q 'error: payload bytes (' "$TMP_DIR/stderr-guard.txt"


### PR DESCRIPTION
## Summary
- add `scripts/innies-compat-direct-bundle-capture.sh` to capture one direct Anthropic `/v1/messages` first-pass bundle for issue #80, including `payload.json`, `upstream-request.json`, `upstream-response.json`, raw response artifacts, and `summary.txt`
- redact the saved Authorization header while preserving the live bearer on the actual request, default to the OpenClaw-style identity lane, and add optional expected body byte/sha guards so exact-replay runs fail fast on drifted payload files
- wire the helper into `scripts/install.sh` and `scripts/README.md` and cover the happy path, identity-disabled lane, token-source fallback, and body-byte guard with a focused shell regression

## Test Plan
- `bash scripts/tests/innies-compat-direct-bundle-capture.test.sh`
- `bash -n scripts/innies-compat-direct-bundle-capture.sh scripts/tests/innies-compat-direct-bundle-capture.test.sh scripts/install.sh`
- `git diff --check origin/main...HEAD`

## Notes
- mock-backed smoke against the real issue-80 extracted payload path showed the new expected-body guard stops a drifted payload file before any network call: `/private/tmp/issue80-artifact-extract-safe/payload.json` currently computes `454165` bytes here vs the artifact summary's recorded `398262`-byte first-pass body
- this workstation still does not have a live direct Anthropic bearer exported, so I did not record a real upstream capture from this branch; verification is focused shell coverage plus mock-backed smoke only

Refs #80
