### PR TITLE
chore: add issue 80 direct header TSV helper

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -25,6 +25,7 @@ innies-buyer-preference-set
 innies-buyer-preference-get
 innies-buyer-preference-check
 innies-slo-check
+innies-compat-direct-header-tsv
 ```
 
 What they do:
@@ -40,6 +41,7 @@ What they do:
 - `innies-buyer-preference-get`: read the current buyer key preference
 - `innies-buyer-preference-check`: run the provider-preference canary after prompting for the expected provider (`Claude Code` or `Codex`)
 - `innies-slo-check`: query analytics endpoints and report Phase 1 SLO pass/fail (TTFB p95, timeout rate, success rate, fallback rate); optional arg sets the window (default `24h`); exits 0 if all SLOs pass, 1 if any fail
+- `innies-compat-direct-header-tsv`: turn a known-good direct Anthropic request JSON or bundle directory into a reusable `direct-headers.tsv` for exact first-pass replay tooling
 
 Behavior:
 - org id auto-uses `INNIES_ORG_ID`
@@ -79,6 +81,7 @@ Behavior:
 - non-pinned buyer traffic always gets automatic cross-provider fallback to the other provider; flipping preference flips fallback order too
 - `innies-buyer-preference-set` prints the effective preferred provider plus the automatic fallback provider before sending the update
 - `innies-buyer-preference-check` now expects and validates the two-provider plan in DB evidence mode
+- `innies-compat-direct-header-tsv` accepts either a request JSON file or a bundle directory containing `direct-request.json`, filters out non-replayable headers like `authorization`, `content-length`, `host`, and HTTP/2 pseudo-headers, then writes `direct-headers.tsv` plus a small summary file next to it by default
 
 ## Env
 

--- a/scripts/innies-compat-direct-header-tsv.sh
+++ b/scripts/innies-compat-direct-header-tsv.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_PATH" ]]; do
+  SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+  SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"
+  [[ "$SCRIPT_PATH" != /* ]] && SCRIPT_PATH="${SCRIPT_DIR}/${SCRIPT_PATH}"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+source "${SCRIPT_DIR}/_common.sh"
+
+resolve_source_file() {
+  local source="$1"
+
+  if [[ -f "$source" ]]; then
+    printf '%s' "$source"
+    return
+  fi
+
+  if [[ -d "$source" ]]; then
+    local candidate
+    for candidate in direct-request.json upstream-request.json request.json; do
+      if [[ -f "$source/$candidate" ]]; then
+        printf '%s' "$source/$candidate"
+        return
+      fi
+    done
+    echo "error: no direct request JSON found in bundle directory: $source" >&2
+    exit 1
+  fi
+
+  echo "error: source path not found: $source" >&2
+  exit 1
+}
+
+default_out_file() {
+  local source_arg="$1"
+  local source_file="$2"
+
+  if [[ -d "$source_arg" ]]; then
+    printf '%s/direct-headers.tsv' "$source_arg"
+    return
+  fi
+
+  local dir base
+  dir="$(cd "$(dirname "$source_file")" && pwd)"
+  base="$(basename "$source_file")"
+  base="${base%.json}"
+  printf '%s/%s.tsv' "$dir" "$base"
+}
+
+SOURCE_PATH="${1:-${INNIES_DIRECT_HEADER_TSV_SOURCE:-}}"
+OUT_PATH="${2:-${INNIES_DIRECT_HEADER_TSV_OUT:-}}"
+require_nonempty 'source path' "$SOURCE_PATH"
+
+SOURCE_FILE="$(resolve_source_file "$SOURCE_PATH")"
+if [[ -z "$OUT_PATH" ]]; then
+  OUT_PATH="$(default_out_file "$SOURCE_PATH" "$SOURCE_FILE")"
+fi
+
+OUT_DIR="$(dirname "$OUT_PATH")"
+mkdir -p "$OUT_DIR"
+OUT_DIR="$(cd "$OUT_DIR" && pwd)"
+OUT_PATH="${OUT_DIR}/$(basename "$OUT_PATH")"
+
+SUMMARY_PATH="${INNIES_DIRECT_HEADER_SUMMARY_OUT:-}"
+if [[ -z "$SUMMARY_PATH" ]]; then
+  SUMMARY_PATH="$OUT_PATH"
+  if [[ "$SUMMARY_PATH" == *.tsv ]]; then
+    SUMMARY_PATH="${SUMMARY_PATH%.tsv}.summary.txt"
+  else
+    SUMMARY_PATH="${SUMMARY_PATH}.summary.txt"
+  fi
+fi
+
+node - "$SOURCE_FILE" "$OUT_PATH" "$SUMMARY_PATH" <<'NODE'
+const fs = require('fs');
+
+const [sourceFile, outPath, summaryPath] = process.argv.slice(2);
+const skippedHeaderNames = new Set(['authorization', 'content-length', 'host']);
+
+function fail(message) {
+  console.error(`error: ${message}`);
+  process.exit(1);
+}
+
+let record;
+try {
+  record = JSON.parse(fs.readFileSync(sourceFile, 'utf8'));
+} catch (error) {
+  fail(`could not parse JSON file ${sourceFile}: ${error.message}`);
+}
+
+if (!record || typeof record !== 'object' || Array.isArray(record)) {
+  fail(`expected request JSON object in ${sourceFile}`);
+}
+
+const headers = record.headers;
+if (!headers || typeof headers !== 'object' || Array.isArray(headers)) {
+  fail(`missing headers object in ${sourceFile}`);
+}
+
+const writtenLines = [];
+const skipped = [];
+for (const [rawName, rawValue] of Object.entries(headers)) {
+  const name = String(rawName ?? '').trim().toLowerCase();
+  if (!name) continue;
+  if (name.startsWith(':') || skippedHeaderNames.has(name)) {
+    skipped.push(name);
+    continue;
+  }
+
+  let value = rawValue;
+  if (value === null || value === undefined) {
+    value = '';
+  } else if (Array.isArray(value)) {
+    value = value.join(', ');
+  } else if (typeof value === 'object') {
+    value = JSON.stringify(value);
+  } else if (typeof value !== 'string') {
+    value = String(value);
+  }
+
+  writtenLines.push(`${name}\t${value}`);
+}
+
+if (writtenLines.length === 0) {
+  fail(`no reusable headers remained after filtering ${sourceFile}`);
+}
+
+fs.writeFileSync(outPath, `${writtenLines.join('\n')}\n`);
+
+const summaryLines = [
+  `source_file=${sourceFile}`,
+  `request_id=${record.request_id ?? ''}`,
+  `target_url=${record.target_url ?? ''}`,
+  `body_bytes=${record.body_bytes ?? ''}`,
+  `body_sha256=${record.body_sha256 ?? ''}`,
+  `headers_written=${writtenLines.length}`,
+  `skipped_headers=${skipped.sort().join(',')}`,
+  `out_file=${outPath}`
+];
+
+fs.writeFileSync(summaryPath, `${summaryLines.join('\n')}\n`);
+NODE
+
+cat "$SUMMARY_PATH"
+printf 'summary_file=%s\n' "$SUMMARY_PATH"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,6 +18,7 @@ ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-set.sh" "${BIN_DIR}/innies-b
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-get.sh" "${BIN_DIR}/innies-buyer-preference-get"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-check.sh" "${BIN_DIR}/innies-buyer-preference-check"
 ln -sf "${ROOT_DIR}/scripts/innies-slo-check.sh" "${BIN_DIR}/innies-slo-check"
+ln -sf "${ROOT_DIR}/scripts/innies-compat-direct-header-tsv.sh" "${BIN_DIR}/innies-compat-direct-header-tsv"
 
 rm -f \
   "${BIN_DIR}/innies-admin" \
@@ -49,6 +50,7 @@ echo "  ${BIN_DIR}/innies-buyer-preference-set -> ${ROOT_DIR}/scripts/innies-buy
 echo "  ${BIN_DIR}/innies-buyer-preference-get -> ${ROOT_DIR}/scripts/innies-buyer-preference-get.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-check -> ${ROOT_DIR}/scripts/innies-buyer-preference-check.sh"
 echo "  ${BIN_DIR}/innies-slo-check -> ${ROOT_DIR}/scripts/innies-slo-check.sh"
+echo "  ${BIN_DIR}/innies-compat-direct-header-tsv -> ${ROOT_DIR}/scripts/innies-compat-direct-header-tsv.sh"
 echo
 echo 'If command not found, add ~/.local/bin to PATH:'
 echo '  export PATH="$HOME/.local/bin:$PATH"'

--- a/scripts/tests/innies-compat-direct-header-tsv.test.sh
+++ b/scripts/tests/innies-compat-direct-header-tsv.test.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="$ROOT_DIR/scripts/innies-compat-direct-header-tsv.sh"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+BUNDLE_DIR="$TMP_DIR/direct-bundle"
+mkdir -p "$BUNDLE_DIR"
+
+cat >"$BUNDLE_DIR/direct-request.json" <<'JSON'
+{
+  "request_id": "req_direct_good",
+  "body_bytes": 393038,
+  "body_sha256": "fe256e82a18beecd90f4b5d7d3ae788b42ff6b2cd2693b12d695fc415f1fc853",
+  "target_url": "https://api.anthropic.com/v1/messages",
+  "headers": {
+    "accept": "text/event-stream",
+    "anthropic-beta": "fine-grained-tool-streaming-2025-05-14",
+    "anthropic-version": "2023-06-01",
+    "authorization": "Bearer <redacted>",
+    "content-type": "application/json",
+    "content-length": "393038",
+    "host": "api.anthropic.com",
+    "x-request-id": "req_direct_good",
+    "user-agent": "OpenClawGateway/1.0",
+    "x-app": "cli",
+    "anthropic-dangerous-direct-browser-access": "true",
+    ":authority": "api.anthropic.com"
+  }
+}
+JSON
+
+cat >"$BUNDLE_DIR/upstream-request.json" <<'JSON'
+{
+  "request_id": "req_wrong_source",
+  "headers": {
+    "accept": "text/plain",
+    "x-request-id": "req_wrong_source",
+    "user-agent": "wrong-source"
+  }
+}
+JSON
+
+STDOUT_PATH="$TMP_DIR/stdout.txt"
+STDERR_PATH="$TMP_DIR/stderr.txt"
+
+set +e
+"$SCRIPT_PATH" "$BUNDLE_DIR" >"$STDOUT_PATH" 2>"$STDERR_PATH"
+STATUS=$?
+set -e
+
+if [[ "$STATUS" -ne 0 ]]; then
+  cat "$STDERR_PATH" >&2
+  exit 1
+fi
+
+DEFAULT_TSV="$BUNDLE_DIR/direct-headers.tsv"
+DEFAULT_SUMMARY="$BUNDLE_DIR/direct-headers.summary.txt"
+[[ -f "$DEFAULT_TSV" ]]
+[[ -f "$DEFAULT_SUMMARY" ]]
+
+cat >"$TMP_DIR/expected-default.tsv" <<'TSV'
+accept	text/event-stream
+anthropic-beta	fine-grained-tool-streaming-2025-05-14
+anthropic-version	2023-06-01
+content-type	application/json
+x-request-id	req_direct_good
+user-agent	OpenClawGateway/1.0
+x-app	cli
+anthropic-dangerous-direct-browser-access	true
+TSV
+
+diff -u "$TMP_DIR/expected-default.tsv" "$DEFAULT_TSV"
+grep -q '^request_id=req_direct_good$' "$DEFAULT_SUMMARY"
+grep -q '^body_bytes=393038$' "$DEFAULT_SUMMARY"
+grep -q '^body_sha256=fe256e82a18beecd90f4b5d7d3ae788b42ff6b2cd2693b12d695fc415f1fc853$' "$DEFAULT_SUMMARY"
+grep -q '^source_file=.*direct-request.json$' "$DEFAULT_SUMMARY"
+grep -q '^headers_written=8$' "$DEFAULT_SUMMARY"
+grep -q '^skipped_headers=:authority,authorization,content-length,host$' "$DEFAULT_SUMMARY"
+grep -q '^out_file=.*direct-headers.tsv$' "$DEFAULT_SUMMARY"
+grep -q '^summary_file=.*direct-headers.summary.txt$' "$STDOUT_PATH"
+
+SINGLE_FILE="$TMP_DIR/known-good-direct.json"
+CUSTOM_TSV="$TMP_DIR/nested/known-good-direct.tsv"
+CUSTOM_SUMMARY="$TMP_DIR/nested/known-good-direct.summary.txt"
+
+cat >"$SINGLE_FILE" <<'JSON'
+{
+  "request_id": "req_known_good_single",
+  "body_bytes": 128,
+  "body_sha256": "0d84f0df2f7bc42fca815f16d0f5a44f8a48b0afcefb2b3b31df0f8bc3cb60eb",
+  "target_url": "https://api.anthropic.com/v1/messages",
+  "headers": {
+    "accept": "application/json",
+    "anthropic-version": "2023-06-01",
+    "authorization": "Bearer should-be-removed",
+    "x-request-id": "req_known_good_single"
+  }
+}
+JSON
+
+set +e
+"$SCRIPT_PATH" "$SINGLE_FILE" "$CUSTOM_TSV" >"$STDOUT_PATH" 2>"$STDERR_PATH"
+STATUS=$?
+set -e
+
+if [[ "$STATUS" -ne 0 ]]; then
+  cat "$STDERR_PATH" >&2
+  exit 1
+fi
+
+[[ -f "$CUSTOM_TSV" ]]
+[[ -f "$CUSTOM_SUMMARY" ]]
+cat >"$TMP_DIR/expected-custom.tsv" <<'TSV'
+accept	application/json
+anthropic-version	2023-06-01
+x-request-id	req_known_good_single
+TSV
+
+diff -u "$TMP_DIR/expected-custom.tsv" "$CUSTOM_TSV"
+grep -q '^request_id=req_known_good_single$' "$CUSTOM_SUMMARY"
+grep -q '^headers_written=3$' "$CUSTOM_SUMMARY"
+grep -q '^skipped_headers=authorization$' "$CUSTOM_SUMMARY"
+
+INVALID_JSON="$TMP_DIR/invalid.json"
+cat >"$INVALID_JSON" <<'JSON'
+{"request_id":"req_missing_headers"}
+JSON
+
+set +e
+"$SCRIPT_PATH" "$INVALID_JSON" >"$STDOUT_PATH" 2>"$STDERR_PATH"
+STATUS=$?
+set -e
+
+if [[ "$STATUS" -eq 0 ]]; then
+  echo 'expected missing-headers invocation to fail' >&2
+  exit 1
+fi
+
+grep -q 'missing headers object' "$STDERR_PATH"


### PR DESCRIPTION
Refs #80

## Summary
- add `scripts/innies-compat-direct-header-tsv.sh` to turn a known-good direct Anthropic request JSON or bundle directory into a reusable `direct-headers.tsv`
- filter non-replayable headers (`authorization`, `content-length`, `host`, and HTTP/2 pseudo-headers) and emit a small summary alongside the TSV
- wire the helper into `scripts/install.sh`, document it in `scripts/README.md`, and add focused shell coverage

## Why
The current issue-80 evidence path needs an exact direct/OpenClaw first-pass header lane that can be replayed or diffed against the failing Innies first pass. This PR adds the missing standalone conversion step from a captured direct request bundle to the reusable TSV input expected by the direct replay tooling.

## Verification
- `bash scripts/tests/innies-compat-direct-header-tsv.test.sh`
- `bash -n scripts/innies-compat-direct-header-tsv.sh scripts/tests/innies-compat-direct-header-tsv.test.sh scripts/install.sh`
- `git diff --check`