### PR TITLE
chore: add issue 80 exact header case generator

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -25,6 +25,7 @@ innies-buyer-preference-set
 innies-buyer-preference-get
 innies-buyer-preference-check
 innies-slo-check
+innies-compat-exact-header-cases
 ```
 
 What they do:
@@ -40,6 +41,7 @@ What they do:
 - `innies-buyer-preference-get`: read the current buyer key preference
 - `innies-buyer-preference-check`: run the provider-preference canary after prompting for the expected provider (`Claude Code` or `Codex`)
 - `innies-slo-check`: query analytics endpoints and report Phase 1 SLO pass/fail (TTFB p95, timeout rate, success rate, fallback rate); optional arg sets the window (default `24h`); exits 0 if all SLOs pass, 1 if any fail
+- `innies-compat-exact-header-cases`: derive replay-ready TSV case files from a failing compat first pass plus a known-good direct first pass so issue-80 replays can use exact observed deltas instead of hand-built matrices
 
 Behavior:
 - org id auto-uses `INNIES_ORG_ID`

--- a/scripts/innies-compat-exact-header-cases.mjs
+++ b/scripts/innies-compat-exact-header-cases.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const [compatFile, directFile, outDir] = process.argv.slice(2);
+
+const IGNORED_HEADERS = new Set(['authorization', 'content-length', 'host']);
+const REQUEST_SCOPED_HEADERS = new Set(['x-request-id']);
+const IDENTITY_HEADERS = new Set([
+  'anthropic-dangerous-direct-browser-access',
+  'user-agent',
+  'x-app'
+]);
+
+function fail(message) {
+  console.error(`error: ${message}`);
+  process.exit(1);
+}
+
+function readRecord(filePath) {
+  let value;
+  try {
+    value = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (error) {
+    fail(`could not parse JSON file ${filePath}: ${error.message}`);
+  }
+
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    fail(`expected request JSON object in ${filePath}`);
+  }
+
+  const headers = value.headers;
+  if (!headers || typeof headers !== 'object' || Array.isArray(headers)) {
+    fail(`missing headers object in ${filePath}`);
+  }
+
+  return value;
+}
+
+function normalizeHeaders(headers) {
+  const normalized = new Map();
+
+  for (const [rawName, rawValue] of Object.entries(headers)) {
+    const name = String(rawName ?? '').trim().toLowerCase();
+    if (!name || IGNORED_HEADERS.has(name)) continue;
+
+    let value = rawValue;
+    if (value === null || value === undefined) {
+      value = '';
+    } else if (typeof value !== 'string') {
+      value = String(value);
+    }
+
+    normalized.set(name, value);
+  }
+
+  return normalized;
+}
+
+function writeTsv(filePath, headersMap) {
+  const lines = Array.from(headersMap.entries())
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([name, value]) => `${name}\t${value}`);
+
+  fs.writeFileSync(filePath, `${lines.join('\n')}\n`);
+}
+
+function csv(values) {
+  return values.length === 0 ? '' : values.slice().sort().join(',');
+}
+
+function matchFlag(left, right) {
+  if (left === undefined || left === null || left === '' || right === undefined || right === null || right === '') {
+    return 'unknown';
+  }
+
+  return String(left) === String(right) ? 'true' : 'false';
+}
+
+function addHeaders(baseMap, sourceMap, headerNames) {
+  const merged = new Map(baseMap);
+  for (const name of headerNames) {
+    if (sourceMap.has(name)) {
+      merged.set(name, sourceMap.get(name));
+    }
+  }
+  return merged;
+}
+
+function uniq(values) {
+  return Array.from(new Set(values));
+}
+
+const compatRecord = readRecord(compatFile);
+const directRecord = readRecord(directFile);
+
+const compatHeaders = normalizeHeaders(compatRecord.headers);
+const directHeaders = normalizeHeaders(directRecord.headers);
+
+const bodyShaMatch = matchFlag(compatRecord.body_sha256, directRecord.body_sha256);
+const bodyBytesMatch = matchFlag(compatRecord.body_bytes, directRecord.body_bytes);
+
+if (
+  process.env.INNIES_ALLOW_BODY_MISMATCH !== 'true' &&
+  (bodyShaMatch === 'false' || bodyBytesMatch === 'false')
+) {
+  fail(
+    [
+      'body-held-constant mismatch',
+      `compat_body_sha256=${compatRecord.body_sha256 ?? ''}`,
+      `direct_body_sha256=${directRecord.body_sha256 ?? ''}`,
+      `compat_body_bytes=${compatRecord.body_bytes ?? ''}`,
+      `direct_body_bytes=${directRecord.body_bytes ?? ''}`
+    ].join(' ')
+  );
+}
+
+const sharedHeaders = new Map();
+const functionalValueMismatches = [];
+const compatOnlyHeaders = [];
+const directOnlyHeaders = [];
+const identityDirectOnlyHeaders = [];
+const requestScopedValueMismatches = [];
+const requestScopedCompatOnlyHeaders = [];
+const requestScopedDirectOnlyHeaders = [];
+
+const allHeaderNames = uniq([
+  ...compatHeaders.keys(),
+  ...directHeaders.keys()
+]).sort();
+
+for (const name of allHeaderNames) {
+  const compatValue = compatHeaders.get(name);
+  const directValue = directHeaders.get(name);
+  const hasCompat = compatHeaders.has(name);
+  const hasDirect = directHeaders.has(name);
+  const isRequestScoped = REQUEST_SCOPED_HEADERS.has(name);
+
+  if (hasCompat && hasDirect) {
+    if (compatValue === directValue) {
+      sharedHeaders.set(name, compatValue);
+      continue;
+    }
+
+    if (isRequestScoped) {
+      requestScopedValueMismatches.push(name);
+    } else {
+      functionalValueMismatches.push(name);
+    }
+    continue;
+  }
+
+  if (hasCompat) {
+    if (isRequestScoped) {
+      requestScopedCompatOnlyHeaders.push(name);
+    } else {
+      compatOnlyHeaders.push(name);
+    }
+    continue;
+  }
+
+  if (isRequestScoped) {
+    requestScopedDirectOnlyHeaders.push(name);
+  } else if (IDENTITY_HEADERS.has(name)) {
+    identityDirectOnlyHeaders.push(name);
+  } else {
+    directOnlyHeaders.push(name);
+  }
+}
+
+const betaHeaders = [];
+if (
+  directHeaders.has('anthropic-beta') &&
+  compatHeaders.get('anthropic-beta') !== directHeaders.get('anthropic-beta')
+) {
+  betaHeaders.push('anthropic-beta');
+}
+
+const identityDeltaHeaders = uniq(
+  Array.from(IDENTITY_HEADERS).filter(
+    (name) => directHeaders.has(name) && compatHeaders.get(name) !== directHeaders.get(name)
+  )
+);
+
+const replayableDirectDeltaHeaders = uniq([
+  ...functionalValueMismatches.filter((name) => !REQUEST_SCOPED_HEADERS.has(name)),
+  ...directOnlyHeaders,
+  ...identityDirectOnlyHeaders
+]).sort();
+
+const casesDir = path.join(outDir, 'cases');
+fs.mkdirSync(casesDir, { recursive: true });
+
+const caseFiles = [
+  ['compat-exact.tsv', compatHeaders],
+  ['direct-exact.tsv', directHeaders],
+  ['shared.tsv', sharedHeaders],
+  ['compat-with-direct-beta.tsv', addHeaders(compatHeaders, directHeaders, betaHeaders)],
+  ['compat-with-direct-identity.tsv', addHeaders(compatHeaders, directHeaders, identityDeltaHeaders)],
+  [
+    'compat-with-direct-beta-and-identity.tsv',
+    addHeaders(compatHeaders, directHeaders, uniq([...betaHeaders, ...identityDeltaHeaders]))
+  ],
+  ['compat-with-all-direct-deltas.tsv', addHeaders(compatHeaders, directHeaders, replayableDirectDeltaHeaders)]
+];
+
+for (const [fileName, headersMap] of caseFiles) {
+  writeTsv(path.join(casesDir, fileName), headersMap);
+}
+
+const summaryLines = [
+  `compat_source_file=${compatFile}`,
+  `direct_source_file=${directFile}`,
+  `compat_request_id=${compatRecord.request_id ?? ''}`,
+  `direct_request_id=${directRecord.request_id ?? ''}`,
+  `compat_body_bytes=${compatRecord.body_bytes ?? ''}`,
+  `direct_body_bytes=${directRecord.body_bytes ?? ''}`,
+  `compat_body_sha256=${compatRecord.body_sha256 ?? ''}`,
+  `direct_body_sha256=${directRecord.body_sha256 ?? ''}`,
+  `body_bytes_match=${bodyBytesMatch}`,
+  `body_sha256_match=${bodyShaMatch}`,
+  `compat_header_count=${compatHeaders.size}`,
+  `direct_header_count=${directHeaders.size}`,
+  `shared_header_count=${sharedHeaders.size}`,
+  `functional_value_mismatches=${csv(functionalValueMismatches)}`,
+  `compat_only_headers=${csv(compatOnlyHeaders)}`,
+  `direct_only_headers=${csv(directOnlyHeaders)}`,
+  `identity_direct_only_headers=${csv(identityDirectOnlyHeaders)}`,
+  `request_scoped_value_mismatches=${csv(requestScopedValueMismatches)}`,
+  `request_scoped_compat_only_headers=${csv(requestScopedCompatOnlyHeaders)}`,
+  `request_scoped_direct_only_headers=${csv(requestScopedDirectOnlyHeaders)}`,
+  `all_replayable_direct_delta_headers=${csv(replayableDirectDeltaHeaders)}`,
+  `cases_dir=${casesDir}`,
+  `case_files=${caseFiles.map(([fileName]) => fileName).join(',')}`
+];
+
+fs.writeFileSync(path.join(outDir, 'summary.txt'), `${summaryLines.join('\n')}\n`);

--- a/scripts/innies-compat-exact-header-cases.sh
+++ b/scripts/innies-compat-exact-header-cases.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_PATH" ]]; do
+  SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+  SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"
+  [[ "$SCRIPT_PATH" != /* ]] && SCRIPT_PATH="${SCRIPT_DIR}/${SCRIPT_PATH}"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+source "${SCRIPT_DIR}/_common.sh"
+
+resolve_source_file() {
+  local source="$1"
+  local mode="$2"
+
+  if [[ -f "$source" ]]; then
+    printf '%s' "$source"
+    return
+  fi
+
+  if [[ -d "$source" ]]; then
+    local candidate
+    case "$mode" in
+      compat)
+        for candidate in upstream-request.json request.json direct-request.json; do
+          if [[ -f "$source/$candidate" ]]; then
+            printf '%s' "$source/$candidate"
+            return
+          fi
+        done
+        ;;
+      direct)
+        for candidate in direct-request.json upstream-request.json request.json; do
+          if [[ -f "$source/$candidate" ]]; then
+            printf '%s' "$source/$candidate"
+            return
+          fi
+        done
+        ;;
+      *)
+        echo "error: unsupported source mode: $mode" >&2
+        exit 1
+        ;;
+    esac
+
+    echo "error: no request JSON found in bundle directory: $source" >&2
+    exit 1
+  fi
+
+  echo "error: source path not found: $source" >&2
+  exit 1
+}
+
+COMPAT_SOURCE="${1:-${INNIES_COMPAT_HEADER_CASE_SOURCE:-}}"
+DIRECT_SOURCE="${2:-${INNIES_DIRECT_HEADER_CASE_SOURCE:-}}"
+OUT_DIR="${3:-${INNIES_EXACT_HEADER_CASES_OUT_DIR:-${TMPDIR:-/tmp}/innies-compat-exact-header-cases-$(date -u +%Y%m%dT%H%M%SZ)}}"
+
+require_nonempty 'compat source path' "$COMPAT_SOURCE"
+require_nonempty 'direct source path' "$DIRECT_SOURCE"
+
+COMPAT_FILE="$(resolve_source_file "$COMPAT_SOURCE" compat)"
+DIRECT_FILE="$(resolve_source_file "$DIRECT_SOURCE" direct)"
+mkdir -p "$OUT_DIR"
+
+node "${SCRIPT_DIR}/innies-compat-exact-header-cases.mjs" "$COMPAT_FILE" "$DIRECT_FILE" "$OUT_DIR"
+
+SUMMARY_FILE="$OUT_DIR/summary.txt"
+cat "$SUMMARY_FILE"
+printf 'summary_file=%s\n' "$SUMMARY_FILE"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,6 +18,7 @@ ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-set.sh" "${BIN_DIR}/innies-b
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-get.sh" "${BIN_DIR}/innies-buyer-preference-get"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-check.sh" "${BIN_DIR}/innies-buyer-preference-check"
 ln -sf "${ROOT_DIR}/scripts/innies-slo-check.sh" "${BIN_DIR}/innies-slo-check"
+ln -sf "${ROOT_DIR}/scripts/innies-compat-exact-header-cases.sh" "${BIN_DIR}/innies-compat-exact-header-cases"
 
 rm -f \
   "${BIN_DIR}/innies-admin" \
@@ -49,6 +50,7 @@ echo "  ${BIN_DIR}/innies-buyer-preference-set -> ${ROOT_DIR}/scripts/innies-buy
 echo "  ${BIN_DIR}/innies-buyer-preference-get -> ${ROOT_DIR}/scripts/innies-buyer-preference-get.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-check -> ${ROOT_DIR}/scripts/innies-buyer-preference-check.sh"
 echo "  ${BIN_DIR}/innies-slo-check -> ${ROOT_DIR}/scripts/innies-slo-check.sh"
+echo "  ${BIN_DIR}/innies-compat-exact-header-cases -> ${ROOT_DIR}/scripts/innies-compat-exact-header-cases.sh"
 echo
 echo 'If command not found, add ~/.local/bin to PATH:'
 echo '  export PATH="$HOME/.local/bin:$PATH"'

--- a/scripts/tests/innies-compat-exact-header-cases.test.sh
+++ b/scripts/tests/innies-compat-exact-header-cases.test.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEST_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${TEST_SCRIPT_DIR}/../.." && pwd)"
+SCRIPT_PATH="${ROOT_DIR}/scripts/innies-compat-exact-header-cases.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_file_exists() {
+  local path="$1"
+  [[ -f "$path" ]] || fail "expected file to exist: $path"
+}
+
+assert_file_contains() {
+  local path="$1"
+  local pattern="$2"
+  if ! grep -Fq "$pattern" "$path"; then
+    echo "Expected pattern not found in $path: $pattern" >&2
+    echo "--- file contents ---" >&2
+    cat "$path" >&2
+    echo "---------------------" >&2
+    exit 1
+  fi
+}
+
+assert_file_not_contains() {
+  local path="$1"
+  local pattern="$2"
+  if grep -Fq "$pattern" "$path"; then
+    echo "Unexpected pattern found in $path: $pattern" >&2
+    echo "--- file contents ---" >&2
+    cat "$path" >&2
+    echo "---------------------" >&2
+    exit 1
+  fi
+}
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+COMPAT_BUNDLE="$TMP_DIR/compat-bundle"
+DIRECT_BUNDLE="$TMP_DIR/direct-bundle"
+mkdir -p "$COMPAT_BUNDLE" "$DIRECT_BUNDLE"
+
+cat >"$COMPAT_BUNDLE/upstream-request.json" <<'JSON'
+{
+  "request_id": "req_issue80_compat",
+  "target_url": "https://api.anthropic.com/v1/messages",
+  "body_bytes": 398262,
+  "body_sha256": "1717a039bed013d162eb47daead7f7eea440bccc6fb2719b9233142976e9a093",
+  "headers": {
+    "accept": "text/event-stream",
+    "anthropic-beta": "fine-grained-tool-streaming-2025-05-14,claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14",
+    "anthropic-version": "2023-06-01",
+    "content-type": "application/json",
+    "x-request-id": "req_issue80_compat"
+  }
+}
+JSON
+
+cat >"$DIRECT_BUNDLE/direct-request.json" <<'JSON'
+{
+  "request_id": "req_issue80_direct",
+  "target_url": "https://api.anthropic.com/v1/messages",
+  "body_bytes": 398262,
+  "body_sha256": "1717a039bed013d162eb47daead7f7eea440bccc6fb2719b9233142976e9a093",
+  "headers": {
+    "accept": "text/event-stream",
+    "anthropic-beta": "fine-grained-tool-streaming-2025-05-14",
+    "anthropic-dangerous-direct-browser-access": "true",
+    "anthropic-version": "2023-06-01",
+    "authorization": "Bearer secret-token",
+    "content-type": "application/json",
+    "user-agent": "OpenClawGateway/1.0",
+    "x-app": "cli",
+    "x-request-id": "req_issue80_direct"
+  }
+}
+JSON
+
+OUT_DIR="$TMP_DIR/out"
+"$SCRIPT_PATH" "$COMPAT_BUNDLE" "$DIRECT_BUNDLE" "$OUT_DIR" >"$TMP_DIR/stdout.txt" 2>"$TMP_DIR/stderr.txt"
+
+assert_file_exists "$OUT_DIR/summary.txt"
+assert_file_exists "$OUT_DIR/cases/compat-exact.tsv"
+assert_file_exists "$OUT_DIR/cases/direct-exact.tsv"
+assert_file_exists "$OUT_DIR/cases/shared.tsv"
+assert_file_exists "$OUT_DIR/cases/compat-with-direct-beta.tsv"
+assert_file_exists "$OUT_DIR/cases/compat-with-direct-identity.tsv"
+assert_file_exists "$OUT_DIR/cases/compat-with-direct-beta-and-identity.tsv"
+assert_file_exists "$OUT_DIR/cases/compat-with-all-direct-deltas.tsv"
+
+assert_file_contains "$OUT_DIR/cases/compat-exact.tsv" $'anthropic-beta\tfine-grained-tool-streaming-2025-05-14,claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14'
+assert_file_contains "$OUT_DIR/cases/direct-exact.tsv" $'anthropic-dangerous-direct-browser-access\ttrue'
+assert_file_contains "$OUT_DIR/cases/direct-exact.tsv" $'user-agent\tOpenClawGateway/1.0'
+assert_file_contains "$OUT_DIR/cases/shared.tsv" $'anthropic-version\t2023-06-01'
+assert_file_contains "$OUT_DIR/cases/compat-with-direct-beta.tsv" $'anthropic-beta\tfine-grained-tool-streaming-2025-05-14'
+assert_file_contains "$OUT_DIR/cases/compat-with-direct-identity.tsv" $'anthropic-dangerous-direct-browser-access\ttrue'
+assert_file_contains "$OUT_DIR/cases/compat-with-direct-identity.tsv" $'x-app\tcli'
+assert_file_not_contains "$OUT_DIR/cases/compat-with-direct-identity.tsv" 'authorization'
+assert_file_contains "$OUT_DIR/cases/compat-with-direct-beta-and-identity.tsv" $'anthropic-beta\tfine-grained-tool-streaming-2025-05-14'
+assert_file_contains "$OUT_DIR/cases/compat-with-direct-beta-and-identity.tsv" $'user-agent\tOpenClawGateway/1.0'
+assert_file_contains "$OUT_DIR/cases/compat-with-all-direct-deltas.tsv" $'anthropic-beta\tfine-grained-tool-streaming-2025-05-14'
+assert_file_contains "$OUT_DIR/cases/compat-with-all-direct-deltas.tsv" $'x-app\tcli'
+
+assert_file_contains "$OUT_DIR/summary.txt" 'body_sha256_match=true'
+assert_file_contains "$OUT_DIR/summary.txt" 'body_bytes_match=true'
+assert_file_contains "$OUT_DIR/summary.txt" 'functional_value_mismatches=anthropic-beta'
+assert_file_contains "$OUT_DIR/summary.txt" 'identity_direct_only_headers=anthropic-dangerous-direct-browser-access,user-agent,x-app'
+assert_file_contains "$OUT_DIR/summary.txt" 'request_scoped_value_mismatches=x-request-id'
+
+MISMATCH_BUNDLE="$TMP_DIR/direct-body-mismatch"
+mkdir -p "$MISMATCH_BUNDLE"
+
+cat >"$MISMATCH_BUNDLE/direct-request.json" <<'JSON'
+{
+  "request_id": "req_issue80_direct_mismatch",
+  "target_url": "https://api.anthropic.com/v1/messages",
+  "body_bytes": 398263,
+  "body_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "headers": {
+    "accept": "text/event-stream",
+    "anthropic-beta": "fine-grained-tool-streaming-2025-05-14",
+    "anthropic-version": "2023-06-01"
+  }
+}
+JSON
+
+set +e
+"$SCRIPT_PATH" "$COMPAT_BUNDLE" "$MISMATCH_BUNDLE" "$TMP_DIR/out-mismatch" >"$TMP_DIR/mismatch.stdout.txt" 2>"$TMP_DIR/mismatch.stderr.txt"
+STATUS=$?
+set -e
+
+if [[ "$STATUS" -eq 0 ]]; then
+  fail 'expected body mismatch invocation to fail'
+fi
+
+assert_file_contains "$TMP_DIR/mismatch.stderr.txt" 'body-held-constant mismatch'
+
+echo 'PASS'


### PR DESCRIPTION
## Summary
- add `scripts/innies-compat-exact-header-cases`, which turns a failing compat first-pass bundle plus a known-good direct first-pass bundle into replay-ready TSV case files grounded in exact observed header deltas
- keep the issue-80 workflow body-held-constant by hard-failing on mismatched body metadata unless `INNIES_ALLOW_BODY_MISMATCH=true` is set, and emit focused cases for beta-only, identity-only, beta-plus-identity, and all replayable direct deltas
- wire the helper into `scripts/install.sh` and `scripts/README.md`, and cover the happy path plus the body-mismatch guard with focused shell regression

## Test Plan
- `bash scripts/tests/innies-compat-exact-header-cases.test.sh`
- `bash -n scripts/innies-compat-exact-header-cases.sh scripts/tests/innies-compat-exact-header-cases.test.sh scripts/install.sh`
- `node --check scripts/innies-compat-exact-header-cases.mjs`
- `TMP_HOME="$(mktemp -d)" && HOME="$TMP_HOME" bash scripts/install.sh >/tmp/issue80-exact-header-cases-install.out && test -L "$TMP_HOME/.local/bin/innies-compat-exact-header-cases" && git diff --check`

Refs #80
