### PR TITLE
chore: add issue 80 direct token lane matrix helper

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -24,6 +24,7 @@ innies-buyer-key-create
 innies-buyer-preference-set
 innies-buyer-preference-get
 innies-buyer-preference-check
+innies-compat-direct-token-lane-matrix
 innies-slo-check
 ```
 
@@ -39,6 +40,7 @@ What they do:
 - `innies-buyer-preference-set`: set a buyer key preference to `Claude Code`, `Codex`, or `null`
 - `innies-buyer-preference-get`: read the current buyer key preference
 - `innies-buyer-preference-check`: run the provider-preference canary after prompting for the expected provider (`Claude Code` or `Codex`)
+- `innies-compat-direct-token-lane-matrix`: replay one preserved Anthropic `/v1/messages` payload directly across multiple bearer lanes to isolate credential-specific first-pass behavior for issue `#80`
 - `innies-slo-check`: query analytics endpoints and report Phase 1 SLO pass/fail (TTFB p95, timeout rate, success rate, fallback rate); optional arg sets the window (default `24h`); exits 0 if all SLOs pass, 1 if any fail
 
 Behavior:
@@ -79,6 +81,10 @@ Behavior:
 - non-pinned buyer traffic always gets automatic cross-provider fallback to the other provider; flipping preference flips fallback order too
 - `innies-buyer-preference-set` prints the effective preferred provider plus the automatic fallback provider before sending the update
 - `innies-buyer-preference-check` now expects and validates the two-provider plan in DB evidence mode
+- `innies-compat-direct-token-lane-matrix` takes `payload.json`, `direct-headers.tsv`, and a token-matrix TSV with one lane per line:
+  - `lane_alpha<TAB>env:ANTHROPIC_TOKEN_ALPHA`
+  - `lane_beta<TAB>literal:sk-ant-oat-...`
+- `innies-compat-direct-token-lane-matrix` keeps the payload and non-auth headers fixed, rewrites `x-request-id` per lane, stores redacted request headers plus raw response artifacts under `lanes/<lane>/`, and appends one summary line per lane so issue `#80` can distinguish credential-lane-specific failures from header-held-constant failures
 
 ## Env
 

--- a/scripts/innies-compat-direct-token-lane-matrix.sh
+++ b/scripts/innies-compat-direct-token-lane-matrix.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_PATH" ]]; do
+  SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+  SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"
+  [[ "$SCRIPT_PATH" != /* ]] && SCRIPT_PATH="${SCRIPT_DIR}/${SCRIPT_PATH}"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+source "${SCRIPT_DIR}/_common.sh"
+
+resolve_direct_base_url() {
+  if [[ -n "${ANTHROPIC_DIRECT_BASE_URL:-}" ]]; then
+    printf '%s' "${ANTHROPIC_DIRECT_BASE_URL%/}"
+    return
+  fi
+  if [[ -n "${ANTHROPIC_BASE_URL:-}" ]]; then
+    printf '%s' "${ANTHROPIC_BASE_URL%/}"
+    return
+  fi
+  printf '%s' 'https://api.anthropic.com'
+}
+
+extract_response_header() {
+  local name="$1"
+  local file="$2"
+  awk -F': ' -v header_name="$name" '
+    BEGIN { IGNORECASE = 1 }
+    tolower($1) == tolower(header_name) {
+      gsub("\r", "", $2)
+      print $2
+    }
+  ' "$file" | tail -1
+}
+
+extract_body_request_id() {
+  local file="$1"
+  sed -n 's/.*"request_id":"\([^"]*\)".*/\1/p' "$file" | head -n 1
+}
+
+write_lines() {
+  local file="$1"
+  shift
+  printf '%s\n' "$@" >"$file"
+}
+
+resolve_token_spec() {
+  local token_spec="$1"
+  case "$token_spec" in
+    env:*)
+      local env_name="${token_spec#env:}"
+      require_nonempty 'token env var name' "$env_name"
+      local env_value="${!env_name:-}"
+      if [[ -z "$env_value" ]]; then
+        echo "error: missing token env var: $env_name" >&2
+        exit 1
+      fi
+      printf '%s\t%s' "$env_value" "env:$env_name"
+      ;;
+    literal:*)
+      local literal_value="${token_spec#literal:}"
+      require_nonempty 'literal token value' "$literal_value"
+      printf '%s\tliteral' "$literal_value"
+      ;;
+    *)
+      echo "error: unsupported token source '$token_spec' (expected env:VAR_NAME or literal:TOKEN)" >&2
+      exit 1
+      ;;
+  esac
+}
+
+PAYLOAD_PATH="${1:-${INNIES_DIRECT_PAYLOAD_PATH:-}}"
+HEADERS_TSV_PATH="${2:-${INNIES_DIRECT_HEADERS_TSV:-}}"
+TOKENS_TSV_PATH="${3:-${INNIES_DIRECT_TOKEN_MATRIX_TSV:-}}"
+require_nonempty 'payload path' "$PAYLOAD_PATH"
+require_nonempty 'headers tsv path' "$HEADERS_TSV_PATH"
+require_nonempty 'token matrix tsv path' "$TOKENS_TSV_PATH"
+
+if [[ ! -f "$PAYLOAD_PATH" ]]; then
+  echo "error: payload file not found: $PAYLOAD_PATH" >&2
+  exit 1
+fi
+
+if [[ ! -f "$HEADERS_TSV_PATH" ]]; then
+  echo "error: headers TSV file not found: $HEADERS_TSV_PATH" >&2
+  exit 1
+fi
+
+if [[ ! -f "$TOKENS_TSV_PATH" ]]; then
+  echo "error: token matrix TSV file not found: $TOKENS_TSV_PATH" >&2
+  exit 1
+fi
+
+DIRECT_BASE_URL="$(resolve_direct_base_url)"
+DIRECT_PATH="${INNIES_DIRECT_PATH:-/v1/messages}"
+TARGET_URL="${DIRECT_BASE_URL}${DIRECT_PATH}"
+REQUEST_ID_PREFIX="${INNIES_DIRECT_TOKEN_MATRIX_REQUEST_ID_PREFIX:-req_issue80_token_matrix_$(date -u +%Y%m%dT%H%M%SZ)}"
+OUT_DIR="${INNIES_DIRECT_TOKEN_MATRIX_OUT_DIR:-${TMPDIR:-/tmp}/innies-compat-direct-token-lane-matrix-${REQUEST_ID_PREFIX}}"
+LANES_DIR="$OUT_DIR/lanes"
+SUMMARY_FILE="$OUT_DIR/summary.txt"
+mkdir -p "$LANES_DIR"
+: >"$SUMMARY_FILE"
+
+run_lane() {
+  local lane_name="$1"
+  local token_spec="$2"
+  local token_value_and_source
+  token_value_and_source="$(resolve_token_spec "$token_spec")"
+  local access_token="${token_value_and_source%%$'\t'*}"
+  local token_source="${token_value_and_source#*$'\t'}"
+  local request_id="${REQUEST_ID_PREFIX}_${lane_name}"
+  local lane_dir="$LANES_DIR/$lane_name"
+  local request_headers_tsv="$lane_dir/request-headers.tsv"
+  local response_headers_file="$lane_dir/response-headers.txt"
+  local response_body_file="$lane_dir/response-body.txt"
+  local meta_file="$lane_dir/meta.txt"
+  mkdir -p "$lane_dir"
+
+  declare -a curl_args
+  curl_args=(
+    -sS
+    -D "$response_headers_file"
+    -o "$response_body_file"
+    -w '%{http_code}'
+    -X POST "$TARGET_URL"
+    --data-binary "@$PAYLOAD_PATH"
+  )
+
+  printf 'authorization\tBearer <redacted>\n' >"$request_headers_tsv"
+  local have_request_id='false'
+  while IFS=$'\t' read -r raw_header_name raw_header_value; do
+    [[ -z "${raw_header_name:-}" ]] && continue
+    local header_name
+    local header_value
+    local normalized_name
+    header_name="$(trim "$raw_header_name")"
+    header_value="$(trim "${raw_header_value:-}")"
+    [[ -z "$header_name" ]] && continue
+    normalized_name="$(printf '%s' "$header_name" | tr '[:upper:]' '[:lower:]')"
+    case "$normalized_name" in
+      authorization|content-length|host)
+        continue
+        ;;
+      x-request-id)
+        header_value="$request_id"
+        have_request_id='true'
+        ;;
+    esac
+
+    curl_args+=(-H "${normalized_name}: ${header_value}")
+    printf '%s\t%s\n' "$normalized_name" "$header_value" >>"$request_headers_tsv"
+  done <"$HEADERS_TSV_PATH"
+
+  if [[ "$have_request_id" != 'true' ]]; then
+    curl_args+=(-H "x-request-id: $request_id")
+    printf 'x-request-id\t%s\n' "$request_id" >>"$request_headers_tsv"
+  fi
+
+  curl_args+=(-H "authorization: Bearer $access_token")
+
+  local status
+  status="$(curl "${curl_args[@]}")"
+  local provider_request_id
+  provider_request_id="$(extract_response_header 'request-id' "$response_headers_file")"
+  if [[ -z "$provider_request_id" ]]; then
+    provider_request_id="$(extract_body_request_id "$response_body_file")"
+  fi
+
+  local outcome='unexpected_http_status'
+  if [[ "$status" =~ ^2 ]]; then
+    outcome='request_succeeded'
+  elif [[ "$status" == '400' ]] && grep -q '"type":"invalid_request_error"' "$response_body_file"; then
+    outcome='reproduced_invalid_request_error'
+  fi
+
+  local meta_lines=(
+    "lane=$lane_name"
+    "status=$status"
+    "outcome=$outcome"
+    "request_id=$request_id"
+    "provider_request_id=${provider_request_id:-}"
+    "token_source=$token_source"
+    "target_url=$TARGET_URL"
+    "payload_path=$PAYLOAD_PATH"
+    "headers_tsv_path=$HEADERS_TSV_PATH"
+    "request_headers_tsv=$request_headers_tsv"
+    "response_headers_file=$response_headers_file"
+    "response_body_file=$response_body_file"
+  )
+  write_lines "$meta_file" "${meta_lines[@]}"
+  printf 'lane=%s status=%s provider_request_id=%s request_id=%s token_source=%s\n' \
+    "$lane_name" \
+    "$status" \
+    "${provider_request_id:-}" \
+    "$request_id" \
+    "$token_source" >>"$SUMMARY_FILE"
+}
+
+lane_count=0
+while IFS=$'\t' read -r raw_lane_name raw_token_spec _; do
+  local_lane_name="$(trim "${raw_lane_name:-}")"
+  local_token_spec="$(trim "${raw_token_spec:-}")"
+  [[ -z "$local_lane_name" ]] && continue
+  [[ "$local_lane_name" == \#* ]] && continue
+  require_nonempty "token spec for lane '$local_lane_name'" "$local_token_spec"
+  if [[ ! "$local_lane_name" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    echo "error: invalid lane name '$local_lane_name' (use letters, numbers, dot, underscore, or dash)" >&2
+    exit 1
+  fi
+  run_lane "$local_lane_name" "$local_token_spec"
+  lane_count=$((lane_count + 1))
+done <"$TOKENS_TSV_PATH"
+
+if [[ "$lane_count" -eq 0 ]]; then
+  echo "error: no token lanes found in $TOKENS_TSV_PATH" >&2
+  exit 1
+fi
+
+cat "$SUMMARY_FILE"
+printf 'summary_file=%s\n' "$SUMMARY_FILE"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,6 +17,7 @@ ln -sf "${ROOT_DIR}/scripts/innies-buyer-key-create.sh" "${BIN_DIR}/innies-buyer
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-set.sh" "${BIN_DIR}/innies-buyer-preference-set"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-get.sh" "${BIN_DIR}/innies-buyer-preference-get"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-check.sh" "${BIN_DIR}/innies-buyer-preference-check"
+ln -sf "${ROOT_DIR}/scripts/innies-compat-direct-token-lane-matrix.sh" "${BIN_DIR}/innies-compat-direct-token-lane-matrix"
 ln -sf "${ROOT_DIR}/scripts/innies-slo-check.sh" "${BIN_DIR}/innies-slo-check"
 
 rm -f \
@@ -48,6 +49,7 @@ echo "  ${BIN_DIR}/innies-buyer-key-create -> ${ROOT_DIR}/scripts/innies-buyer-k
 echo "  ${BIN_DIR}/innies-buyer-preference-set -> ${ROOT_DIR}/scripts/innies-buyer-preference-set.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-get -> ${ROOT_DIR}/scripts/innies-buyer-preference-get.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-check -> ${ROOT_DIR}/scripts/innies-buyer-preference-check.sh"
+echo "  ${BIN_DIR}/innies-compat-direct-token-lane-matrix -> ${ROOT_DIR}/scripts/innies-compat-direct-token-lane-matrix.sh"
 echo "  ${BIN_DIR}/innies-slo-check -> ${ROOT_DIR}/scripts/innies-slo-check.sh"
 echo
 echo 'If command not found, add ~/.local/bin to PATH:'

--- a/scripts/tests/innies-compat-direct-token-lane-matrix.test.sh
+++ b/scripts/tests/innies-compat-direct-token-lane-matrix.test.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="$ROOT_DIR/scripts/innies-compat-direct-token-lane-matrix.sh"
+TMP_DIR="$(mktemp -d)"
+PAYLOAD_PATH="$TMP_DIR/payload.json"
+HEADERS_TSV_PATH="$TMP_DIR/direct-headers.tsv"
+TOKENS_TSV_PATH="$TMP_DIR/direct-tokens.tsv"
+REQUESTS_DIR="$TMP_DIR/requests"
+OUT_DIR="$TMP_DIR/out"
+STDOUT_PATH="$TMP_DIR/stdout.txt"
+STDERR_PATH="$TMP_DIR/stderr.txt"
+
+cleanup() {
+  if [[ -n "${SERVER_PID:-}" ]]; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$REQUESTS_DIR"
+
+cat >"$PAYLOAD_PATH" <<'JSON'
+{"model":"claude-opus-4-6","stream":true,"max_tokens":32,"messages":[{"role":"user","content":[{"type":"text","text":"hello from token matrix test"}]}]}
+JSON
+
+cat >"$HEADERS_TSV_PATH" <<'TSV'
+accept	text/event-stream
+anthropic-beta	fine-grained-tool-streaming-2025-05-14
+anthropic-dangerous-direct-browser-access	true
+anthropic-version	2023-06-01
+content-type	application/json
+user-agent	OpenClawGateway/1.0
+x-app	cli
+x-request-id	req_original_should_be_replaced
+TSV
+
+cat >"$TOKENS_TSV_PATH" <<'TSV'
+lane_alpha	env:ANTHROPIC_TOKEN_ALPHA
+lane_beta	literal:sk-ant-oat-beta-live-token
+TSV
+
+cat >"$TMP_DIR/mock-server.mjs" <<'NODE'
+import { createServer } from 'node:http';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const port = Number(process.env.PORT);
+const requestsDir = process.env.REQUESTS_DIR;
+mkdirSync(requestsDir, { recursive: true });
+
+const server = createServer((req, res) => {
+  const chunks = [];
+  req.on('data', (chunk) => chunks.push(chunk));
+  req.on('end', () => {
+    const bodyBuffer = Buffer.concat(chunks);
+    const requestId = String(req.headers['x-request-id'] ?? `unknown-${Date.now()}`);
+    writeFileSync(join(requestsDir, `${requestId}.json`), JSON.stringify({
+      method: req.method,
+      url: req.url,
+      headers: req.headers,
+      bodyText: bodyBuffer.toString('utf8'),
+      bodyBytes: bodyBuffer.length
+    }, null, 2));
+
+    const authHeader = String(req.headers.authorization ?? '');
+    if (authHeader.endsWith('alpha-live-token')) {
+      res.statusCode = 200;
+      res.setHeader('content-type', 'application/json');
+      res.setHeader('request-id', 'req_provider_alpha');
+      res.end(JSON.stringify({
+        id: 'msg_alpha_ok',
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'text', text: 'ok' }],
+        stop_reason: 'end_turn'
+      }));
+      return;
+    }
+
+    res.statusCode = 400;
+    res.setHeader('content-type', 'application/json');
+    res.setHeader('request-id', 'req_provider_beta');
+    res.end(JSON.stringify({
+      type: 'error',
+      error: {
+        type: 'invalid_request_error',
+        message: 'Error'
+      },
+      request_id: 'req_provider_beta'
+    }));
+  });
+});
+
+server.listen(port, '127.0.0.1', () => {
+  process.stdout.write(`ready:${port}\n`);
+});
+NODE
+
+PORT="$(node -e "const net=require('node:net');const s=net.createServer();s.listen(0,'127.0.0.1',()=>{const {port}=s.address();console.log(port);s.close();});")"
+PORT="$PORT" REQUESTS_DIR="$REQUESTS_DIR" node "$TMP_DIR/mock-server.mjs" >"$TMP_DIR/server.log" 2>&1 &
+SERVER_PID=$!
+
+for _ in $(seq 1 50); do
+  if grep -q '^ready:' "$TMP_DIR/server.log" 2>/dev/null; then
+    break
+  fi
+  sleep 0.1
+done
+
+if ! grep -q '^ready:' "$TMP_DIR/server.log" 2>/dev/null; then
+  echo 'server did not start' >&2
+  cat "$TMP_DIR/server.log" >&2
+  exit 1
+fi
+
+set +e
+ANTHROPIC_TOKEN_ALPHA="sk-ant-oat-alpha-live-token" \
+ANTHROPIC_DIRECT_BASE_URL="http://127.0.0.1:$PORT" \
+INNIES_DIRECT_TOKEN_MATRIX_REQUEST_ID_PREFIX="req_issue80_token_matrix" \
+INNIES_DIRECT_TOKEN_MATRIX_OUT_DIR="$OUT_DIR" \
+"$SCRIPT_PATH" "$PAYLOAD_PATH" "$HEADERS_TSV_PATH" "$TOKENS_TSV_PATH" >"$STDOUT_PATH" 2>"$STDERR_PATH"
+STATUS=$?
+set -e
+
+if [[ "$STATUS" -ne 0 ]]; then
+  cat "$STDERR_PATH" >&2
+  exit 1
+fi
+
+[[ -f "$OUT_DIR/summary.txt" ]]
+[[ -f "$OUT_DIR/lanes/lane_alpha/meta.txt" ]]
+[[ -f "$OUT_DIR/lanes/lane_alpha/request-headers.tsv" ]]
+[[ -f "$OUT_DIR/lanes/lane_alpha/response-headers.txt" ]]
+[[ -f "$OUT_DIR/lanes/lane_alpha/response-body.txt" ]]
+[[ -f "$OUT_DIR/lanes/lane_beta/meta.txt" ]]
+[[ -f "$OUT_DIR/lanes/lane_beta/request-headers.tsv" ]]
+[[ -f "$OUT_DIR/lanes/lane_beta/response-headers.txt" ]]
+[[ -f "$OUT_DIR/lanes/lane_beta/response-body.txt" ]]
+
+grep -q 'lane=lane_alpha status=200 provider_request_id=req_provider_alpha request_id=req_issue80_token_matrix_lane_alpha token_source=env:ANTHROPIC_TOKEN_ALPHA' "$OUT_DIR/summary.txt"
+grep -q 'lane=lane_beta status=400 provider_request_id=req_provider_beta request_id=req_issue80_token_matrix_lane_beta token_source=literal' "$OUT_DIR/summary.txt"
+grep -q '^authorization\tBearer <redacted>$' "$OUT_DIR/lanes/lane_alpha/request-headers.tsv"
+grep -q '^authorization\tBearer <redacted>$' "$OUT_DIR/lanes/lane_beta/request-headers.tsv"
+grep -q '^request_id=req_issue80_token_matrix_lane_alpha$' "$OUT_DIR/lanes/lane_alpha/meta.txt"
+grep -q '^request_id=req_issue80_token_matrix_lane_beta$' "$OUT_DIR/lanes/lane_beta/meta.txt"
+grep -q '^token_source=env:ANTHROPIC_TOKEN_ALPHA$' "$OUT_DIR/lanes/lane_alpha/meta.txt"
+grep -q '^token_source=literal$' "$OUT_DIR/lanes/lane_beta/meta.txt"
+grep -q '^summary_file=' "$STDOUT_PATH"
+
+node - "$REQUESTS_DIR" <<'NODE'
+const fs = require('fs');
+const path = require('path');
+const requestsDir = process.argv[2];
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+const laneAlpha = readJson(path.join(requestsDir, 'req_issue80_token_matrix_lane_alpha.json'));
+const laneBeta = readJson(path.join(requestsDir, 'req_issue80_token_matrix_lane_beta.json'));
+
+if (laneAlpha.headers.authorization !== 'Bearer sk-ant-oat-alpha-live-token') {
+  throw new Error('lane alpha auth header mismatch');
+}
+if (laneBeta.headers.authorization !== 'Bearer sk-ant-oat-beta-live-token') {
+  throw new Error('lane beta auth header mismatch');
+}
+if (laneAlpha.headers['anthropic-beta'] !== 'fine-grained-tool-streaming-2025-05-14') {
+  throw new Error('lane alpha beta mismatch');
+}
+if (laneBeta.headers['x-app'] !== 'cli') {
+  throw new Error('lane beta x-app mismatch');
+}
+NODE
+
+MISSING_TOKENS_TSV_PATH="$TMP_DIR/missing-env.tsv"
+cat >"$MISSING_TOKENS_TSV_PATH" <<'TSV'
+lane_missing	env:ANTHROPIC_TOKEN_MISSING
+TSV
+
+set +e
+ANTHROPIC_DIRECT_BASE_URL="http://127.0.0.1:$PORT" \
+"$SCRIPT_PATH" "$PAYLOAD_PATH" "$HEADERS_TSV_PATH" "$MISSING_TOKENS_TSV_PATH" >"$STDOUT_PATH" 2>"$STDERR_PATH"
+STATUS=$?
+set -e
+
+if [[ "$STATUS" -eq 0 ]]; then
+  echo 'expected missing env token invocation to fail' >&2
+  exit 1
+fi
+
+grep -q 'missing token env var' "$STDERR_PATH"


### PR DESCRIPTION
Refs #80

## Summary
- add `scripts/innies-compat-direct-token-lane-matrix.sh` to replay one preserved Anthropic `/v1/messages` payload across multiple bearer lanes while holding the payload and non-auth headers constant
- capture per-lane redacted request headers plus raw response artifacts and append one summary line per lane so issue `#80` can isolate credential-lane-specific failures from header-held-constant failures
- wire the helper into `scripts/install.sh` / `scripts/README.md` and cover it with focused shell regression

## Why
The current issue-80 helper lanes cover exact first-pass diffing, direct replay, header matrices, and direct-header TSV generation, but they are still single-bearer. This helper fills the remaining credential-lane evidence gap called out in the issue body by letting operators replay the same preserved request across multiple Anthropic bearer lanes without touching the runtime proxy path.

## Verification
- `bash scripts/tests/innies-compat-direct-token-lane-matrix.test.sh`
- `bash -n scripts/innies-compat-direct-token-lane-matrix.sh scripts/tests/innies-compat-direct-token-lane-matrix.test.sh scripts/install.sh`
- `TMP_HOME="$(mktemp -d)" && HOME="$TMP_HOME" bash scripts/install.sh >/tmp/issue80-token-lane-matrix-install.out && test -L "$TMP_HOME/.local/bin/innies-compat-direct-token-lane-matrix"`
- `git diff --check HEAD~1..HEAD`

## Limit
- this shell still has no live Anthropic bearer matrix available, so verification is mock-backed rather than a real multi-lane upstream run from this session
