### PR TITLE
chore: add issue 80 exact case matrix runner

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -24,6 +24,7 @@ innies-buyer-key-create
 innies-buyer-preference-set
 innies-buyer-preference-get
 innies-buyer-preference-check
+innies-compat-exact-case-matrix
 innies-slo-check
 ```
 
@@ -39,6 +40,7 @@ What they do:
 - `innies-buyer-preference-set`: set a buyer key preference to `Claude Code`, `Codex`, or `null`
 - `innies-buyer-preference-get`: read the current buyer key preference
 - `innies-buyer-preference-check`: run the provider-preference canary after prompting for the expected provider (`Claude Code` or `Codex`)
+- `innies-compat-exact-case-matrix`: replay one preserved Anthropic payload through a directory of replay-ready `*.tsv` header cases and write per-case request/response bundles plus a merged summary
 - `innies-slo-check`: query analytics endpoints and report Phase 1 SLO pass/fail (TTFB p95, timeout rate, success rate, fallback rate); optional arg sets the window (default `24h`); exits 0 if all SLOs pass, 1 if any fail
 
 Behavior:
@@ -79,6 +81,7 @@ Behavior:
 - non-pinned buyer traffic always gets automatic cross-provider fallback to the other provider; flipping preference flips fallback order too
 - `innies-buyer-preference-set` prints the effective preferred provider plus the automatic fallback provider before sending the update
 - `innies-buyer-preference-check` now expects and validates the two-provider plan in DB evidence mode
+- `innies-compat-exact-case-matrix` expects a preserved `payload.json` plus either a case TSV directory or one `*.tsv` file; it replays those exact headers against Anthropic using `ANTHROPIC_OAUTH_ACCESS_TOKEN`, `ANTHROPIC_ACCESS_TOKEN`, or `CLAUDE_CODE_OAUTH_TOKEN`
 
 ## Env
 

--- a/scripts/innies-compat-exact-case-matrix.sh
+++ b/scripts/innies-compat-exact-case-matrix.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_PATH" ]]; do
+  SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+  SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"
+  [[ "$SCRIPT_PATH" != /* ]] && SCRIPT_PATH="${SCRIPT_DIR}/${SCRIPT_PATH}"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+source "${SCRIPT_DIR}/_common.sh"
+
+resolve_direct_base_url() {
+  if [[ -n "${ANTHROPIC_DIRECT_BASE_URL:-}" ]]; then
+    printf '%s' "${ANTHROPIC_DIRECT_BASE_URL%/}"
+    return
+  fi
+  if [[ -n "${ANTHROPIC_BASE_URL:-}" ]]; then
+    printf '%s' "${ANTHROPIC_BASE_URL%/}"
+    return
+  fi
+  printf '%s' 'https://api.anthropic.com'
+}
+
+resolve_access_token() {
+  if [[ -n "${ANTHROPIC_OAUTH_ACCESS_TOKEN:-}" ]]; then
+    printf '%s\t%s' "${ANTHROPIC_OAUTH_ACCESS_TOKEN}" 'anthropic_oauth_access_token'
+    return
+  fi
+  if [[ -n "${ANTHROPIC_ACCESS_TOKEN:-}" ]]; then
+    printf '%s\t%s' "${ANTHROPIC_ACCESS_TOKEN}" 'anthropic_access_token'
+    return
+  fi
+  if [[ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
+    printf '%s\t%s' "${CLAUDE_CODE_OAUTH_TOKEN}" 'claude_code_oauth_token'
+    return
+  fi
+  echo 'error: missing Anthropic OAuth access token (set ANTHROPIC_OAUTH_ACCESS_TOKEN, ANTHROPIC_ACCESS_TOKEN, or CLAUDE_CODE_OAUTH_TOKEN)' >&2
+  exit 1
+}
+
+extract_response_header() {
+  local name="$1"
+  local file="$2"
+  awk -F': ' -v header_name="$name" '
+    BEGIN { IGNORECASE = 1 }
+    tolower($1) == tolower(header_name) {
+      gsub("\r", "", $2)
+      print $2
+    }
+  ' "$file" | tail -1
+}
+
+extract_body_request_id() {
+  local file="$1"
+  sed -n 's/.*"request_id":"\([^"]*\)".*/\1/p' "$file" | head -n 1
+}
+
+write_lines() {
+  local file="$1"
+  shift
+  printf '%s\n' "$@" >"$file"
+}
+
+resolve_case_files() {
+  local source="$1"
+
+  if [[ -f "$source" ]]; then
+    if [[ "$source" != *.tsv ]]; then
+      echo "error: case file must be a .tsv file: $source" >&2
+      exit 1
+    fi
+    printf '%s\n' "$source"
+    return
+  fi
+
+  if [[ -d "$source" ]]; then
+    find "$source" -maxdepth 1 -type f -name '*.tsv' | sort
+    return
+  fi
+
+  echo "error: case source path not found: $source" >&2
+  exit 1
+}
+
+PAYLOAD_PATH="${1:-${INNIES_EXACT_CASE_MATRIX_PAYLOAD_PATH:-}}"
+CASE_SOURCE="${2:-${INNIES_EXACT_CASE_MATRIX_CASE_SOURCE:-}}"
+OUT_DIR="${3:-${INNIES_EXACT_CASE_MATRIX_OUT_DIR:-${TMPDIR:-/tmp}/innies-compat-exact-case-matrix-$(date -u +%Y%m%dT%H%M%SZ)}}"
+require_nonempty 'payload path' "$PAYLOAD_PATH"
+require_nonempty 'case source path' "$CASE_SOURCE"
+
+if [[ ! -f "$PAYLOAD_PATH" ]]; then
+  echo "error: payload file not found: $PAYLOAD_PATH" >&2
+  exit 1
+fi
+
+CASE_FILES=()
+while IFS= read -r case_file; do
+  [[ -n "$case_file" ]] && CASE_FILES+=("$case_file")
+done < <(resolve_case_files "$CASE_SOURCE")
+
+if [[ "${#CASE_FILES[@]}" -eq 0 ]]; then
+  echo "error: no case TSV files found: $CASE_SOURCE" >&2
+  exit 1
+fi
+
+DIRECT_BASE_URL="$(resolve_direct_base_url)"
+DIRECT_PATH="${INNIES_DIRECT_PATH:-/v1/messages}"
+TARGET_URL="${DIRECT_BASE_URL}${DIRECT_PATH}"
+
+TOKEN_AND_SOURCE="$(resolve_access_token)"
+ACCESS_TOKEN="${TOKEN_AND_SOURCE%%$'\t'*}"
+DIRECT_ACCESS_TOKEN_SOURCE="${TOKEN_AND_SOURCE#*$'\t'}"
+
+mkdir -p "$OUT_DIR"
+PAYLOAD_COPY_PATH="$OUT_DIR/payload.json"
+cp "$PAYLOAD_PATH" "$PAYLOAD_COPY_PATH"
+
+PAYLOAD_BYTES="$(wc -c <"$PAYLOAD_PATH" | tr -d '[:space:]')"
+PAYLOAD_SHA256="$(openssl dgst -sha256 -r "$PAYLOAD_PATH" | awk '{print $1}')"
+PAYLOAD_STREAM="$(node -e "const fs=require('fs'); try { const payload=JSON.parse(fs.readFileSync(process.argv[1],'utf8')); process.stdout.write(String(Boolean(payload && payload.stream))); } catch { process.stdout.write(''); }" "$PAYLOAD_PATH")"
+
+CASE_LINES=()
+CASE_FILE_NAMES=()
+
+for case_file in "${CASE_FILES[@]}"; do
+  case_name="$(basename "$case_file" .tsv)"
+  CASE_FILE_NAMES+=("$(basename "$case_file")")
+
+  case_dir="$OUT_DIR/$case_name"
+  mkdir -p "$case_dir"
+
+  request_headers_tsv="$case_dir/request-headers.tsv"
+  response_headers_file="$case_dir/response-headers.txt"
+  response_body_file="$case_dir/response-body.txt"
+  request_json_file="$case_dir/request.json"
+  response_json_file="$case_dir/response.json"
+
+  printf 'authorization\tBearer <redacted>\n' >"$request_headers_tsv"
+
+  header_names='authorization'
+  request_id_header=''
+  anthropic_beta=''
+  anthropic_version=''
+  user_agent=''
+  x_app=''
+  dangerous_direct_browser_access=''
+
+  curl_args=(
+    -sS
+    -D "$response_headers_file"
+    -o "$response_body_file"
+    -w '%{http_code}'
+    -X POST "$TARGET_URL"
+    --data-binary "@$PAYLOAD_PATH"
+    -H "authorization: Bearer $ACCESS_TOKEN"
+  )
+
+  while IFS=$'\t' read -r raw_header_name raw_header_value; do
+    [[ -z "$raw_header_name" ]] && continue
+    header_name="$(trim "$raw_header_name")"
+    header_value="$(trim "${raw_header_value:-}")"
+    [[ -z "$header_name" ]] && continue
+
+    header_name="$(printf '%s' "$header_name" | tr '[:upper:]' '[:lower:]')"
+    case "$header_name" in
+      authorization|content-length|host)
+        continue
+        ;;
+    esac
+
+    curl_args+=(-H "${header_name}: ${header_value}")
+    printf '%s\t%s\n' "$header_name" "$header_value" >>"$request_headers_tsv"
+    header_names="${header_names},${header_name}"
+
+    case "$header_name" in
+      x-request-id) request_id_header="$header_value" ;;
+      anthropic-beta) anthropic_beta="$header_value" ;;
+      anthropic-version) anthropic_version="$header_value" ;;
+      user-agent) user_agent="$header_value" ;;
+      x-app) x_app="$header_value" ;;
+      anthropic-dangerous-direct-browser-access) dangerous_direct_browser_access="$header_value" ;;
+    esac
+  done <"$case_file"
+
+  case_status="$(curl "${curl_args[@]}")"
+  provider_request_id="$(extract_response_header 'request-id' "$response_headers_file")"
+  if [[ -z "$provider_request_id" ]]; then
+    provider_request_id="$(extract_body_request_id "$response_body_file")"
+  fi
+
+  node - "$request_headers_tsv" "$response_headers_file" "$response_body_file" "$request_json_file" "$response_json_file" "$TARGET_URL" "$request_id_header" "$PAYLOAD_BYTES" "$PAYLOAD_SHA256" "$PAYLOAD_STREAM" "$case_status" "$provider_request_id" <<'NODE'
+const fs = require('fs');
+
+const [
+  requestHeadersTsvPath,
+  responseHeadersPath,
+  responseBodyPath,
+  requestJsonPath,
+  responseJsonPath,
+  targetUrl,
+  requestIdHeader,
+  payloadBytes,
+  payloadSha256,
+  payloadStream,
+  caseStatus,
+  providerRequestId
+] = process.argv.slice(2);
+
+function readHeadersTsv(filePath) {
+  const headers = {};
+  const text = fs.readFileSync(filePath, 'utf8');
+  for (const line of text.split(/\r?\n/)) {
+    if (!line) continue;
+    const parts = line.split('\t');
+    const name = String(parts[0] ?? '').trim().toLowerCase();
+    const value = String(parts.slice(1).join('\t') ?? '').trim();
+    if (!name) continue;
+    headers[name] = value;
+  }
+  return headers;
+}
+
+function readResponseHeaders(filePath) {
+  const headers = {};
+  const text = fs.readFileSync(filePath, 'utf8');
+  for (const line of text.split(/\r?\n/)) {
+    if (!line || !line.includes(':')) continue;
+    const index = line.indexOf(':');
+    const name = line.slice(0, index).trim().toLowerCase();
+    const value = line.slice(index + 1).trim();
+    if (!name) continue;
+    headers[name] = value;
+  }
+  return headers;
+}
+
+const requestHeaders = readHeadersTsv(requestHeadersTsvPath);
+const responseHeaders = readResponseHeaders(responseHeadersPath);
+const responseBodyText = fs.readFileSync(responseBodyPath, 'utf8');
+
+let responseBodyJson = null;
+try {
+  responseBodyJson = JSON.parse(responseBodyText);
+} catch {}
+
+const requestRecord = {
+  provider: 'anthropic',
+  request_id: requestIdHeader || '',
+  method: 'POST',
+  target_url: targetUrl,
+  headers: requestHeaders,
+  body_bytes: Number(payloadBytes),
+  body_sha256: payloadSha256,
+  stream: payloadStream === '' ? null : payloadStream === 'true'
+};
+
+const responseRecord = {
+  request_id: requestIdHeader || '',
+  status: Number(caseStatus),
+  provider_request_id: providerRequestId || '',
+  headers: responseHeaders,
+  body_json: responseBodyJson,
+  body_text: responseBodyText
+};
+
+fs.writeFileSync(requestJsonPath, `${JSON.stringify(requestRecord, null, 2)}\n`);
+fs.writeFileSync(responseJsonPath, `${JSON.stringify(responseRecord, null, 2)}\n`);
+NODE
+
+  CASE_LINES+=("case=$case_name status=$case_status provider_request_id=${provider_request_id:-} request_id_header=${request_id_header:-} anthropic_beta=${anthropic_beta:-} anthropic_version=${anthropic_version:-} dangerous_direct_browser_access=${dangerous_direct_browser_access:-} user_agent=${user_agent:-} x_app=${x_app:-} header_names=$header_names case_dir=$case_dir")
+done
+
+SUMMARY_FILE="$OUT_DIR/summary.txt"
+SUMMARY_LINES=(
+  "payload_path=$PAYLOAD_PATH"
+  "payload_copy_path=$PAYLOAD_COPY_PATH"
+  "target_url=$TARGET_URL"
+  "body_bytes=$PAYLOAD_BYTES"
+  "body_sha256=$PAYLOAD_SHA256"
+  "direct_access_token_source=$DIRECT_ACCESS_TOKEN_SOURCE"
+  "case_count=${#CASE_LINES[@]}"
+  "case_files=$(IFS=,; printf '%s' "${CASE_FILE_NAMES[*]}")"
+)
+
+write_lines "$SUMMARY_FILE" "${SUMMARY_LINES[@]}" "${CASE_LINES[@]}"
+cat "$SUMMARY_FILE"
+printf 'summary_file=%s\n' "$SUMMARY_FILE"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,6 +17,7 @@ ln -sf "${ROOT_DIR}/scripts/innies-buyer-key-create.sh" "${BIN_DIR}/innies-buyer
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-set.sh" "${BIN_DIR}/innies-buyer-preference-set"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-get.sh" "${BIN_DIR}/innies-buyer-preference-get"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-check.sh" "${BIN_DIR}/innies-buyer-preference-check"
+ln -sf "${ROOT_DIR}/scripts/innies-compat-exact-case-matrix.sh" "${BIN_DIR}/innies-compat-exact-case-matrix"
 ln -sf "${ROOT_DIR}/scripts/innies-slo-check.sh" "${BIN_DIR}/innies-slo-check"
 
 rm -f \
@@ -48,6 +49,7 @@ echo "  ${BIN_DIR}/innies-buyer-key-create -> ${ROOT_DIR}/scripts/innies-buyer-k
 echo "  ${BIN_DIR}/innies-buyer-preference-set -> ${ROOT_DIR}/scripts/innies-buyer-preference-set.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-get -> ${ROOT_DIR}/scripts/innies-buyer-preference-get.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-check -> ${ROOT_DIR}/scripts/innies-buyer-preference-check.sh"
+echo "  ${BIN_DIR}/innies-compat-exact-case-matrix -> ${ROOT_DIR}/scripts/innies-compat-exact-case-matrix.sh"
 echo "  ${BIN_DIR}/innies-slo-check -> ${ROOT_DIR}/scripts/innies-slo-check.sh"
 echo
 echo 'If command not found, add ~/.local/bin to PATH:'

--- a/scripts/tests/innies-compat-exact-case-matrix.test.sh
+++ b/scripts/tests/innies-compat-exact-case-matrix.test.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEST_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${TEST_SCRIPT_DIR}/../.." && pwd)"
+SCRIPT_PATH="${ROOT_DIR}/scripts/innies-compat-exact-case-matrix.sh"
+TMP_DIR="$(mktemp -d)"
+SERVER_PID=''
+
+cleanup() {
+  if [[ -n "$SERVER_PID" ]]; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_file_exists() {
+  local path="$1"
+  [[ -f "$path" ]] || fail "expected file to exist: $path"
+}
+
+assert_file_contains() {
+  local path="$1"
+  local pattern="$2"
+  if ! grep -Fq "$pattern" "$path"; then
+    echo "Expected pattern not found in $path: $pattern" >&2
+    echo "--- file contents ---" >&2
+    cat "$path" >&2
+    echo "---------------------" >&2
+    exit 1
+  fi
+}
+
+assert_file_not_contains() {
+  local path="$1"
+  local pattern="$2"
+  if grep -Fq "$pattern" "$path"; then
+    echo "Unexpected pattern found in $path: $pattern" >&2
+    echo "--- file contents ---" >&2
+    cat "$path" >&2
+    echo "---------------------" >&2
+    exit 1
+  fi
+}
+
+PAYLOAD_PATH="$TMP_DIR/payload.json"
+CASES_DIR="$TMP_DIR/cases"
+REQUESTS_JSON="$TMP_DIR/requests.json"
+SERVER_LOG="$TMP_DIR/server.log"
+OUT_DIR="$TMP_DIR/out"
+EMPTY_CASES_DIR="$TMP_DIR/empty-cases"
+mkdir -p "$CASES_DIR" "$EMPTY_CASES_DIR"
+
+cat >"$PAYLOAD_PATH" <<'JSON'
+{
+  "model": "claude-opus-4-6",
+  "stream": true,
+  "max_tokens": 16384,
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        {
+          "type": "text",
+          "text": "hello from issue 80 exact case matrix"
+        }
+      ]
+    }
+  ]
+}
+JSON
+
+cat >"$CASES_DIR/compat-with-direct-beta.tsv" <<'EOF_CASE'
+accept	text/event-stream
+anthropic-beta	fine-grained-tool-streaming-2025-05-14
+anthropic-version	2023-06-01
+content-type	application/json
+EOF_CASE
+
+cat >"$CASES_DIR/direct-exact.tsv" <<'EOF_CASE'
+accept	text/event-stream
+anthropic-beta	fine-grained-tool-streaming-2025-05-14
+anthropic-dangerous-direct-browser-access	true
+anthropic-version	2023-06-01
+content-type	application/json
+user-agent	OpenClawGateway/1.0
+x-app	cli
+x-request-id	req_issue80_direct_exact
+EOF_CASE
+
+cat >"$CASES_DIR/shared.tsv" <<'EOF_CASE'
+accept	text/event-stream
+anthropic-version	2023-06-01
+content-type	application/json
+EOF_CASE
+
+printf '[]\n' >"$REQUESTS_JSON"
+
+cat >"$TMP_DIR/server.mjs" <<'NODE'
+import { createServer } from 'node:http';
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const port = Number(process.env.PORT);
+const requestsPath = process.env.REQUESTS_PATH;
+let requestCount = 0;
+
+const server = createServer((req, res) => {
+  const chunks = [];
+  req.on('data', (chunk) => chunks.push(chunk));
+  req.on('end', () => {
+    requestCount += 1;
+    const existing = JSON.parse(readFileSync(requestsPath, 'utf8'));
+    existing.push({
+      index: requestCount,
+      method: req.method,
+      url: req.url,
+      headers: req.headers,
+      body: Buffer.concat(chunks).toString('utf8')
+    });
+    writeFileSync(requestsPath, JSON.stringify(existing, null, 2));
+
+    res.statusCode = 400;
+    res.setHeader('content-type', 'application/json');
+    res.setHeader('request-id', `req_upstream_case_${requestCount}`);
+    res.end(JSON.stringify({
+      type: 'error',
+      error: { type: 'invalid_request_error', message: 'Error' },
+      request_id: `req_upstream_case_${requestCount}`
+    }));
+  });
+});
+
+server.listen(port, '127.0.0.1', () => {
+  process.stdout.write(`ready:${port}\n`);
+});
+NODE
+
+PORT="$(node -e "const net=require('node:net');const server=net.createServer();server.listen(0,'127.0.0.1',()=>{const address=server.address();console.log(address.port);server.close();});")"
+REQUESTS_PATH="$REQUESTS_JSON" PORT="$PORT" node "$TMP_DIR/server.mjs" >"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+
+for _ in $(seq 1 50); do
+  if grep -q '^ready:' "$SERVER_LOG" 2>/dev/null; then
+    break
+  fi
+  sleep 0.1
+done
+
+if ! grep -q '^ready:' "$SERVER_LOG" 2>/dev/null; then
+  fail "server did not start"
+fi
+
+ANTHROPIC_DIRECT_BASE_URL="http://127.0.0.1:$PORT" \
+ANTHROPIC_OAUTH_ACCESS_TOKEN="sk-ant-oat-test-token" \
+INNIES_EXACT_CASE_MATRIX_OUT_DIR="$OUT_DIR" \
+"$SCRIPT_PATH" "$PAYLOAD_PATH" "$CASES_DIR" >"$TMP_DIR/output.txt" 2>"$TMP_DIR/error.txt"
+
+assert_file_exists "$OUT_DIR/payload.json"
+assert_file_exists "$OUT_DIR/summary.txt"
+assert_file_exists "$OUT_DIR/compat-with-direct-beta/request.json"
+assert_file_exists "$OUT_DIR/compat-with-direct-beta/response.json"
+assert_file_exists "$OUT_DIR/direct-exact/request.json"
+assert_file_exists "$OUT_DIR/direct-exact/response.json"
+assert_file_exists "$OUT_DIR/shared/request.json"
+assert_file_exists "$OUT_DIR/shared/response.json"
+
+assert_file_contains "$OUT_DIR/summary.txt" "payload_path=$PAYLOAD_PATH"
+assert_file_contains "$OUT_DIR/summary.txt" 'case_count=3'
+assert_file_contains "$OUT_DIR/summary.txt" 'case_files=compat-with-direct-beta.tsv,direct-exact.tsv,shared.tsv'
+assert_file_contains "$OUT_DIR/summary.txt" 'case=compat-with-direct-beta status=400 provider_request_id=req_upstream_case_1'
+assert_file_contains "$OUT_DIR/summary.txt" 'case=direct-exact status=400 provider_request_id=req_upstream_case_2'
+assert_file_contains "$OUT_DIR/summary.txt" 'case=shared status=400 provider_request_id=req_upstream_case_3'
+
+assert_file_contains "$OUT_DIR/direct-exact/request.json" '"authorization": "Bearer <redacted>"'
+assert_file_not_contains "$OUT_DIR/direct-exact/request.json" 'sk-ant-oat-test-token'
+assert_file_contains "$OUT_DIR/direct-exact/request.json" '"x-request-id": "req_issue80_direct_exact"'
+assert_file_not_contains "$OUT_DIR/shared/request.json" '"x-request-id"'
+
+node - "$REQUESTS_JSON" "$PAYLOAD_PATH" <<'NODE'
+const fs = require('fs');
+
+const requests = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+const payload = fs.readFileSync(process.argv[3], 'utf8');
+
+if (requests.length !== 3) {
+  console.error(`expected 3 requests, saw ${requests.length}`);
+  process.exit(1);
+}
+
+const byIndex = new Map(requests.map((entry) => [entry.index, entry]));
+
+function requireHeader(index, name, expected) {
+  const actual = byIndex.get(index)?.headers?.[name];
+  if (actual !== expected) {
+    console.error(`request ${index} expected header ${name}=${expected}, got ${actual}`);
+    process.exit(1);
+  }
+}
+
+function requireMissingHeader(index, name) {
+  if (Object.prototype.hasOwnProperty.call(byIndex.get(index)?.headers ?? {}, name)) {
+    console.error(`request ${index} should not send header ${name}`);
+    process.exit(1);
+  }
+}
+
+for (const entry of requests) {
+  if (entry.method !== 'POST') {
+    console.error(`request ${entry.index} expected POST, got ${entry.method}`);
+    process.exit(1);
+  }
+  if (entry.url !== '/v1/messages') {
+    console.error(`request ${entry.index} expected /v1/messages, got ${entry.url}`);
+    process.exit(1);
+  }
+  if (entry.body !== payload) {
+    console.error(`request ${entry.index} body mismatch`);
+    process.exit(1);
+  }
+  requireHeader(entry.index, 'authorization', 'Bearer sk-ant-oat-test-token');
+}
+
+requireHeader(1, 'anthropic-beta', 'fine-grained-tool-streaming-2025-05-14');
+requireMissingHeader(1, 'x-request-id');
+
+requireHeader(2, 'anthropic-dangerous-direct-browser-access', 'true');
+requireHeader(2, 'user-agent', 'OpenClawGateway/1.0');
+requireHeader(2, 'x-app', 'cli');
+requireHeader(2, 'x-request-id', 'req_issue80_direct_exact');
+
+requireMissingHeader(3, 'anthropic-beta');
+requireMissingHeader(3, 'x-request-id');
+NODE
+
+set +e
+ANTHROPIC_DIRECT_BASE_URL="http://127.0.0.1:$PORT" \
+ANTHROPIC_OAUTH_ACCESS_TOKEN="sk-ant-oat-test-token" \
+"$SCRIPT_PATH" "$PAYLOAD_PATH" "$EMPTY_CASES_DIR" >"$TMP_DIR/empty.stdout.txt" 2>"$TMP_DIR/empty.stderr.txt"
+STATUS=$?
+set -e
+
+if [[ "$STATUS" -eq 0 ]]; then
+  fail "expected empty cases invocation to fail"
+fi
+
+assert_file_contains "$TMP_DIR/empty.stderr.txt" 'no case TSV files found'
+
+echo 'PASS'


### PR DESCRIPTION
Refs #80

## Summary
- add `scripts/innies-compat-exact-case-matrix.sh`, a standalone helper that replays one preserved Anthropic payload through replay-ready `*.tsv` header cases and writes per-case request/response bundles plus a merged summary
- add focused shell coverage for the runner, including an empty-case failure guard
- wire the helper into `scripts/install.sh` and `scripts/README.md`

## Why This Advances #80
- the current issue-80 helper lanes already cover exact case generation and direct replay inputs, but they still leave the operator stitching together the actual controlled case execution by hand
- this adds the missing execution step from replay-ready case TSVs to a concrete matrix run without touching the runtime proxy path or weakening tools / thinking / streaming behavior

## Verification
- `bash scripts/tests/innies-compat-exact-case-matrix.test.sh`
- `bash -n scripts/innies-compat-exact-case-matrix.sh scripts/tests/innies-compat-exact-case-matrix.test.sh scripts/install.sh`
- `TMP_HOME="$(mktemp -d)" && HOME="$TMP_HOME" bash scripts/install.sh >/tmp/issue80-exact-case-matrix-install.out && test -L "$TMP_HOME/.local/bin/innies-compat-exact-case-matrix"`
- `git diff --check`

## Limit
- this shell still has no live Anthropic bearer (`claude auth status` reports `loggedIn: false` and no `ANTHROPIC_*` / `CLAUDE_*` token env is exported), so this PR adds the exact-case runner but does not record a fresh live matrix result from this session
