### PR TITLE
chore: add issue 80 exact-case replay matrix helper

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -25,6 +25,7 @@ innies-buyer-preference-set
 innies-buyer-preference-get
 innies-buyer-preference-check
 innies-slo-check
+innies-compat-exact-case-matrix
 ```
 
 What they do:
@@ -40,6 +41,7 @@ What they do:
 - `innies-buyer-preference-get`: read the current buyer key preference
 - `innies-buyer-preference-check`: run the provider-preference canary after prompting for the expected provider (`Claude Code` or `Codex`)
 - `innies-slo-check`: query analytics endpoints and report Phase 1 SLO pass/fail (TTFB p95, timeout rate, success rate, fallback rate); optional arg sets the window (default `24h`); exits 0 if all SLOs pass, 1 if any fail
+- `innies-compat-exact-case-matrix`: replay a preserved Anthropic `/v1/messages` payload through a directory of exact header-case TSVs and write one direct request/response bundle plus summary per case
 
 Behavior:
 - org id auto-uses `INNIES_ORG_ID`
@@ -79,6 +81,7 @@ Behavior:
 - non-pinned buyer traffic always gets automatic cross-provider fallback to the other provider; flipping preference flips fallback order too
 - `innies-buyer-preference-set` prints the effective preferred provider plus the automatic fallback provider before sending the update
 - `innies-buyer-preference-check` now expects and validates the two-provider plan in DB evidence mode
+- `innies-compat-exact-case-matrix` accepts a payload path plus a directory of replay-ready `*.tsv` header cases and uses `ANTHROPIC_OAUTH_ACCESS_TOKEN`, `ANTHROPIC_ACCESS_TOKEN`, or `CLAUDE_CODE_OAUTH_TOKEN` for the direct Anthropic replay
 
 ## Env
 

--- a/scripts/innies-compat-exact-case-matrix.sh
+++ b/scripts/innies-compat-exact-case-matrix.sh
@@ -1,0 +1,317 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_PATH" ]]; do
+  SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+  SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"
+  [[ "$SCRIPT_PATH" != /* ]] && SCRIPT_PATH="${SCRIPT_DIR}/${SCRIPT_PATH}"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+source "${SCRIPT_DIR}/_common.sh"
+
+resolve_direct_base_url() {
+  if [[ -n "${ANTHROPIC_DIRECT_BASE_URL:-}" ]]; then
+    printf '%s' "${ANTHROPIC_DIRECT_BASE_URL%/}"
+    return
+  fi
+  if [[ -n "${ANTHROPIC_BASE_URL:-}" ]]; then
+    printf '%s' "${ANTHROPIC_BASE_URL%/}"
+    return
+  fi
+  printf '%s' 'https://api.anthropic.com'
+}
+
+resolve_access_token() {
+  if [[ -n "${ANTHROPIC_OAUTH_ACCESS_TOKEN:-}" ]]; then
+    printf '%s\t%s' "${ANTHROPIC_OAUTH_ACCESS_TOKEN}" 'anthropic_oauth_access_token'
+    return
+  fi
+  if [[ -n "${ANTHROPIC_ACCESS_TOKEN:-}" ]]; then
+    printf '%s\t%s' "${ANTHROPIC_ACCESS_TOKEN}" 'anthropic_access_token'
+    return
+  fi
+  if [[ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
+    printf '%s\t%s' "${CLAUDE_CODE_OAUTH_TOKEN}" 'claude_code_oauth_token'
+    return
+  fi
+  echo 'error: missing Anthropic OAuth access token (set ANTHROPIC_OAUTH_ACCESS_TOKEN, ANTHROPIC_ACCESS_TOKEN, or CLAUDE_CODE_OAUTH_TOKEN)' >&2
+  exit 1
+}
+
+extract_header_value() {
+  local name="$1"
+  local file="$2"
+  awk -F'\t' -v target="$name" '
+    BEGIN { IGNORECASE = 1 }
+    tolower($1) == tolower(target) {
+      print $2
+    }
+  ' "$file" | tail -1
+}
+
+extract_response_header() {
+  local name="$1"
+  local file="$2"
+  awk -F': ' -v header_name="$name" '
+    BEGIN { IGNORECASE = 1 }
+    tolower($1) == tolower(header_name) {
+      gsub("\r", "", $2)
+      print $2
+    }
+  ' "$file" | tail -1
+}
+
+extract_body_request_id() {
+  local file="$1"
+  sed -n 's/.*"request_id":"\([^"]*\)".*/\1/p' "$file" | head -n 1
+}
+
+write_lines() {
+  local file="$1"
+  shift
+  printf '%s\n' "$@" >"$file"
+}
+
+PAYLOAD_PATH="${1:-${INNIES_EXACT_CASE_MATRIX_PAYLOAD_PATH:-}}"
+CASES_DIR="${2:-${INNIES_EXACT_CASE_MATRIX_CASES_DIR:-}}"
+require_nonempty 'payload path' "$PAYLOAD_PATH"
+require_nonempty 'cases dir' "$CASES_DIR"
+
+if [[ ! -f "$PAYLOAD_PATH" ]]; then
+  echo "error: payload file not found: $PAYLOAD_PATH" >&2
+  exit 1
+fi
+
+if [[ ! -d "$CASES_DIR" ]]; then
+  echo "error: cases directory not found: $CASES_DIR" >&2
+  exit 1
+fi
+
+CASE_FILES=()
+while IFS= read -r case_file; do
+  CASE_FILES+=("$case_file")
+done < <(find "$CASES_DIR" -maxdepth 1 -type f -name '*.tsv' | LC_ALL=C sort)
+
+if [[ "${#CASE_FILES[@]}" -eq 0 ]]; then
+  echo "error: no case TSV files found in $CASES_DIR" >&2
+  exit 1
+fi
+
+DIRECT_BASE_URL="$(resolve_direct_base_url)"
+DIRECT_PATH="${INNIES_DIRECT_PATH:-/v1/messages}"
+TARGET_URL="${DIRECT_BASE_URL}${DIRECT_PATH}"
+TOKEN_AND_SOURCE="$(resolve_access_token)"
+ACCESS_TOKEN="${TOKEN_AND_SOURCE%%$'\t'*}"
+DIRECT_ACCESS_TOKEN_SOURCE="${TOKEN_AND_SOURCE#*$'\t'}"
+
+REQUEST_ID_PREFIX="${INNIES_EXACT_CASE_MATRIX_REQUEST_ID_PREFIX:-req_issue80_exact_case_$(date -u +%Y%m%dT%H%M%SZ)}"
+OUT_DIR="${INNIES_EXACT_CASE_MATRIX_OUT_DIR:-${TMPDIR:-/tmp}/innies-compat-exact-case-matrix-${REQUEST_ID_PREFIX}}"
+mkdir -p "$OUT_DIR/cases"
+
+PAYLOAD_BYTES="$(wc -c <"$PAYLOAD_PATH" | tr -d '[:space:]')"
+PAYLOAD_SHA256="$(openssl dgst -sha256 -r "$PAYLOAD_PATH" | awk '{print $1}')"
+SUMMARY_FILE="$OUT_DIR/summary.txt"
+SUMMARY_LINES=(
+  "target_url=$TARGET_URL"
+  "body_bytes=$PAYLOAD_BYTES"
+  "body_sha256=$PAYLOAD_SHA256"
+  "case_count=${#CASE_FILES[@]}"
+  "cases_dir=$CASES_DIR"
+  "direct_access_token_source=$DIRECT_ACCESS_TOKEN_SOURCE"
+)
+write_lines "$SUMMARY_FILE" "${SUMMARY_LINES[@]}"
+
+run_case() {
+  local case_file="$1"
+  local case_name
+  case_name="$(basename "$case_file" .tsv)"
+  local case_dir="$OUT_DIR/cases/$case_name"
+  local request_headers_tsv="$case_dir/request-headers.tsv"
+  local response_headers_file="$case_dir/response-headers.txt"
+  local response_body_file="$case_dir/response-body.txt"
+  local request_id="${REQUEST_ID_PREFIX}_${case_name}"
+
+  mkdir -p "$case_dir"
+  printf 'authorization\tBearer <redacted>\n' >"$request_headers_tsv"
+
+  local -a curl_args
+  curl_args=(
+    -sS
+    -D "$response_headers_file"
+    -o "$response_body_file"
+    -w '%{http_code}'
+    -X POST "$TARGET_URL"
+    --data-binary "@$PAYLOAD_PATH"
+  )
+
+  local have_request_id='false'
+  while IFS=$'\t' read -r header_name header_value; do
+    [[ -z "${header_name:-}" ]] && continue
+    header_name="$(trim "$header_name")"
+    header_value="$(trim "${header_value:-}")"
+    [[ -z "$header_name" ]] && continue
+
+    local header_name_normalized
+    header_name_normalized="$(printf '%s' "$header_name" | tr '[:upper:]' '[:lower:]')"
+    case "$header_name_normalized" in
+      authorization|content-length|host|:*)
+        continue
+        ;;
+      x-request-id)
+        header_value="$request_id"
+        have_request_id='true'
+        ;;
+    esac
+
+    curl_args+=(-H "${header_name_normalized}: ${header_value}")
+    printf '%s\t%s\n' "$header_name_normalized" "$header_value" >>"$request_headers_tsv"
+  done <"$case_file"
+
+  if [[ "$have_request_id" != 'true' ]]; then
+    curl_args+=(-H "x-request-id: $request_id")
+    printf 'x-request-id\t%s\n' "$request_id" >>"$request_headers_tsv"
+  fi
+
+  curl_args+=(-H "authorization: Bearer $ACCESS_TOKEN")
+  local status
+  status="$(curl "${curl_args[@]}")"
+
+  local provider_request_id
+  provider_request_id="$(extract_response_header 'request-id' "$response_headers_file")"
+  if [[ -z "$provider_request_id" ]]; then
+    provider_request_id="$(extract_body_request_id "$response_body_file")"
+  fi
+
+  local outcome='unexpected_http_status'
+  if [[ "$status" == 2* ]]; then
+    outcome='request_succeeded'
+  elif [[ "$status" == '400' ]] && grep -q '"type":"invalid_request_error"' "$response_body_file"; then
+    outcome='reproduced_invalid_request_error'
+  fi
+
+  node - "$PAYLOAD_PATH" "$request_headers_tsv" "$response_headers_file" "$response_body_file" "$case_dir" "$case_name" "$request_id" "$TARGET_URL" "$PAYLOAD_BYTES" "$PAYLOAD_SHA256" "$status" "$provider_request_id" <<'NODE'
+const fs = require('fs');
+const path = require('path');
+
+const [
+  payloadPath,
+  requestHeadersTsvPath,
+  responseHeadersPath,
+  responseBodyPath,
+  caseDir,
+  caseName,
+  requestId,
+  targetUrl,
+  payloadBytes,
+  payloadSha256,
+  directStatus,
+  providerRequestId
+] = process.argv.slice(2);
+
+function readHeadersTsv(filePath) {
+  const headers = {};
+  const text = fs.readFileSync(filePath, 'utf8');
+  for (const line of text.split(/\r?\n/)) {
+    if (!line) continue;
+    const parts = line.split('\t');
+    const name = String(parts[0] ?? '').trim().toLowerCase();
+    const value = String(parts.slice(1).join('\t') ?? '').trim();
+    if (!name) continue;
+    headers[name] = value;
+  }
+  return headers;
+}
+
+function readResponseHeaders(filePath) {
+  const headers = {};
+  const text = fs.readFileSync(filePath, 'utf8');
+  for (const line of text.split(/\r?\n/)) {
+    if (!line || !line.includes(':')) continue;
+    const index = line.indexOf(':');
+    const name = line.slice(0, index).trim().toLowerCase();
+    const value = line.slice(index + 1).trim();
+    if (!name) continue;
+    headers[name] = value;
+  }
+  return headers;
+}
+
+const payloadText = fs.readFileSync(payloadPath, 'utf8');
+const payload = JSON.parse(payloadText);
+const requestHeaders = readHeadersTsv(requestHeadersTsvPath);
+const responseHeaders = readResponseHeaders(responseHeadersPath);
+const responseBodyText = fs.readFileSync(responseBodyPath, 'utf8');
+
+let responseBodyJson = null;
+try {
+  responseBodyJson = JSON.parse(responseBodyText);
+} catch {}
+
+const requestRecord = {
+  provider: 'anthropic',
+  case_name: caseName,
+  request_id: requestId,
+  method: 'POST',
+  target_url: targetUrl,
+  headers: requestHeaders,
+  body_bytes: Number(payloadBytes),
+  body_sha256: payloadSha256,
+  stream: Boolean(payload.stream)
+};
+
+const responseRecord = {
+  case_name: caseName,
+  request_id: requestId,
+  status: Number(directStatus),
+  provider_request_id: providerRequestId,
+  headers: responseHeaders,
+  body_json: responseBodyJson,
+  body_text: responseBodyText
+};
+
+fs.writeFileSync(path.join(caseDir, 'payload.json'), `${JSON.stringify(payload, null, 2)}\n`);
+fs.writeFileSync(path.join(caseDir, 'direct-request.json'), `${JSON.stringify(requestRecord, null, 2)}\n`);
+fs.writeFileSync(path.join(caseDir, 'upstream-request.json'), `${JSON.stringify(requestRecord, null, 2)}\n`);
+fs.writeFileSync(path.join(caseDir, 'direct-response.json'), `${JSON.stringify(responseRecord, null, 2)}\n`);
+fs.writeFileSync(path.join(caseDir, 'upstream-response.json'), `${JSON.stringify(responseRecord, null, 2)}\n`);
+NODE
+
+  local identity_headers='false'
+  if [[ "$(extract_header_value 'anthropic-dangerous-direct-browser-access' "$request_headers_tsv")" == 'true' ]]; then
+    identity_headers='true'
+  fi
+
+  local case_summary_file="$case_dir/summary.txt"
+  local -a case_summary_lines
+  case_summary_lines=(
+    "case=$case_name"
+    "status=$status"
+    "outcome=$outcome"
+    "request_id=$request_id"
+    "provider_request_id=${provider_request_id:-}"
+    "body_bytes=$PAYLOAD_BYTES"
+    "body_sha256=$PAYLOAD_SHA256"
+    "anthropic_beta=$(extract_header_value 'anthropic-beta' "$request_headers_tsv")"
+    "identity_headers=$identity_headers"
+    "request_headers_tsv=$request_headers_tsv"
+    "response_headers_file=$response_headers_file"
+    "response_body_file=$response_body_file"
+  )
+  write_lines "$case_summary_file" "${case_summary_lines[@]}"
+
+  printf 'case=%s status=%s outcome=%s provider_request_id=%s anthropic_beta=%s identity_headers=%s\n' \
+    "$case_name" \
+    "$status" \
+    "$outcome" \
+    "${provider_request_id:-}" \
+    "$(extract_header_value 'anthropic-beta' "$request_headers_tsv")" \
+    "$identity_headers" >>"$SUMMARY_FILE"
+}
+
+for case_file in "${CASE_FILES[@]}"; do
+  run_case "$case_file"
+done
+
+cat "$SUMMARY_FILE"
+printf 'summary_file=%s\n' "$SUMMARY_FILE"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,6 +18,7 @@ ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-set.sh" "${BIN_DIR}/innies-b
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-get.sh" "${BIN_DIR}/innies-buyer-preference-get"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-check.sh" "${BIN_DIR}/innies-buyer-preference-check"
 ln -sf "${ROOT_DIR}/scripts/innies-slo-check.sh" "${BIN_DIR}/innies-slo-check"
+ln -sf "${ROOT_DIR}/scripts/innies-compat-exact-case-matrix.sh" "${BIN_DIR}/innies-compat-exact-case-matrix"
 
 rm -f \
   "${BIN_DIR}/innies-admin" \
@@ -49,6 +50,7 @@ echo "  ${BIN_DIR}/innies-buyer-preference-set -> ${ROOT_DIR}/scripts/innies-buy
 echo "  ${BIN_DIR}/innies-buyer-preference-get -> ${ROOT_DIR}/scripts/innies-buyer-preference-get.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-check -> ${ROOT_DIR}/scripts/innies-buyer-preference-check.sh"
 echo "  ${BIN_DIR}/innies-slo-check -> ${ROOT_DIR}/scripts/innies-slo-check.sh"
+echo "  ${BIN_DIR}/innies-compat-exact-case-matrix -> ${ROOT_DIR}/scripts/innies-compat-exact-case-matrix.sh"
 echo
 echo 'If command not found, add ~/.local/bin to PATH:'
 echo '  export PATH="$HOME/.local/bin:$PATH"'

--- a/scripts/tests/innies-compat-exact-case-matrix.test.sh
+++ b/scripts/tests/innies-compat-exact-case-matrix.test.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="$ROOT_DIR/scripts/innies-compat-exact-case-matrix.sh"
+TMP_DIR="$(mktemp -d)"
+PAYLOAD_PATH="$TMP_DIR/payload.json"
+CASES_DIR="$TMP_DIR/cases"
+REQUESTS_DIR="$TMP_DIR/requests"
+OUT_DIR="$TMP_DIR/out"
+STDOUT_PATH="$TMP_DIR/stdout.txt"
+STDERR_PATH="$TMP_DIR/stderr.txt"
+
+cleanup() {
+  if [[ -n "${SERVER_PID:-}" ]]; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$CASES_DIR" "$REQUESTS_DIR"
+
+cat >"$PAYLOAD_PATH" <<'JSON'
+{"model":"claude-opus-4-6","stream":true,"max_tokens":32,"messages":[{"role":"user","content":[{"type":"text","text":"hello from exact case matrix"}]}]}
+JSON
+
+cat >"$CASES_DIR/compat-with-all-direct-deltas.tsv" <<'TSV'
+accept	text/event-stream
+anthropic-beta	fine-grained-tool-streaming-2025-05-14,claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14
+anthropic-dangerous-direct-browser-access	true
+anthropic-version	2023-06-01
+authorization	should-not-pass-through
+content-length	999
+host	api.anthropic.com
+user-agent	OpenClawGateway/1.0
+x-app	cli
+x-request-id	req_should_be_replaced
+TSV
+
+cat >"$CASES_DIR/compat-exact.tsv" <<'TSV'
+accept	text/event-stream
+anthropic-beta	fine-grained-tool-streaming-2025-05-14
+anthropic-version	2023-06-01
+:authority	api.anthropic.com
+TSV
+
+cat >"$TMP_DIR/mock-server.mjs" <<'NODE'
+import { createServer } from 'node:http';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const port = Number(process.env.PORT);
+const requestsDir = process.env.REQUESTS_DIR;
+mkdirSync(requestsDir, { recursive: true });
+
+const mergedBeta = 'fine-grained-tool-streaming-2025-05-14,claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14';
+
+const server = createServer((req, res) => {
+  const chunks = [];
+  req.on('data', (chunk) => chunks.push(chunk));
+  req.on('end', () => {
+    const bodyBuffer = Buffer.concat(chunks);
+    const requestId = String(req.headers['x-request-id'] ?? `unknown-${Date.now()}`);
+    writeFileSync(join(requestsDir, `${requestId}.json`), JSON.stringify({
+      method: req.method,
+      url: req.url,
+      headers: req.headers,
+      bodyText: bodyBuffer.toString('utf8'),
+      bodyBytes: bodyBuffer.length
+    }, null, 2));
+
+    const identityPresent = req.headers['anthropic-dangerous-direct-browser-access'] === 'true'
+      && req.headers['x-app'] === 'cli'
+      && req.headers['user-agent'] === 'OpenClawGateway/1.0';
+    const beta = String(req.headers['anthropic-beta'] ?? '');
+
+    if (beta === mergedBeta && identityPresent) {
+      res.statusCode = 200;
+      res.setHeader('content-type', 'application/json');
+      res.setHeader('request-id', 'req_upstream_exact_case_success');
+      res.end(JSON.stringify({
+        id: 'msg_exact_case_ok',
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'text', text: 'ok' }],
+        stop_reason: 'end_turn'
+      }));
+      return;
+    }
+
+    res.statusCode = 400;
+    res.setHeader('content-type', 'application/json');
+    res.setHeader('request-id', 'req_upstream_exact_case_fail');
+    res.end(JSON.stringify({
+      type: 'error',
+      error: { type: 'invalid_request_error', message: 'Error' },
+      request_id: 'req_upstream_exact_case_fail'
+    }));
+  });
+});
+
+server.listen(port, '127.0.0.1', () => {
+  process.stdout.write(`ready:${port}\n`);
+});
+NODE
+
+PORT="$(node -e "const net=require('node:net');const s=net.createServer();s.listen(0,'127.0.0.1',()=>{const {port}=s.address();console.log(port);s.close();});")"
+PORT="$PORT" REQUESTS_DIR="$REQUESTS_DIR" node "$TMP_DIR/mock-server.mjs" >"$TMP_DIR/server.log" 2>&1 &
+SERVER_PID=$!
+
+for _ in $(seq 1 50); do
+  if grep -q '^ready:' "$TMP_DIR/server.log" 2>/dev/null; then
+    break
+  fi
+  sleep 0.1
+done
+
+if ! grep -q '^ready:' "$TMP_DIR/server.log" 2>/dev/null; then
+  echo 'server did not start' >&2
+  cat "$TMP_DIR/server.log" >&2
+  exit 1
+fi
+
+set +e
+CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat-exact-case-matrix" \
+ANTHROPIC_DIRECT_BASE_URL="http://127.0.0.1:$PORT" \
+INNIES_EXACT_CASE_MATRIX_OUT_DIR="$OUT_DIR" \
+INNIES_EXACT_CASE_MATRIX_REQUEST_ID_PREFIX="req_issue80_exact_case" \
+"$SCRIPT_PATH" "$PAYLOAD_PATH" "$CASES_DIR" >"$STDOUT_PATH" 2>"$STDERR_PATH"
+STATUS=$?
+set -e
+
+if [[ "$STATUS" -ne 0 ]]; then
+  cat "$STDERR_PATH" >&2
+  exit 1
+fi
+
+[[ -f "$OUT_DIR/summary.txt" ]]
+[[ -f "$OUT_DIR/cases/compat-with-all-direct-deltas/summary.txt" ]]
+[[ -f "$OUT_DIR/cases/compat-with-all-direct-deltas/request-headers.tsv" ]]
+[[ -f "$OUT_DIR/cases/compat-with-all-direct-deltas/direct-request.json" ]]
+[[ -f "$OUT_DIR/cases/compat-with-all-direct-deltas/direct-response.json" ]]
+[[ -f "$OUT_DIR/cases/compat-exact/summary.txt" ]]
+[[ -f "$OUT_DIR/cases/compat-exact/request-headers.tsv" ]]
+
+grep -q '^body_bytes=' "$OUT_DIR/summary.txt"
+grep -q '^body_sha256=' "$OUT_DIR/summary.txt"
+grep -q '^case_count=2$' "$OUT_DIR/summary.txt"
+grep -q 'case=compat-with-all-direct-deltas status=200 outcome=request_succeeded provider_request_id=req_upstream_exact_case_success' "$OUT_DIR/summary.txt"
+grep -q 'case=compat-exact status=400 outcome=reproduced_invalid_request_error provider_request_id=req_upstream_exact_case_fail' "$OUT_DIR/summary.txt"
+
+grep -q '^authorization	Bearer <redacted>$' "$OUT_DIR/cases/compat-with-all-direct-deltas/request-headers.tsv"
+if grep -q '^authorization	should-not-pass-through$' "$OUT_DIR/cases/compat-with-all-direct-deltas/request-headers.tsv"; then
+  echo 'redacted request headers should not keep authorization from the case TSV' >&2
+  exit 1
+fi
+if grep -q '^:authority	' "$OUT_DIR/cases/compat-exact/request-headers.tsv"; then
+  echo 'request headers should not keep HTTP/2 pseudo headers' >&2
+  exit 1
+fi
+
+node - "$OUT_DIR" "$REQUESTS_DIR" "$PAYLOAD_PATH" <<'NODE'
+const fs = require('fs');
+const path = require('path');
+const outDir = process.argv[2];
+const requestsDir = process.argv[3];
+const payloadPath = process.argv[4];
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+const payloadBytes = fs.statSync(payloadPath).size;
+const successRequest = readJson(path.join(requestsDir, 'req_issue80_exact_case_compat-with-all-direct-deltas.json'));
+const failRequest = readJson(path.join(requestsDir, 'req_issue80_exact_case_compat-exact.json'));
+const successBundle = readJson(path.join(outDir, 'cases/compat-with-all-direct-deltas/direct-request.json'));
+const failBundle = readJson(path.join(outDir, 'cases/compat-exact/direct-request.json'));
+const successResponse = readJson(path.join(outDir, 'cases/compat-with-all-direct-deltas/direct-response.json'));
+const failResponse = readJson(path.join(outDir, 'cases/compat-exact/direct-response.json'));
+
+if (successRequest.headers.authorization !== 'Bearer sk-ant-oat-exact-case-matrix') {
+  throw new Error('success request did not use the live bearer token');
+}
+if (successRequest.headers['x-request-id'] !== 'req_issue80_exact_case_compat-with-all-direct-deltas') {
+  throw new Error('success request id was not normalized');
+}
+if (successRequest.headers['anthropic-beta'] !== 'fine-grained-tool-streaming-2025-05-14,claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14') {
+  throw new Error('success request beta mismatch');
+}
+if (successRequest.headers.host !== '127.0.0.1:' + String(new URL(successRequest.url, 'http://127.0.0.1').port || '')) {
+  // no-op host check; node sets host automatically for the mock server
+}
+if ('authorization' in successBundle.headers && successBundle.headers.authorization !== 'Bearer <redacted>') {
+  throw new Error('success bundle should redact authorization');
+}
+if (successBundle.body_bytes !== payloadBytes) {
+  throw new Error('success bundle body bytes mismatch');
+}
+if (successResponse.status !== 200) {
+  throw new Error('success response status mismatch');
+}
+if (failRequest.headers['anthropic-beta'] !== 'fine-grained-tool-streaming-2025-05-14') {
+  throw new Error('failure request beta mismatch');
+}
+if ('anthropic-dangerous-direct-browser-access' in failRequest.headers) {
+  throw new Error('failure request should not include identity headers');
+}
+if (failBundle.headers['x-request-id'] !== 'req_issue80_exact_case_compat-exact') {
+  throw new Error('failure bundle request id mismatch');
+}
+if (failResponse.status !== 400) {
+  throw new Error('failure response status mismatch');
+}
+NODE
+
+grep -q '^summary_file=' "$STDOUT_PATH"


### PR DESCRIPTION
## Summary
- add `scripts/innies-compat-exact-case-matrix.sh`, a standalone issue-80 helper that replays a preserved Anthropic `/v1/messages` payload through every `*.tsv` header case in a directory and writes one direct request/response bundle plus summary per case
- filter auth-only / transport-only headers from case TSV input, normalize per-case `x-request-id`, and accept `CLAUDE_CODE_OAUTH_TOKEN` as a direct Anthropic bearer fallback
- wire the helper into `scripts/install.sh` / `scripts/README.md` and cover it with a focused shell regression

## Why
- PR #89 covers a fixed built-in header matrix and PR #107 generates replay-ready exact case TSVs, but `main` still lacks a clean helper that executes an arbitrary exact-case directory as a controlled replay matrix
- this keeps issue #80 on exact first-pass evidence instead of another guessed header tweak
- the runtime proxy path stays untouched

## Verification
- `bash scripts/tests/innies-compat-exact-case-matrix.test.sh`
- `bash -n scripts/innies-compat-exact-case-matrix.sh scripts/tests/innies-compat-exact-case-matrix.test.sh scripts/install.sh`
- `TMP_HOME="$(mktemp -d)" && HOME="$TMP_HOME" bash scripts/install.sh >/tmp/issue80-exact-case-matrix-install.out && test -L "$TMP_HOME/.local/bin/innies-compat-exact-case-matrix"`
- `git diff --check`

Refs #80
