### PR TITLE
chore: add issue 80 exact-case token lane matrix helper

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -94,3 +94,17 @@ For `innies-buyer-preference-check`:
 - `DATABASE_URL` is optional, but needed for DB evidence
 - `INNIES_MODEL_ANTHROPIC` is required if you check Claude Code
 - `INNIES_MODEL_CODEX` is required if you check Codex
+
+## Issue 80 Evidence Helper
+
+```bash
+innies-compat-exact-case-token-lane-matrix /path/to/payload.json /path/to/cases /path/to/token-lanes.tsv
+```
+
+What it does:
+- replays one preserved Anthropic `/v1/messages` payload across every `*.tsv` exact-header case and every bearer lane in a token-matrix TSV
+- writes per-lane/per-case request headers, raw response artifacts, and a merged `summary.txt` under `lanes/<lane>/cases/<case>/`
+- keeps the body and non-auth per-case headers fixed so header deltas and credential-lane deltas can be compared in one run
+
+Token matrix TSV format:
+- one lane per line: `<lane-name><TAB>env:VAR_NAME` or `<lane-name><TAB>literal:TOKEN`

--- a/scripts/innies-compat-exact-case-token-lane-matrix.sh
+++ b/scripts/innies-compat-exact-case-token-lane-matrix.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_PATH" ]]; do
+  SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+  SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"
+  [[ "$SCRIPT_PATH" != /* ]] && SCRIPT_PATH="${SCRIPT_DIR}/${SCRIPT_PATH}"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+source "${SCRIPT_DIR}/_common.sh"
+
+resolve_direct_base_url() {
+  if [[ -n "${ANTHROPIC_DIRECT_BASE_URL:-}" ]]; then
+    printf '%s' "${ANTHROPIC_DIRECT_BASE_URL%/}"
+    return
+  fi
+  if [[ -n "${ANTHROPIC_BASE_URL:-}" ]]; then
+    printf '%s' "${ANTHROPIC_BASE_URL%/}"
+    return
+  fi
+  printf '%s' 'https://api.anthropic.com'
+}
+
+extract_response_header() {
+  local name="$1"
+  local file="$2"
+  awk -F': ' -v header_name="$name" '
+    BEGIN { IGNORECASE = 1 }
+    tolower($1) == tolower(header_name) {
+      gsub("\r", "", $2)
+      print $2
+    }
+  ' "$file" | tail -1
+}
+
+extract_body_request_id() {
+  local file="$1"
+  sed -n 's/.*"request_id":"\([^"]*\)".*/\1/p' "$file" | head -n 1
+}
+
+write_lines() {
+  local file="$1"
+  shift
+  printf '%s\n' "$@" >"$file"
+}
+
+resolve_token_spec() {
+  local token_spec="$1"
+  case "$token_spec" in
+    env:*)
+      local env_name="${token_spec#env:}"
+      require_nonempty 'token env var name' "$env_name"
+      local env_value="${!env_name:-}"
+      if [[ -z "$env_value" ]]; then
+        echo "error: missing token env var: $env_name" >&2
+        exit 1
+      fi
+      printf '%s\t%s' "$env_value" "env:$env_name"
+      ;;
+    literal:*)
+      local literal_value="${token_spec#literal:}"
+      require_nonempty 'literal token value' "$literal_value"
+      printf '%s\tliteral' "$literal_value"
+      ;;
+    *)
+      echo "error: unsupported token source '$token_spec' (expected env:VAR_NAME or literal:TOKEN)" >&2
+      exit 1
+      ;;
+  esac
+}
+
+PAYLOAD_PATH="${1:-${INNIES_EXACT_CASE_TOKEN_LANE_MATRIX_PAYLOAD_PATH:-}}"
+CASES_DIR="${2:-${INNIES_EXACT_CASE_TOKEN_LANE_MATRIX_CASES_DIR:-}}"
+TOKENS_TSV_PATH="${3:-${INNIES_EXACT_CASE_TOKEN_LANE_MATRIX_TOKENS_TSV:-}}"
+require_nonempty 'payload path' "$PAYLOAD_PATH"
+require_nonempty 'cases dir' "$CASES_DIR"
+require_nonempty 'token matrix TSV path' "$TOKENS_TSV_PATH"
+
+if [[ ! -f "$PAYLOAD_PATH" ]]; then
+  echo "error: payload file not found: $PAYLOAD_PATH" >&2
+  exit 1
+fi
+
+if [[ ! -d "$CASES_DIR" ]]; then
+  echo "error: cases directory not found: $CASES_DIR" >&2
+  exit 1
+fi
+
+if [[ ! -f "$TOKENS_TSV_PATH" ]]; then
+  echo "error: token matrix TSV file not found: $TOKENS_TSV_PATH" >&2
+  exit 1
+fi
+
+CASE_FILES=()
+while IFS= read -r case_file; do
+  CASE_FILES+=("$case_file")
+done < <(find "$CASES_DIR" -maxdepth 1 -type f -name '*.tsv' | LC_ALL=C sort)
+
+if [[ "${#CASE_FILES[@]}" -eq 0 ]]; then
+  echo "error: no case TSV files found in $CASES_DIR" >&2
+  exit 1
+fi
+
+DIRECT_BASE_URL="$(resolve_direct_base_url)"
+DIRECT_PATH="${INNIES_DIRECT_PATH:-/v1/messages}"
+TARGET_URL="${DIRECT_BASE_URL}${DIRECT_PATH}"
+REQUEST_ID_PREFIX="${INNIES_EXACT_CASE_TOKEN_LANE_MATRIX_REQUEST_ID_PREFIX:-req_issue80_case_lane_$(date -u +%Y%m%dT%H%M%SZ)}"
+OUT_DIR="${INNIES_EXACT_CASE_TOKEN_LANE_MATRIX_OUT_DIR:-${TMPDIR:-/tmp}/innies-compat-exact-case-token-lane-matrix-${REQUEST_ID_PREFIX}}"
+SUMMARY_FILE="$OUT_DIR/summary.txt"
+mkdir -p "$OUT_DIR/lanes"
+
+PAYLOAD_BYTES="$(wc -c <"$PAYLOAD_PATH" | tr -d '[:space:]')"
+PAYLOAD_SHA256="$(openssl dgst -sha256 -r "$PAYLOAD_PATH" | awk '{print $1}')"
+
+run_case_lane() {
+  local lane_name="$1"
+  local token_spec="$2"
+  local case_file="$3"
+  local token_value_and_source
+  token_value_and_source="$(resolve_token_spec "$token_spec")"
+  local access_token="${token_value_and_source%%$'\t'*}"
+  local token_source="${token_value_and_source#*$'\t'}"
+  local case_name
+  case_name="$(basename "$case_file" .tsv)"
+  local request_id="${REQUEST_ID_PREFIX}_${lane_name}_${case_name}"
+  local case_dir="$OUT_DIR/lanes/$lane_name/cases/$case_name"
+  local request_headers_tsv="$case_dir/request-headers.tsv"
+  local response_headers_file="$case_dir/response-headers.txt"
+  local response_body_file="$case_dir/response-body.txt"
+  local meta_file="$case_dir/meta.txt"
+  mkdir -p "$case_dir"
+
+  declare -a curl_args
+  curl_args=(
+    -sS
+    -D "$response_headers_file"
+    -o "$response_body_file"
+    -w '%{http_code}'
+    -X POST "$TARGET_URL"
+    --data-binary "@$PAYLOAD_PATH"
+  )
+
+  printf 'authorization\tBearer <redacted>\n' >"$request_headers_tsv"
+  local have_request_id='false'
+  while IFS=$'\t' read -r raw_header_name raw_header_value; do
+    [[ -z "${raw_header_name:-}" ]] && continue
+    local header_name
+    local header_value
+    local normalized_name
+    header_name="$(trim "$raw_header_name")"
+    header_value="$(trim "${raw_header_value:-}")"
+    [[ -z "$header_name" ]] && continue
+    normalized_name="$(printf '%s' "$header_name" | tr '[:upper:]' '[:lower:]')"
+    case "$normalized_name" in
+      authorization|content-length|host|:*)
+        continue
+        ;;
+      x-request-id)
+        header_value="$request_id"
+        have_request_id='true'
+        ;;
+    esac
+
+    curl_args+=(-H "${normalized_name}: ${header_value}")
+    printf '%s\t%s\n' "$normalized_name" "$header_value" >>"$request_headers_tsv"
+  done <"$case_file"
+
+  if [[ "$have_request_id" != 'true' ]]; then
+    curl_args+=(-H "x-request-id: $request_id")
+    printf 'x-request-id\t%s\n' "$request_id" >>"$request_headers_tsv"
+  fi
+
+  curl_args+=(-H "authorization: Bearer $access_token")
+
+  local status
+  status="$(curl "${curl_args[@]}")"
+  local provider_request_id
+  provider_request_id="$(extract_response_header 'request-id' "$response_headers_file")"
+  if [[ -z "$provider_request_id" ]]; then
+    provider_request_id="$(extract_body_request_id "$response_body_file")"
+  fi
+
+  local outcome='unexpected_http_status'
+  if [[ "$status" =~ ^2 ]]; then
+    outcome='request_succeeded'
+  elif [[ "$status" == '400' ]] && grep -q '"type":"invalid_request_error"' "$response_body_file"; then
+    outcome='reproduced_invalid_request_error'
+  fi
+
+  local meta_lines=(
+    "lane=$lane_name"
+    "case=$case_name"
+    "status=$status"
+    "outcome=$outcome"
+    "request_id=$request_id"
+    "provider_request_id=${provider_request_id:-}"
+    "token_source=$token_source"
+    "case_file=$case_file"
+    "payload_path=$PAYLOAD_PATH"
+    "target_url=$TARGET_URL"
+    "request_headers_tsv=$request_headers_tsv"
+    "response_headers_file=$response_headers_file"
+    "response_body_file=$response_body_file"
+  )
+  write_lines "$meta_file" "${meta_lines[@]}"
+  printf 'lane=%s case=%s status=%s outcome=%s provider_request_id=%s request_id=%s token_source=%s\n' \
+    "$lane_name" \
+    "$case_name" \
+    "$status" \
+    "$outcome" \
+    "${provider_request_id:-}" \
+    "$request_id" \
+    "$token_source" >>"$SUMMARY_FILE"
+}
+
+lane_count=0
+while IFS=$'\t' read -r raw_lane_name raw_token_spec _; do
+  lane_name="$(trim "${raw_lane_name:-}")"
+  token_spec="$(trim "${raw_token_spec:-}")"
+  [[ -z "$lane_name" ]] && continue
+  [[ "$lane_name" == \#* ]] && continue
+  require_nonempty "token spec for lane '$lane_name'" "$token_spec"
+  if [[ ! "$lane_name" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    echo "error: invalid lane name '$lane_name' (use letters, numbers, dot, underscore, or dash)" >&2
+    exit 1
+  fi
+  for case_file in "${CASE_FILES[@]}"; do
+    run_case_lane "$lane_name" "$token_spec" "$case_file"
+  done
+  lane_count=$((lane_count + 1))
+done <"$TOKENS_TSV_PATH"
+
+if [[ "$lane_count" -eq 0 ]]; then
+  echo "error: no token lanes found in $TOKENS_TSV_PATH" >&2
+  exit 1
+fi
+
+SUMMARY_LINES=(
+  "target_url=$TARGET_URL"
+  "body_bytes=$PAYLOAD_BYTES"
+  "body_sha256=$PAYLOAD_SHA256"
+  "case_count=${#CASE_FILES[@]}"
+  "lane_count=$lane_count"
+  "cases_dir=$CASES_DIR"
+  "token_matrix_tsv=$TOKENS_TSV_PATH"
+)
+{
+  printf '%s\n' "${SUMMARY_LINES[@]}"
+  cat "$SUMMARY_FILE"
+} >"${SUMMARY_FILE}.tmp"
+mv "${SUMMARY_FILE}.tmp" "$SUMMARY_FILE"
+
+cat "$SUMMARY_FILE"
+printf 'summary_file=%s\n' "$SUMMARY_FILE"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,6 +18,7 @@ ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-set.sh" "${BIN_DIR}/innies-b
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-get.sh" "${BIN_DIR}/innies-buyer-preference-get"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-check.sh" "${BIN_DIR}/innies-buyer-preference-check"
 ln -sf "${ROOT_DIR}/scripts/innies-slo-check.sh" "${BIN_DIR}/innies-slo-check"
+ln -sf "${ROOT_DIR}/scripts/innies-compat-exact-case-token-lane-matrix.sh" "${BIN_DIR}/innies-compat-exact-case-token-lane-matrix"
 
 rm -f \
   "${BIN_DIR}/innies-admin" \
@@ -49,6 +50,7 @@ echo "  ${BIN_DIR}/innies-buyer-preference-set -> ${ROOT_DIR}/scripts/innies-buy
 echo "  ${BIN_DIR}/innies-buyer-preference-get -> ${ROOT_DIR}/scripts/innies-buyer-preference-get.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-check -> ${ROOT_DIR}/scripts/innies-buyer-preference-check.sh"
 echo "  ${BIN_DIR}/innies-slo-check -> ${ROOT_DIR}/scripts/innies-slo-check.sh"
+echo "  ${BIN_DIR}/innies-compat-exact-case-token-lane-matrix -> ${ROOT_DIR}/scripts/innies-compat-exact-case-token-lane-matrix.sh"
 echo
 echo 'If command not found, add ~/.local/bin to PATH:'
 echo '  export PATH="$HOME/.local/bin:$PATH"'

--- a/scripts/tests/innies-compat-exact-case-token-lane-matrix.test.sh
+++ b/scripts/tests/innies-compat-exact-case-token-lane-matrix.test.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="$ROOT_DIR/scripts/innies-compat-exact-case-token-lane-matrix.sh"
+TMP_DIR="$(mktemp -d)"
+PAYLOAD_PATH="$TMP_DIR/payload.json"
+CASES_DIR="$TMP_DIR/cases"
+TOKENS_TSV_PATH="$TMP_DIR/token-lanes.tsv"
+REQUESTS_DIR="$TMP_DIR/requests"
+OUT_DIR="$TMP_DIR/out"
+STDOUT_PATH="$TMP_DIR/stdout.txt"
+STDERR_PATH="$TMP_DIR/stderr.txt"
+
+cleanup() {
+  if [[ -n "${SERVER_PID:-}" ]]; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$CASES_DIR" "$REQUESTS_DIR"
+
+cat >"$PAYLOAD_PATH" <<'JSON'
+{"model":"claude-opus-4-6","stream":true,"max_tokens":32,"messages":[{"role":"user","content":[{"type":"text","text":"hello from exact case token lane matrix"}]}]}
+JSON
+
+cat >"$CASES_DIR/compat-exact.tsv" <<'TSV'
+accept	text/event-stream
+anthropic-beta	fine-grained-tool-streaming-2025-05-14
+anthropic-version	2023-06-01
+x-request-id	req_should_be_replaced
+TSV
+
+cat >"$CASES_DIR/compat-with-all-direct-deltas.tsv" <<'TSV'
+accept	text/event-stream
+anthropic-beta	fine-grained-tool-streaming-2025-05-14,claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14
+anthropic-dangerous-direct-browser-access	true
+anthropic-version	2023-06-01
+content-type	application/json
+user-agent	OpenClawGateway/1.0
+x-app	cli
+x-request-id	req_should_be_replaced
+TSV
+
+cat >"$TOKENS_TSV_PATH" <<'TSV'
+lane_alpha	env:ANTHROPIC_TOKEN_ALPHA
+lane_beta	literal:sk-ant-oat-beta-live-token
+TSV
+
+cat >"$TMP_DIR/mock-server.mjs" <<'NODE'
+import { createServer } from 'node:http';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const port = Number(process.env.PORT);
+const requestsDir = process.env.REQUESTS_DIR;
+mkdirSync(requestsDir, { recursive: true });
+
+const mergedBeta = 'fine-grained-tool-streaming-2025-05-14,claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14';
+
+const server = createServer((req, res) => {
+  const chunks = [];
+  req.on('data', (chunk) => chunks.push(chunk));
+  req.on('end', () => {
+    const bodyBuffer = Buffer.concat(chunks);
+    const requestId = String(req.headers['x-request-id'] ?? `unknown-${Date.now()}`);
+    writeFileSync(join(requestsDir, `${requestId}.json`), JSON.stringify({
+      method: req.method,
+      url: req.url,
+      headers: req.headers,
+      bodyText: bodyBuffer.toString('utf8'),
+      bodyBytes: bodyBuffer.length
+    }, null, 2));
+
+    const authHeader = String(req.headers.authorization ?? '');
+    const beta = String(req.headers['anthropic-beta'] ?? '');
+    const identityPresent = req.headers['anthropic-dangerous-direct-browser-access'] === 'true'
+      && req.headers['x-app'] === 'cli'
+      && req.headers['user-agent'] === 'OpenClawGateway/1.0';
+
+    if (authHeader.endsWith('alpha-live-token') && beta === mergedBeta && identityPresent) {
+      res.statusCode = 200;
+      res.setHeader('content-type', 'application/json');
+      res.setHeader('request-id', 'req_provider_alpha_success');
+      res.end(JSON.stringify({
+        id: 'msg_case_lane_ok',
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'text', text: 'ok' }],
+        stop_reason: 'end_turn'
+      }));
+      return;
+    }
+
+    res.statusCode = 400;
+    res.setHeader('content-type', 'application/json');
+    res.setHeader('request-id', 'req_provider_case_lane_fail');
+    res.end(JSON.stringify({
+      type: 'error',
+      error: { type: 'invalid_request_error', message: 'Error' },
+      request_id: 'req_provider_case_lane_fail'
+    }));
+  });
+});
+
+server.listen(port, '127.0.0.1', () => {
+  process.stdout.write(`ready:${port}\n`);
+});
+NODE
+
+PORT="$(node -e "const net=require('node:net');const s=net.createServer();s.listen(0,'127.0.0.1',()=>{const {port}=s.address();console.log(port);s.close();});")"
+PORT="$PORT" REQUESTS_DIR="$REQUESTS_DIR" node "$TMP_DIR/mock-server.mjs" >"$TMP_DIR/server.log" 2>&1 &
+SERVER_PID=$!
+
+for _ in $(seq 1 50); do
+  if grep -q '^ready:' "$TMP_DIR/server.log" 2>/dev/null; then
+    break
+  fi
+  sleep 0.1
+done
+
+if ! grep -q '^ready:' "$TMP_DIR/server.log" 2>/dev/null; then
+  echo 'server did not start' >&2
+  cat "$TMP_DIR/server.log" >&2
+  exit 1
+fi
+
+set +e
+ANTHROPIC_TOKEN_ALPHA="sk-ant-oat-alpha-live-token" \
+ANTHROPIC_DIRECT_BASE_URL="http://127.0.0.1:$PORT" \
+INNIES_EXACT_CASE_TOKEN_LANE_MATRIX_OUT_DIR="$OUT_DIR" \
+INNIES_EXACT_CASE_TOKEN_LANE_MATRIX_REQUEST_ID_PREFIX="req_issue80_case_lane" \
+"$SCRIPT_PATH" "$PAYLOAD_PATH" "$CASES_DIR" "$TOKENS_TSV_PATH" >"$STDOUT_PATH" 2>"$STDERR_PATH"
+STATUS=$?
+set -e
+
+if [[ "$STATUS" -ne 0 ]]; then
+  cat "$STDERR_PATH" >&2
+  exit 1
+fi
+
+[[ -f "$OUT_DIR/summary.txt" ]]
+[[ -f "$OUT_DIR/lanes/lane_alpha/cases/compat-exact/meta.txt" ]]
+[[ -f "$OUT_DIR/lanes/lane_alpha/cases/compat-exact/request-headers.tsv" ]]
+[[ -f "$OUT_DIR/lanes/lane_alpha/cases/compat-exact/response-headers.txt" ]]
+[[ -f "$OUT_DIR/lanes/lane_alpha/cases/compat-exact/response-body.txt" ]]
+[[ -f "$OUT_DIR/lanes/lane_alpha/cases/compat-with-all-direct-deltas/meta.txt" ]]
+[[ -f "$OUT_DIR/lanes/lane_beta/cases/compat-with-all-direct-deltas/meta.txt" ]]
+
+grep -q '^body_bytes=' "$OUT_DIR/summary.txt"
+grep -q '^body_sha256=' "$OUT_DIR/summary.txt"
+grep -q '^case_count=2$' "$OUT_DIR/summary.txt"
+grep -q '^lane_count=2$' "$OUT_DIR/summary.txt"
+grep -q 'lane=lane_alpha case=compat-with-all-direct-deltas status=200 outcome=request_succeeded provider_request_id=req_provider_alpha_success request_id=req_issue80_case_lane_lane_alpha_compat-with-all-direct-deltas token_source=env:ANTHROPIC_TOKEN_ALPHA' "$OUT_DIR/summary.txt"
+grep -q 'lane=lane_alpha case=compat-exact status=400 outcome=reproduced_invalid_request_error provider_request_id=req_provider_case_lane_fail request_id=req_issue80_case_lane_lane_alpha_compat-exact token_source=env:ANTHROPIC_TOKEN_ALPHA' "$OUT_DIR/summary.txt"
+grep -q 'lane=lane_beta case=compat-with-all-direct-deltas status=400 outcome=reproduced_invalid_request_error provider_request_id=req_provider_case_lane_fail request_id=req_issue80_case_lane_lane_beta_compat-with-all-direct-deltas token_source=literal' "$OUT_DIR/summary.txt"
+
+grep -q '^authorization\tBearer <redacted>$' "$OUT_DIR/lanes/lane_alpha/cases/compat-with-all-direct-deltas/request-headers.tsv"
+grep -q '^request_id=req_issue80_case_lane_lane_alpha_compat-with-all-direct-deltas$' "$OUT_DIR/lanes/lane_alpha/cases/compat-with-all-direct-deltas/meta.txt"
+grep -q '^token_source=literal$' "$OUT_DIR/lanes/lane_beta/cases/compat-with-all-direct-deltas/meta.txt"
+grep -q '^summary_file=' "$STDOUT_PATH"
+
+node - "$REQUESTS_DIR" <<'NODE'
+const fs = require('fs');
+const path = require('path');
+const requestsDir = process.argv[2];
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+const alphaSuccess = readJson(path.join(requestsDir, 'req_issue80_case_lane_lane_alpha_compat-with-all-direct-deltas.json'));
+const alphaCompat = readJson(path.join(requestsDir, 'req_issue80_case_lane_lane_alpha_compat-exact.json'));
+const betaSuccessCase = readJson(path.join(requestsDir, 'req_issue80_case_lane_lane_beta_compat-with-all-direct-deltas.json'));
+
+if (alphaSuccess.headers.authorization !== 'Bearer sk-ant-oat-alpha-live-token') {
+  throw new Error('alpha success auth header mismatch');
+}
+if (alphaSuccess.headers['anthropic-beta'] !== 'fine-grained-tool-streaming-2025-05-14,claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14') {
+  throw new Error('alpha success beta mismatch');
+}
+if (alphaCompat.headers['anthropic-beta'] !== 'fine-grained-tool-streaming-2025-05-14') {
+  throw new Error('alpha compat case beta mismatch');
+}
+if (betaSuccessCase.headers.authorization !== 'Bearer sk-ant-oat-beta-live-token') {
+  throw new Error('beta auth header mismatch');
+}
+if (betaSuccessCase.headers['x-app'] !== 'cli') {
+  throw new Error('beta case identity header mismatch');
+}
+NODE
+
+MISSING_TOKENS_TSV_PATH="$TMP_DIR/missing-token-lanes.tsv"
+cat >"$MISSING_TOKENS_TSV_PATH" <<'TSV'
+lane_missing	env:ANTHROPIC_TOKEN_MISSING
+TSV
+
+set +e
+ANTHROPIC_DIRECT_BASE_URL="http://127.0.0.1:$PORT" \
+"$SCRIPT_PATH" "$PAYLOAD_PATH" "$CASES_DIR" "$MISSING_TOKENS_TSV_PATH" >"$STDOUT_PATH" 2>"$STDERR_PATH"
+STATUS=$?
+set -e
+
+if [[ "$STATUS" -eq 0 ]]; then
+  echo 'expected missing env token invocation to fail' >&2
+  exit 1
+fi
+
+grep -q 'missing token env var' "$STDERR_PATH"


### PR DESCRIPTION
## Summary
- add `scripts/innies-compat-exact-case-token-lane-matrix.sh` to run one preserved payload across every exact-case TSV and every Anthropic bearer lane in a single matrix
- write per-lane/per-case request headers, raw response artifacts, and a merged `summary.txt` so header-specific vs credential-lane-specific behavior is visible in one run
- wire the helper into `scripts/install.sh` / `scripts/README.md` and cover it with a focused shell test

## Test Plan
- [x] `bash scripts/tests/innies-compat-exact-case-token-lane-matrix.test.sh`
- [x] `bash -n scripts/innies-compat-exact-case-token-lane-matrix.sh scripts/tests/innies-compat-exact-case-token-lane-matrix.test.sh scripts/install.sh`
- [x] `TMP_HOME="$(mktemp -d)" HOME="$TMP_HOME" bash scripts/install.sh >/tmp/issue80-exact-case-token-lane-install.out && test -L "$TMP_HOME/.local/bin/innies-compat-exact-case-token-lane-matrix"`
- [x] `git diff --check HEAD~1..HEAD`

Refs #80
