### PR TITLE
chore: add issue 80 exact-case summary helper

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -25,6 +25,7 @@ innies-buyer-preference-set
 innies-buyer-preference-get
 innies-buyer-preference-check
 innies-slo-check
+innies-compat-exact-case-summary
 ```
 
 What they do:
@@ -40,6 +41,7 @@ What they do:
 - `innies-buyer-preference-get`: read the current buyer key preference
 - `innies-buyer-preference-check`: run the provider-preference canary after prompting for the expected provider (`Claude Code` or `Codex`)
 - `innies-slo-check`: query analytics endpoints and report Phase 1 SLO pass/fail (TTFB p95, timeout rate, success rate, fallback rate); optional arg sets the window (default `24h`); exits 0 if all SLOs pass, 1 if any fail
+- `innies-compat-exact-case-summary`: summarize exact-case replay artifacts and classify whether the observed behavior looks header-case-specific, credential-lane-specific, mixed, or uniformly failing
 
 Behavior:
 - org id auto-uses `INNIES_ORG_ID`
@@ -79,6 +81,7 @@ Behavior:
 - non-pinned buyer traffic always gets automatic cross-provider fallback to the other provider; flipping preference flips fallback order too
 - `innies-buyer-preference-set` prints the effective preferred provider plus the automatic fallback provider before sending the update
 - `innies-buyer-preference-check` now expects and validates the two-provider plan in DB evidence mode
+- `innies-compat-exact-case-summary` accepts an exact-case matrix output directory from `innies-compat-exact-case-matrix` or `innies-compat-exact-case-token-lane-matrix`, writes `summary.txt` plus `summary.json`, and prints the classification to stdout
 
 ## Env
 

--- a/scripts/innies-compat-exact-case-summary.mjs
+++ b/scripts/innies-compat-exact-case-summary.mjs
@@ -1,0 +1,283 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const [inputDirArg, outDirArg] = process.argv.slice(2);
+
+if (!inputDirArg) {
+  console.error('error: missing matrix input dir');
+  process.exit(1);
+}
+
+if (!outDirArg) {
+  console.error('error: missing summary output dir');
+  process.exit(1);
+}
+
+const inputDir = path.resolve(inputDirArg);
+const outDir = path.resolve(outDirArg);
+
+if (!fs.existsSync(inputDir) || !fs.statSync(inputDir).isDirectory()) {
+  console.error(`error: matrix input dir not found: ${inputDirArg}`);
+  process.exit(1);
+}
+
+fs.mkdirSync(outDir, { recursive: true });
+
+function readKeyValueFile(filePath) {
+  const result = {};
+  const text = fs.readFileSync(filePath, 'utf8');
+  for (const line of text.split(/\r?\n/)) {
+    if (!line || !line.includes('=')) continue;
+    const index = line.indexOf('=');
+    const key = line.slice(0, index).trim();
+    const value = line.slice(index + 1).trim();
+    if (!key) continue;
+    result[key] = value;
+  }
+  return result;
+}
+
+function listDirectories(dirPath) {
+  if (!fs.existsSync(dirPath)) return [];
+  return fs.readdirSync(dirPath, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort();
+}
+
+function normalizeBoolean(value) {
+  return String(value).toLowerCase() === 'true';
+}
+
+function outcomeToken(run) {
+  return `${run.status}:${run.outcome}`;
+}
+
+function joinNames(values) {
+  return values.length > 0 ? values.join(',') : '-';
+}
+
+function parseCaseMatrix(caseNames) {
+  const runs = [];
+  for (const caseName of caseNames) {
+    const summaryPath = path.join(inputDir, 'cases', caseName, 'summary.txt');
+    const summary = readKeyValueFile(summaryPath);
+    const status = Number(summary.status ?? NaN);
+    const outcome = summary.outcome ?? '';
+    if (!Number.isFinite(status) || !outcome) {
+      console.error(`error: invalid case summary file: ${summaryPath}`);
+      process.exit(1);
+    }
+    runs.push({
+      lane: 'direct',
+      case: summary.case || caseName,
+      status,
+      outcome,
+      providerRequestId: summary.provider_request_id || '',
+      anthropicBeta: summary.anthropic_beta || '',
+      identityHeaders: normalizeBoolean(summary.identity_headers || 'false')
+    });
+  }
+  return runs;
+}
+
+function parseCaseLaneMatrix(laneNames) {
+  const runs = [];
+  for (const laneName of laneNames) {
+    const casesRoot = path.join(inputDir, 'lanes', laneName, 'cases');
+    const caseNames = listDirectories(casesRoot);
+    for (const caseName of caseNames) {
+      const metaCandidates = [
+        path.join(casesRoot, caseName, 'meta.txt'),
+        path.join(casesRoot, caseName, 'summary.txt')
+      ];
+      const metaPath = metaCandidates.find((candidate) => fs.existsSync(candidate));
+      if (!metaPath) {
+        continue;
+      }
+      const summary = readKeyValueFile(metaPath);
+      const status = Number(summary.status ?? NaN);
+      const outcome = summary.outcome ?? '';
+      if (!Number.isFinite(status) || !outcome) {
+        console.error(`error: invalid lane/case summary file: ${metaPath}`);
+        process.exit(1);
+      }
+      runs.push({
+        lane: summary.lane || laneName,
+        case: summary.case || caseName,
+        status,
+        outcome,
+        providerRequestId: summary.provider_request_id || '',
+        tokenSource: summary.token_source || ''
+      });
+    }
+  }
+  return runs;
+}
+
+const rootSummaryPath = path.join(inputDir, 'summary.txt');
+const rootSummary = fs.existsSync(rootSummaryPath) ? readKeyValueFile(rootSummaryPath) : {};
+
+const laneNames = listDirectories(path.join(inputDir, 'lanes'));
+const caseNamesFromRoot = listDirectories(path.join(inputDir, 'cases'));
+
+let mode;
+let runs;
+
+if (laneNames.length > 0) {
+  mode = 'case_lane_matrix';
+  runs = parseCaseLaneMatrix(laneNames);
+} else if (caseNamesFromRoot.length > 0) {
+  mode = 'case_matrix';
+  runs = parseCaseMatrix(caseNamesFromRoot);
+} else {
+  console.error(`error: no exact-case matrix artifacts found in ${inputDir}`);
+  process.exit(1);
+}
+
+if (runs.length === 0) {
+  console.error(`error: no runnable matrix entries found in ${inputDir}`);
+  process.exit(1);
+}
+
+const caseNames = [...new Set(runs.map((run) => run.case))].sort();
+const runLaneNames = [...new Set(runs.map((run) => run.lane))].sort();
+const runCount = runs.length;
+const successRuns = runs.filter((run) => run.outcome === 'request_succeeded');
+const invalidRuns = runs.filter((run) => run.outcome === 'reproduced_invalid_request_error');
+const otherRuns = runs.filter((run) => !['request_succeeded', 'reproduced_invalid_request_error'].includes(run.outcome));
+
+const casePatterns = caseNames.map((caseName) =>
+  runLaneNames.map((laneName) => {
+    const run = runs.find((candidate) => candidate.case === caseName && candidate.lane === laneName);
+    return run ? outcomeToken(run) : 'missing';
+  }).join('|')
+);
+
+const lanePatterns = runLaneNames.map((laneName) =>
+  caseNames.map((caseName) => {
+    const run = runs.find((candidate) => candidate.case === caseName && candidate.lane === laneName);
+    return run ? outcomeToken(run) : 'missing';
+  }).join('|')
+);
+
+const uniqueOutcomeTokens = [...new Set(runs.map(outcomeToken))];
+const headerSensitive = caseNames.length > 1 && new Set(casePatterns).size > 1;
+const tokenLaneSensitive = runLaneNames.length > 1 && new Set(lanePatterns).size > 1;
+const allSuccess = successRuns.length === runCount;
+const allInvalidRequest = invalidRuns.length === runCount;
+const uniformFailure = !allSuccess && uniqueOutcomeTokens.length === 1;
+
+let classification = 'non_uniform_failure';
+if (allSuccess) {
+  classification = 'all_success';
+} else if (uniformFailure) {
+  classification = 'uniform_failure_provider_side_candidate';
+} else if (headerSensitive && tokenLaneSensitive) {
+  classification = 'mixed_case_and_lane_specific';
+} else if (headerSensitive) {
+  classification = 'header_case_specific';
+} else if (tokenLaneSensitive) {
+  classification = 'credential_lane_specific';
+}
+
+const caseSummaries = caseNames.map((caseName) => {
+  const caseRuns = runs.filter((run) => run.case === caseName);
+  const successfulLanes = [...new Set(caseRuns.filter((run) => run.outcome === 'request_succeeded').map((run) => run.lane))].sort();
+  const failingLanes = runLaneNames.filter((laneName) => !successfulLanes.includes(laneName));
+  return {
+    case: caseName,
+    successCount: caseRuns.filter((run) => run.outcome === 'request_succeeded').length,
+    invalidRequestCount: caseRuns.filter((run) => run.outcome === 'reproduced_invalid_request_error').length,
+    otherCount: caseRuns.filter((run) => !['request_succeeded', 'reproduced_invalid_request_error'].includes(run.outcome)).length,
+    successfulLanes,
+    failingLanes
+  };
+});
+
+const laneSummaries = runLaneNames.map((laneName) => {
+  const laneRuns = runs.filter((run) => run.lane === laneName);
+  const successfulCases = [...new Set(laneRuns.filter((run) => run.outcome === 'request_succeeded').map((run) => run.case))].sort();
+  const failingCases = caseNames.filter((caseName) => !successfulCases.includes(caseName));
+  return {
+    lane: laneName,
+    successCount: laneRuns.filter((run) => run.outcome === 'request_succeeded').length,
+    invalidRequestCount: laneRuns.filter((run) => run.outcome === 'reproduced_invalid_request_error').length,
+    otherCount: laneRuns.filter((run) => !['request_succeeded', 'reproduced_invalid_request_error'].includes(run.outcome)).length,
+    successfulCases,
+    failingCases
+  };
+});
+
+const successfulCases = caseSummaries.filter((summary) => summary.successCount > 0).map((summary) => summary.case);
+const failingCases = caseSummaries.filter((summary) => summary.successCount === 0).map((summary) => summary.case);
+const successfulLanes = laneSummaries.filter((summary) => summary.successCount > 0).map((summary) => summary.lane);
+const failingLanes = laneSummaries.filter((summary) => summary.successCount === 0).map((summary) => summary.lane);
+
+const output = {
+  mode,
+  inputDir,
+  outputDir: outDir,
+  runCount,
+  caseCount: caseNames.length,
+  laneCount: runLaneNames.length,
+  successCount: successRuns.length,
+  invalidRequestCount: invalidRuns.length,
+  otherCount: otherRuns.length,
+  classification,
+  headerSensitive,
+  tokenLaneSensitive,
+  uniformFailure,
+  allInvalidRequest,
+  allSuccess,
+  successfulCases,
+  failingCases,
+  successfulLanes,
+  failingLanes,
+  rootSummary,
+  caseSummaries,
+  laneSummaries,
+  runs
+};
+
+const summaryLines = [];
+summaryLines.push(`mode=${mode}`);
+summaryLines.push(`input_dir=${inputDir}`);
+summaryLines.push(`run_count=${runCount}`);
+summaryLines.push(`case_count=${caseNames.length}`);
+summaryLines.push(`lane_count=${runLaneNames.length}`);
+if (rootSummary.body_bytes) summaryLines.push(`body_bytes=${rootSummary.body_bytes}`);
+if (rootSummary.body_sha256) summaryLines.push(`body_sha256=${rootSummary.body_sha256}`);
+if (rootSummary.target_url) summaryLines.push(`target_url=${rootSummary.target_url}`);
+summaryLines.push(`success_count=${successRuns.length}`);
+summaryLines.push(`invalid_request_count=${invalidRuns.length}`);
+summaryLines.push(`other_count=${otherRuns.length}`);
+summaryLines.push(`classification=${classification}`);
+summaryLines.push(`header_sensitive=${String(headerSensitive)}`);
+summaryLines.push(`token_lane_sensitive=${String(tokenLaneSensitive)}`);
+summaryLines.push(`uniform_failure=${String(uniformFailure)}`);
+summaryLines.push(`all_invalid_request=${String(allInvalidRequest)}`);
+summaryLines.push(`all_success=${String(allSuccess)}`);
+summaryLines.push(`successful_cases=${joinNames(successfulCases)}`);
+summaryLines.push(`failing_cases=${joinNames(failingCases)}`);
+summaryLines.push(`successful_lanes=${joinNames(successfulLanes)}`);
+summaryLines.push(`failing_lanes=${joinNames(failingLanes)}`);
+
+for (const summary of laneSummaries) {
+  if (mode !== 'case_lane_matrix') {
+    continue;
+  }
+  summaryLines.push(
+    `lane=${summary.lane} success_count=${summary.successCount} invalid_request_count=${summary.invalidRequestCount} successful_cases=${joinNames(summary.successfulCases)} failing_cases=${joinNames(summary.failingCases)}`
+  );
+}
+
+for (const summary of caseSummaries) {
+  summaryLines.push(
+    `case=${summary.case} success_count=${summary.successCount} invalid_request_count=${summary.invalidRequestCount} successful_lanes=${joinNames(summary.successfulLanes)} failing_lanes=${joinNames(summary.failingLanes)}`
+  );
+}
+
+fs.writeFileSync(path.join(outDir, 'summary.json'), `${JSON.stringify(output, null, 2)}\n`);
+fs.writeFileSync(path.join(outDir, 'summary.txt'), `${summaryLines.join('\n')}\n`);

--- a/scripts/innies-compat-exact-case-summary.sh
+++ b/scripts/innies-compat-exact-case-summary.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_PATH" ]]; do
+  SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+  SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"
+  [[ "$SCRIPT_PATH" != /* ]] && SCRIPT_PATH="${SCRIPT_DIR}/${SCRIPT_PATH}"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+source "${SCRIPT_DIR}/_common.sh"
+
+INPUT_DIR="${1:-${INNIES_EXACT_CASE_SUMMARY_INPUT_DIR:-}}"
+require_nonempty 'exact-case matrix input dir' "$INPUT_DIR"
+
+if [[ ! -d "$INPUT_DIR" ]]; then
+  echo "error: matrix input dir not found: $INPUT_DIR" >&2
+  exit 1
+fi
+
+OUT_DIR="${2:-${INNIES_EXACT_CASE_SUMMARY_OUT_DIR:-${INPUT_DIR%/}/analysis}}"
+mkdir -p "$OUT_DIR"
+
+if ! command -v node >/dev/null 2>&1; then
+  echo 'error: node is required for innies-compat-exact-case-summary.sh' >&2
+  exit 1
+fi
+
+node "${SCRIPT_DIR}/innies-compat-exact-case-summary.mjs" "$INPUT_DIR" "$OUT_DIR"
+
+SUMMARY_FILE="$OUT_DIR/summary.txt"
+cat "$SUMMARY_FILE"
+printf 'summary_file=%s\n' "$SUMMARY_FILE"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,6 +18,7 @@ ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-set.sh" "${BIN_DIR}/innies-b
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-get.sh" "${BIN_DIR}/innies-buyer-preference-get"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-check.sh" "${BIN_DIR}/innies-buyer-preference-check"
 ln -sf "${ROOT_DIR}/scripts/innies-slo-check.sh" "${BIN_DIR}/innies-slo-check"
+ln -sf "${ROOT_DIR}/scripts/innies-compat-exact-case-summary.sh" "${BIN_DIR}/innies-compat-exact-case-summary"
 
 rm -f \
   "${BIN_DIR}/innies-admin" \
@@ -49,6 +50,7 @@ echo "  ${BIN_DIR}/innies-buyer-preference-set -> ${ROOT_DIR}/scripts/innies-buy
 echo "  ${BIN_DIR}/innies-buyer-preference-get -> ${ROOT_DIR}/scripts/innies-buyer-preference-get.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-check -> ${ROOT_DIR}/scripts/innies-buyer-preference-check.sh"
 echo "  ${BIN_DIR}/innies-slo-check -> ${ROOT_DIR}/scripts/innies-slo-check.sh"
+echo "  ${BIN_DIR}/innies-compat-exact-case-summary -> ${ROOT_DIR}/scripts/innies-compat-exact-case-summary.sh"
 echo
 echo 'If command not found, add ~/.local/bin to PATH:'
 echo '  export PATH="$HOME/.local/bin:$PATH"'

--- a/scripts/tests/innies-compat-exact-case-summary.test.sh
+++ b/scripts/tests/innies-compat-exact-case-summary.test.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="$ROOT_DIR/scripts/innies-compat-exact-case-summary.sh"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+write_lines() {
+  local file="$1"
+  shift
+  mkdir -p "$(dirname "$file")"
+  printf '%s\n' "$@" >"$file"
+}
+
+case_matrix_dir="$TMP_DIR/case-matrix"
+write_lines "$case_matrix_dir/summary.txt" \
+  "case_count=2" \
+  "case=compat-exact status=400 outcome=reproduced_invalid_request_error provider_request_id=req_case_fail anthropic_beta=fine-grained-tool-streaming-2025-05-14 identity_headers=false" \
+  "case=compat-with-all-direct-deltas status=200 outcome=request_succeeded provider_request_id=req_case_success anthropic_beta=fine-grained-tool-streaming-2025-05-14,claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14 identity_headers=true"
+write_lines "$case_matrix_dir/cases/compat-exact/summary.txt" \
+  "case=compat-exact" \
+  "status=400" \
+  "outcome=reproduced_invalid_request_error" \
+  "provider_request_id=req_case_fail" \
+  "anthropic_beta=fine-grained-tool-streaming-2025-05-14" \
+  "identity_headers=false"
+write_lines "$case_matrix_dir/cases/compat-with-all-direct-deltas/summary.txt" \
+  "case=compat-with-all-direct-deltas" \
+  "status=200" \
+  "outcome=request_succeeded" \
+  "provider_request_id=req_case_success" \
+  "anthropic_beta=fine-grained-tool-streaming-2025-05-14,claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14" \
+  "identity_headers=true"
+
+case_lane_dir="$TMP_DIR/case-lane-matrix"
+write_lines "$case_lane_dir/summary.txt" \
+  "case_count=2" \
+  "lane_count=2" \
+  "lane=lane_alpha case=compat-exact status=400 outcome=reproduced_invalid_request_error provider_request_id=req_alpha_fail request_id=req_alpha_case_fail token_source=env:ANTHROPIC_TOKEN_ALPHA" \
+  "lane=lane_alpha case=compat-with-all-direct-deltas status=200 outcome=request_succeeded provider_request_id=req_alpha_success request_id=req_alpha_case_success token_source=env:ANTHROPIC_TOKEN_ALPHA" \
+  "lane=lane_beta case=compat-exact status=400 outcome=reproduced_invalid_request_error provider_request_id=req_beta_fail request_id=req_beta_case_fail token_source=literal" \
+  "lane=lane_beta case=compat-with-all-direct-deltas status=400 outcome=reproduced_invalid_request_error provider_request_id=req_beta_fail request_id=req_beta_case_fail_2 token_source=literal"
+write_lines "$case_lane_dir/lanes/lane_alpha/cases/compat-exact/meta.txt" \
+  "lane=lane_alpha" \
+  "case=compat-exact" \
+  "status=400" \
+  "outcome=reproduced_invalid_request_error" \
+  "provider_request_id=req_alpha_fail" \
+  "token_source=env:ANTHROPIC_TOKEN_ALPHA"
+write_lines "$case_lane_dir/lanes/lane_alpha/cases/compat-with-all-direct-deltas/meta.txt" \
+  "lane=lane_alpha" \
+  "case=compat-with-all-direct-deltas" \
+  "status=200" \
+  "outcome=request_succeeded" \
+  "provider_request_id=req_alpha_success" \
+  "token_source=env:ANTHROPIC_TOKEN_ALPHA"
+write_lines "$case_lane_dir/lanes/lane_beta/cases/compat-exact/meta.txt" \
+  "lane=lane_beta" \
+  "case=compat-exact" \
+  "status=400" \
+  "outcome=reproduced_invalid_request_error" \
+  "provider_request_id=req_beta_fail" \
+  "token_source=literal"
+write_lines "$case_lane_dir/lanes/lane_beta/cases/compat-with-all-direct-deltas/meta.txt" \
+  "lane=lane_beta" \
+  "case=compat-with-all-direct-deltas" \
+  "status=400" \
+  "outcome=reproduced_invalid_request_error" \
+  "provider_request_id=req_beta_fail" \
+  "token_source=literal"
+
+uniform_failure_dir="$TMP_DIR/uniform-failure"
+write_lines "$uniform_failure_dir/summary.txt" \
+  "case_count=2" \
+  "lane_count=2" \
+  "lane=lane_alpha case=compat-exact status=400 outcome=reproduced_invalid_request_error provider_request_id=req_uniform_fail request_id=req_uniform_a_case_exact token_source=env:ANTHROPIC_TOKEN_ALPHA" \
+  "lane=lane_alpha case=compat-with-direct-identity status=400 outcome=reproduced_invalid_request_error provider_request_id=req_uniform_fail request_id=req_uniform_a_case_identity token_source=env:ANTHROPIC_TOKEN_ALPHA" \
+  "lane=lane_beta case=compat-exact status=400 outcome=reproduced_invalid_request_error provider_request_id=req_uniform_fail request_id=req_uniform_b_case_exact token_source=literal" \
+  "lane=lane_beta case=compat-with-direct-identity status=400 outcome=reproduced_invalid_request_error provider_request_id=req_uniform_fail request_id=req_uniform_b_case_identity token_source=literal"
+write_lines "$uniform_failure_dir/lanes/lane_alpha/cases/compat-exact/meta.txt" \
+  "lane=lane_alpha" \
+  "case=compat-exact" \
+  "status=400" \
+  "outcome=reproduced_invalid_request_error" \
+  "provider_request_id=req_uniform_fail" \
+  "token_source=env:ANTHROPIC_TOKEN_ALPHA"
+write_lines "$uniform_failure_dir/lanes/lane_alpha/cases/compat-with-direct-identity/meta.txt" \
+  "lane=lane_alpha" \
+  "case=compat-with-direct-identity" \
+  "status=400" \
+  "outcome=reproduced_invalid_request_error" \
+  "provider_request_id=req_uniform_fail" \
+  "token_source=env:ANTHROPIC_TOKEN_ALPHA"
+write_lines "$uniform_failure_dir/lanes/lane_beta/cases/compat-exact/meta.txt" \
+  "lane=lane_beta" \
+  "case=compat-exact" \
+  "status=400" \
+  "outcome=reproduced_invalid_request_error" \
+  "provider_request_id=req_uniform_fail" \
+  "token_source=literal"
+write_lines "$uniform_failure_dir/lanes/lane_beta/cases/compat-with-direct-identity/meta.txt" \
+  "lane=lane_beta" \
+  "case=compat-with-direct-identity" \
+  "status=400" \
+  "outcome=reproduced_invalid_request_error" \
+  "provider_request_id=req_uniform_fail" \
+  "token_source=literal"
+
+run_summary() {
+  local input_dir="$1"
+  local output_dir="$2"
+  local stdout_path="$3"
+  local stderr_path="$4"
+  INNIES_EXACT_CASE_SUMMARY_OUT_DIR="$output_dir" "$SCRIPT_PATH" "$input_dir" >"$stdout_path" 2>"$stderr_path"
+}
+
+run_summary "$case_matrix_dir" "$TMP_DIR/case-matrix-summary" "$TMP_DIR/case-matrix.stdout" "$TMP_DIR/case-matrix.stderr"
+run_summary "$case_lane_dir" "$TMP_DIR/case-lane-summary" "$TMP_DIR/case-lane.stdout" "$TMP_DIR/case-lane.stderr"
+run_summary "$uniform_failure_dir" "$TMP_DIR/uniform-failure-summary" "$TMP_DIR/uniform-failure.stdout" "$TMP_DIR/uniform-failure.stderr"
+
+[[ -f "$TMP_DIR/case-matrix-summary/summary.txt" ]]
+[[ -f "$TMP_DIR/case-matrix-summary/summary.json" ]]
+grep -q '^mode=case_matrix$' "$TMP_DIR/case-matrix-summary/summary.txt"
+grep -q '^classification=header_case_specific$' "$TMP_DIR/case-matrix-summary/summary.txt"
+grep -q '^header_sensitive=true$' "$TMP_DIR/case-matrix-summary/summary.txt"
+grep -q '^token_lane_sensitive=false$' "$TMP_DIR/case-matrix-summary/summary.txt"
+grep -q '^successful_cases=compat-with-all-direct-deltas$' "$TMP_DIR/case-matrix-summary/summary.txt"
+grep -q '^failing_cases=compat-exact$' "$TMP_DIR/case-matrix-summary/summary.txt"
+grep -q '^summary_file=' "$TMP_DIR/case-matrix.stdout"
+
+[[ -f "$TMP_DIR/case-lane-summary/summary.txt" ]]
+[[ -f "$TMP_DIR/case-lane-summary/summary.json" ]]
+grep -q '^mode=case_lane_matrix$' "$TMP_DIR/case-lane-summary/summary.txt"
+grep -q '^classification=mixed_case_and_lane_specific$' "$TMP_DIR/case-lane-summary/summary.txt"
+grep -q '^header_sensitive=true$' "$TMP_DIR/case-lane-summary/summary.txt"
+grep -q '^token_lane_sensitive=true$' "$TMP_DIR/case-lane-summary/summary.txt"
+grep -q '^successful_lanes=lane_alpha$' "$TMP_DIR/case-lane-summary/summary.txt"
+grep -q '^failing_lanes=lane_beta$' "$TMP_DIR/case-lane-summary/summary.txt"
+grep -q '^lane=lane_alpha success_count=1 invalid_request_count=1 successful_cases=compat-with-all-direct-deltas failing_cases=compat-exact$' "$TMP_DIR/case-lane-summary/summary.txt"
+grep -q '^case=compat-with-all-direct-deltas success_count=1 invalid_request_count=1 successful_lanes=lane_alpha failing_lanes=lane_beta$' "$TMP_DIR/case-lane-summary/summary.txt"
+
+[[ -f "$TMP_DIR/uniform-failure-summary/summary.txt" ]]
+[[ -f "$TMP_DIR/uniform-failure-summary/summary.json" ]]
+grep -q '^classification=uniform_failure_provider_side_candidate$' "$TMP_DIR/uniform-failure-summary/summary.txt"
+grep -q '^uniform_failure=true$' "$TMP_DIR/uniform-failure-summary/summary.txt"
+grep -q '^all_invalid_request=true$' "$TMP_DIR/uniform-failure-summary/summary.txt"
+
+node - "$TMP_DIR/case-matrix-summary/summary.json" "$TMP_DIR/case-lane-summary/summary.json" "$TMP_DIR/uniform-failure-summary/summary.json" <<'NODE'
+const fs = require('fs');
+
+const [caseMatrixPath, caseLanePath, uniformFailurePath] = process.argv.slice(2);
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+const caseMatrix = readJson(caseMatrixPath);
+const caseLane = readJson(caseLanePath);
+const uniformFailure = readJson(uniformFailurePath);
+
+if (caseMatrix.classification !== 'header_case_specific') {
+  throw new Error('case matrix classification mismatch');
+}
+if (caseMatrix.mode !== 'case_matrix') {
+  throw new Error('case matrix mode mismatch');
+}
+if (caseMatrix.caseSummaries.length !== 2) {
+  throw new Error('case matrix summary count mismatch');
+}
+if (caseLane.classification !== 'mixed_case_and_lane_specific') {
+  throw new Error('case lane classification mismatch');
+}
+if (caseLane.laneSummaries.length !== 2) {
+  throw new Error('case lane summary count mismatch');
+}
+if (caseLane.caseSummaries.length !== 2) {
+  throw new Error('case lane case summary count mismatch');
+}
+if (uniformFailure.classification !== 'uniform_failure_provider_side_candidate') {
+  throw new Error('uniform failure classification mismatch');
+}
+if (uniformFailure.uniformFailure !== true) {
+  throw new Error('uniform failure flag mismatch');
+}
+NODE


### PR DESCRIPTION
## Summary
- add `scripts/innies-compat-exact-case-summary.sh` plus `scripts/innies-compat-exact-case-summary.mjs` to classify exact-case replay artifacts as header-case-specific, credential-lane-specific, mixed, or uniform failures
- support both single-lane exact-case matrix bundles and multi-lane exact-case token-lane matrix bundles, writing `summary.txt` plus `summary.json` for issue-80 handoffs
- wire the helper into `scripts/install.sh` / `scripts/README.md` and add focused shell coverage

## Test Plan
- [x] `bash scripts/tests/innies-compat-exact-case-summary.test.sh`
- [x] `bash -n scripts/innies-compat-exact-case-summary.sh scripts/tests/innies-compat-exact-case-summary.test.sh scripts/install.sh`
- [x] `node --check scripts/innies-compat-exact-case-summary.mjs`
- [x] `TMP_HOME="$(mktemp -d)" HOME="$TMP_HOME" bash scripts/install.sh >/tmp/issue80-exact-case-summary-install.out && test -L "$TMP_HOME/.local/bin/innies-compat-exact-case-summary"`
- [x] `git diff --check`

Refs #80
