### PR TITLE
chore: add issue 80 exact case outcome summary helper

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -25,6 +25,7 @@ innies-buyer-preference-set
 innies-buyer-preference-get
 innies-buyer-preference-check
 innies-slo-check
+innies-compat-exact-case-outcome-summary
 ```
 
 What they do:
@@ -40,6 +41,7 @@ What they do:
 - `innies-buyer-preference-get`: read the current buyer key preference
 - `innies-buyer-preference-check`: run the provider-preference canary after prompting for the expected provider (`Claude Code` or `Codex`)
 - `innies-slo-check`: query analytics endpoints and report Phase 1 SLO pass/fail (TTFB p95, timeout rate, success rate, fallback rate); optional arg sets the window (default `24h`); exits 0 if all SLOs pass, 1 if any fail
+- `innies-compat-exact-case-outcome-summary`: summarize an issue-80 exact-case `summary.txt` into case-level vs token-lane-level outcome flips, plus `case-summary.tsv` and `lane-summary.tsv`
 
 Behavior:
 - org id auto-uses `INNIES_ORG_ID`
@@ -73,6 +75,7 @@ Behavior:
 - `innies-token-usage-refresh` lists unexpired Claude credentials in `active|paused|maxed`, plus expired Claude OAuth credentials that still have a stored refresh token (shown as `expired`) so you can recover them manually
 - `innies-token-usage-refresh` also needs `INNIES_ADMIN_API_KEY` (or prompts for it) because it calls the admin API provider-usage refresh endpoint directly
 - `innies-token-usage-refresh` bypasses in-memory usage-fetch backoff and prints both parsed 5h / 7d usage plus the raw Anthropic payload
+- `innies-compat-exact-case-outcome-summary` accepts either a matrix output directory or a direct `summary.txt` path; by default it writes `outcome-summary.txt`, `case-summary.tsv`, and `lane-summary.tsv` alongside the source summary
 - `label` maps to API field `debugLabel`
 - set/get preference accept either the buyer-key UUID or the live buyer key value; live-key lookup uses `DATABASE_URL`
 - script-side default provider display for `null` preference follows `BUYER_PROVIDER_PREFERENCE_DEFAULT` (legacy alias `INNIES_BUYER_PROVIDER_PREFERENCE_DEFAULT` also works)

--- a/scripts/innies-compat-exact-case-outcome-summary.sh
+++ b/scripts/innies-compat-exact-case-outcome-summary.sh
@@ -1,0 +1,289 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_PATH" ]]; do
+  SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+  SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"
+  [[ "$SCRIPT_PATH" != /* ]] && SCRIPT_PATH="${SCRIPT_DIR}/${SCRIPT_PATH}"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+source "${SCRIPT_DIR}/_common.sh"
+
+INPUT_PATH="${1:-${INNIES_EXACT_CASE_OUTCOME_SUMMARY_INPUT:-}}"
+require_nonempty 'summary input path' "$INPUT_PATH"
+
+SUMMARY_PATH="$INPUT_PATH"
+if [[ -d "$INPUT_PATH" ]]; then
+  SUMMARY_PATH="${INPUT_PATH%/}/summary.txt"
+fi
+
+if [[ ! -f "$SUMMARY_PATH" ]]; then
+  echo "error: summary file not found: $SUMMARY_PATH" >&2
+  exit 1
+fi
+
+SOURCE_DIR="$(cd "$(dirname "$SUMMARY_PATH")" && pwd)"
+OUT_DIR="${INNIES_EXACT_CASE_OUTCOME_SUMMARY_OUT_DIR:-$SOURCE_DIR}"
+mkdir -p "$OUT_DIR"
+
+OUTCOME_SUMMARY_FILE="$OUT_DIR/outcome-summary.txt"
+CASE_SUMMARY_FILE="$OUT_DIR/case-summary.tsv"
+LANE_SUMMARY_FILE="$OUT_DIR/lane-summary.tsv"
+
+node - "$SUMMARY_PATH" "$OUT_DIR" "$OUTCOME_SUMMARY_FILE" "$CASE_SUMMARY_FILE" "$LANE_SUMMARY_FILE" <<'NODE'
+const fs = require('fs');
+
+const [
+  summaryPath,
+  outDir,
+  outcomeSummaryPath,
+  caseSummaryPath,
+  laneSummaryPath
+] = process.argv.slice(2);
+
+function parseKeyValueLine(line) {
+  const index = line.indexOf('=');
+  if (index === -1) {
+    return null;
+  }
+  return {
+    key: line.slice(0, index),
+    value: line.slice(index + 1)
+  };
+}
+
+function parseRunLine(line) {
+  const entry = {};
+  for (const token of line.split(/\s+/)) {
+    const parsed = parseKeyValueLine(token);
+    if (!parsed) {
+      continue;
+    }
+    entry[parsed.key] = parsed.value;
+  }
+  if (!entry.case || !entry.status || !entry.outcome) {
+    throw new Error(`malformed case outcome row: ${line}`);
+  }
+  if (!entry.lane) {
+    entry.lane = 'single_lane';
+  }
+  return {
+    lane: entry.lane,
+    caseName: entry.case,
+    status: entry.status,
+    outcome: entry.outcome,
+    providerRequestId: entry.provider_request_id ?? '',
+    requestId: entry.request_id ?? '',
+    tokenSource: entry.token_source ?? ''
+  };
+}
+
+function sortStatuses(values) {
+  return Array.from(new Set(values)).sort((left, right) => Number(left) - Number(right));
+}
+
+function uniqueInRunOrder(runs, pick) {
+  const seen = new Set();
+  const ordered = [];
+  for (const run of runs) {
+    const value = pick(run);
+    if (seen.has(value)) {
+      continue;
+    }
+    seen.add(value);
+    ordered.push(value);
+  }
+  return ordered;
+}
+
+function joinNames(values) {
+  if (values.length === 0) {
+    return 'none';
+  }
+  return values.join(',');
+}
+
+function isSuccess(run) {
+  return run.status.startsWith('2') || run.outcome === 'request_succeeded';
+}
+
+const text = fs.readFileSync(summaryPath, 'utf8');
+const headers = {};
+const runs = [];
+let sawExplicitLane = false;
+
+for (const rawLine of text.split(/\r?\n/)) {
+  const line = rawLine.trim();
+  if (!line) {
+    continue;
+  }
+  if (line.startsWith('lane=') || line.startsWith('case=')) {
+    const run = parseRunLine(line);
+    if (line.startsWith('lane=')) {
+      sawExplicitLane = true;
+    }
+    runs.push(run);
+    continue;
+  }
+  const parsed = parseKeyValueLine(line);
+  if (!parsed) {
+    continue;
+  }
+  headers[parsed.key] = parsed.value;
+}
+
+if (runs.length === 0) {
+  console.error('error: no case outcome rows found');
+  process.exit(1);
+}
+
+fs.mkdirSync(outDir, { recursive: true });
+
+const matrixType = sawExplicitLane ? 'exact_case_token_lane' : 'exact_case';
+const allRunsSorted = [...runs].sort((left, right) => {
+  const statusDiff = Number(left.status) - Number(right.status);
+  if (statusDiff !== 0) {
+    return statusDiff;
+  }
+  const outcomeDiff = left.outcome.localeCompare(right.outcome);
+  if (outcomeDiff !== 0) {
+    return outcomeDiff;
+  }
+  const laneDiff = left.lane.localeCompare(right.lane);
+  if (laneDiff !== 0) {
+    return laneDiff;
+  }
+  return left.caseName.localeCompare(right.caseName);
+});
+
+const caseNames = Array.from(new Set(runs.map((run) => run.caseName))).sort();
+const laneNames = Array.from(new Set(runs.map((run) => run.lane))).sort();
+const statuses = sortStatuses(runs.map((run) => run.status));
+const outcomes = uniqueInRunOrder(allRunsSorted, (run) => run.outcome);
+
+const runsByLane = new Map();
+for (const laneName of laneNames) {
+  runsByLane.set(
+    laneName,
+    allRunsSorted.filter((run) => run.lane === laneName)
+  );
+}
+
+const runsByCase = new Map();
+for (const caseName of caseNames) {
+  runsByCase.set(
+    caseName,
+    allRunsSorted.filter((run) => run.caseName === caseName)
+  );
+}
+
+const caseAxisFlips = laneNames.some((laneName) => {
+  const laneRuns = runsByLane.get(laneName) ?? [];
+  return new Set(laneRuns.map((run) => run.outcome)).size > 1;
+});
+
+const laneAxisFlips = caseNames.some((caseName) => {
+  const caseRuns = runsByCase.get(caseName) ?? [];
+  return new Set(caseRuns.map((run) => run.outcome)).size > 1;
+});
+
+let axisClassification = 'no_controlled_axis_flip';
+let inference = 'remaining_delta_outside_controlled_case_or_lane_matrix';
+if (caseAxisFlips && laneAxisFlips) {
+  axisClassification = 'case_and_lane';
+  inference = 'controlled_case_and_token_lane_changes_flip_outcome';
+} else if (caseAxisFlips) {
+  axisClassification = 'case_only';
+  inference = 'controlled_case_changes_flip_outcome';
+} else if (laneAxisFlips) {
+  axisClassification = 'lane_only';
+  inference = 'controlled_token_lane_changes_flip_outcome';
+}
+
+const successfulCases = caseNames.filter((caseName) => {
+  const caseRuns = runsByCase.get(caseName) ?? [];
+  return caseRuns.some(isSuccess);
+});
+const successfulLanes = laneNames.filter((laneName) => {
+  const laneRuns = runsByLane.get(laneName) ?? [];
+  return laneRuns.some(isSuccess);
+});
+const failingCases = caseNames.filter((caseName) => !successfulCases.includes(caseName));
+const failingLanes = laneNames.filter((laneName) => !successfulLanes.includes(laneName));
+
+const caseSummaryLines = [
+  'case\trun_count\tlane_count\tstatuses\toutcomes\tsuccess_lanes\tfailing_lanes'
+];
+for (const caseName of caseNames) {
+  const caseRuns = runsByCase.get(caseName) ?? [];
+  const caseStatuses = sortStatuses(caseRuns.map((run) => run.status));
+  const caseOutcomes = uniqueInRunOrder(caseRuns, (run) => run.outcome);
+  const caseSuccessLanes = Array.from(
+    new Set(caseRuns.filter(isSuccess).map((run) => run.lane))
+  ).sort();
+  const caseFailingLanes = laneNames.filter((laneName) => !caseSuccessLanes.includes(laneName));
+  caseSummaryLines.push([
+    caseName,
+    String(caseRuns.length),
+    String(new Set(caseRuns.map((run) => run.lane)).size),
+    caseStatuses.join(','),
+    caseOutcomes.join(','),
+    joinNames(caseSuccessLanes),
+    joinNames(caseFailingLanes)
+  ].join('\t'));
+}
+
+const laneSummaryLines = [
+  'lane\trun_count\tcase_count\tstatuses\toutcomes\tsuccess_cases\tfailing_cases'
+];
+for (const laneName of laneNames) {
+  const laneRuns = runsByLane.get(laneName) ?? [];
+  const laneStatuses = sortStatuses(laneRuns.map((run) => run.status));
+  const laneOutcomes = uniqueInRunOrder(laneRuns, (run) => run.outcome);
+  const laneSuccessCases = Array.from(
+    new Set(laneRuns.filter(isSuccess).map((run) => run.caseName))
+  ).sort();
+  const laneFailingCases = caseNames.filter((caseName) => !laneSuccessCases.includes(caseName));
+  laneSummaryLines.push([
+    laneName,
+    String(laneRuns.length),
+    String(new Set(laneRuns.map((run) => run.caseName)).size),
+    laneStatuses.join(','),
+    laneOutcomes.join(','),
+    joinNames(laneSuccessCases),
+    joinNames(laneFailingCases)
+  ].join('\t'));
+}
+
+const outcomeSummaryLines = [
+  `source_summary=${summaryPath}`,
+  `target_url=${headers.target_url ?? ''}`,
+  `body_bytes=${headers.body_bytes ?? ''}`,
+  `body_sha256=${headers.body_sha256 ?? ''}`,
+  `matrix_type=${matrixType}`,
+  `run_count=${runs.length}`,
+  `case_count=${caseNames.length}`,
+  `lane_count=${laneNames.length}`,
+  `unique_statuses=${statuses.join(',')}`,
+  `unique_outcomes=${outcomes.join(',')}`,
+  `case_axis_flips=${caseAxisFlips}`,
+  `lane_axis_flips=${laneAxisFlips}`,
+  `all_runs_same_outcome=${new Set(runs.map((run) => run.outcome)).size === 1}`,
+  `axis_classification=${axisClassification}`,
+  `inference=${inference}`,
+  `successful_cases=${joinNames(successfulCases)}`,
+  `failing_cases=${joinNames(failingCases)}`,
+  `successful_lanes=${joinNames(successfulLanes)}`,
+  `failing_lanes=${joinNames(failingLanes)}`
+];
+
+fs.writeFileSync(caseSummaryPath, `${caseSummaryLines.join('\n')}\n`);
+fs.writeFileSync(laneSummaryPath, `${laneSummaryLines.join('\n')}\n`);
+fs.writeFileSync(outcomeSummaryPath, `${outcomeSummaryLines.join('\n')}\n`);
+NODE
+
+cat "$OUTCOME_SUMMARY_FILE"
+printf 'summary_file=%s\n' "$OUTCOME_SUMMARY_FILE"
+printf 'case_summary_file=%s\n' "$CASE_SUMMARY_FILE"
+printf 'lane_summary_file=%s\n' "$LANE_SUMMARY_FILE"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,6 +18,7 @@ ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-set.sh" "${BIN_DIR}/innies-b
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-get.sh" "${BIN_DIR}/innies-buyer-preference-get"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-check.sh" "${BIN_DIR}/innies-buyer-preference-check"
 ln -sf "${ROOT_DIR}/scripts/innies-slo-check.sh" "${BIN_DIR}/innies-slo-check"
+ln -sf "${ROOT_DIR}/scripts/innies-compat-exact-case-outcome-summary.sh" "${BIN_DIR}/innies-compat-exact-case-outcome-summary"
 
 rm -f \
   "${BIN_DIR}/innies-admin" \
@@ -49,6 +50,7 @@ echo "  ${BIN_DIR}/innies-buyer-preference-set -> ${ROOT_DIR}/scripts/innies-buy
 echo "  ${BIN_DIR}/innies-buyer-preference-get -> ${ROOT_DIR}/scripts/innies-buyer-preference-get.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-check -> ${ROOT_DIR}/scripts/innies-buyer-preference-check.sh"
 echo "  ${BIN_DIR}/innies-slo-check -> ${ROOT_DIR}/scripts/innies-slo-check.sh"
+echo "  ${BIN_DIR}/innies-compat-exact-case-outcome-summary -> ${ROOT_DIR}/scripts/innies-compat-exact-case-outcome-summary.sh"
 echo
 echo 'If command not found, add ~/.local/bin to PATH:'
 echo '  export PATH="$HOME/.local/bin:$PATH"'

--- a/scripts/tests/innies-compat-exact-case-outcome-summary.test.sh
+++ b/scripts/tests/innies-compat-exact-case-outcome-summary.test.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="$ROOT_DIR/scripts/innies-compat-exact-case-outcome-summary.sh"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+write_multi_axis_fixture() {
+  local dir="$1"
+  mkdir -p "$dir"
+  cat >"$dir/summary.txt" <<'EOF'
+target_url=https://api.anthropic.com/v1/messages
+body_bytes=393038
+body_sha256=abc123
+case_count=3
+lane_count=2
+cases_dir=/tmp/cases
+token_matrix_tsv=/tmp/token-matrix.tsv
+lane=lane_alpha case=compat-exact status=400 outcome=reproduced_invalid_request_error provider_request_id=req_provider_fail_1 request_id=req_issue80_case_1 token_source=env:ANTHROPIC_TOKEN_ALPHA
+lane=lane_alpha case=compat-with-direct-beta status=400 outcome=reproduced_invalid_request_error provider_request_id=req_provider_fail_2 request_id=req_issue80_case_2 token_source=env:ANTHROPIC_TOKEN_ALPHA
+lane=lane_alpha case=compat-with-all-direct-deltas status=200 outcome=request_succeeded provider_request_id=req_provider_ok request_id=req_issue80_case_3 token_source=env:ANTHROPIC_TOKEN_ALPHA
+lane=lane_beta case=compat-exact status=400 outcome=reproduced_invalid_request_error provider_request_id=req_provider_fail_3 request_id=req_issue80_case_4 token_source=env:ANTHROPIC_TOKEN_BETA
+lane=lane_beta case=compat-with-direct-beta status=400 outcome=reproduced_invalid_request_error provider_request_id=req_provider_fail_4 request_id=req_issue80_case_5 token_source=env:ANTHROPIC_TOKEN_BETA
+lane=lane_beta case=compat-with-all-direct-deltas status=400 outcome=reproduced_invalid_request_error provider_request_id=req_provider_fail_5 request_id=req_issue80_case_6 token_source=env:ANTHROPIC_TOKEN_BETA
+EOF
+}
+
+write_case_only_fixture() {
+  local dir="$1"
+  mkdir -p "$dir"
+  cat >"$dir/summary.txt" <<'EOF'
+target_url=https://api.anthropic.com/v1/messages
+body_bytes=393038
+body_sha256=def456
+case_count=2
+cases_dir=/tmp/cases
+direct_access_token_source=claude_code_oauth_token
+case=compat-exact status=400 outcome=reproduced_invalid_request_error provider_request_id=req_provider_fail request_id=req_issue80_case_only_1
+case=compat-with-direct-identity status=200 outcome=request_succeeded provider_request_id=req_provider_ok request_id=req_issue80_case_only_2
+EOF
+}
+
+write_lane_only_fixture() {
+  local dir="$1"
+  mkdir -p "$dir"
+  cat >"$dir/summary.txt" <<'EOF'
+target_url=https://api.anthropic.com/v1/messages
+body_bytes=393038
+body_sha256=ghi789
+case_count=2
+lane_count=2
+cases_dir=/tmp/cases
+token_matrix_tsv=/tmp/token-matrix.tsv
+lane=lane_alpha case=compat-exact status=200 outcome=request_succeeded provider_request_id=req_provider_ok_1 request_id=req_issue80_lane_only_1 token_source=env:ANTHROPIC_TOKEN_ALPHA
+lane=lane_alpha case=compat-with-direct-beta status=200 outcome=request_succeeded provider_request_id=req_provider_ok_2 request_id=req_issue80_lane_only_2 token_source=env:ANTHROPIC_TOKEN_ALPHA
+lane=lane_beta case=compat-exact status=400 outcome=reproduced_invalid_request_error provider_request_id=req_provider_fail_1 request_id=req_issue80_lane_only_3 token_source=env:ANTHROPIC_TOKEN_BETA
+lane=lane_beta case=compat-with-direct-beta status=400 outcome=reproduced_invalid_request_error provider_request_id=req_provider_fail_2 request_id=req_issue80_lane_only_4 token_source=env:ANTHROPIC_TOKEN_BETA
+EOF
+}
+
+write_no_flip_fixture() {
+  local dir="$1"
+  mkdir -p "$dir"
+  cat >"$dir/summary.txt" <<'EOF'
+target_url=https://api.anthropic.com/v1/messages
+body_bytes=393038
+body_sha256=jkl012
+case_count=2
+lane_count=2
+cases_dir=/tmp/cases
+token_matrix_tsv=/tmp/token-matrix.tsv
+lane=lane_alpha case=compat-exact status=400 outcome=reproduced_invalid_request_error provider_request_id=req_provider_fail_1 request_id=req_issue80_no_flip_1 token_source=env:ANTHROPIC_TOKEN_ALPHA
+lane=lane_alpha case=compat-with-direct-beta status=400 outcome=reproduced_invalid_request_error provider_request_id=req_provider_fail_2 request_id=req_issue80_no_flip_2 token_source=env:ANTHROPIC_TOKEN_ALPHA
+lane=lane_beta case=compat-exact status=400 outcome=reproduced_invalid_request_error provider_request_id=req_provider_fail_3 request_id=req_issue80_no_flip_3 token_source=env:ANTHROPIC_TOKEN_BETA
+lane=lane_beta case=compat-with-direct-beta status=400 outcome=reproduced_invalid_request_error provider_request_id=req_provider_fail_4 request_id=req_issue80_no_flip_4 token_source=env:ANTHROPIC_TOKEN_BETA
+EOF
+}
+
+MULTI_DIR="$TMP_DIR/multi-axis"
+write_multi_axis_fixture "$MULTI_DIR"
+"$SCRIPT_PATH" "$MULTI_DIR/summary.txt" >"$MULTI_DIR/stdout.txt"
+
+[[ -f "$MULTI_DIR/outcome-summary.txt" ]]
+[[ -f "$MULTI_DIR/case-summary.tsv" ]]
+[[ -f "$MULTI_DIR/lane-summary.tsv" ]]
+grep -q '^matrix_type=exact_case_token_lane$' "$MULTI_DIR/outcome-summary.txt"
+grep -q '^run_count=6$' "$MULTI_DIR/outcome-summary.txt"
+grep -q '^case_count=3$' "$MULTI_DIR/outcome-summary.txt"
+grep -q '^lane_count=2$' "$MULTI_DIR/outcome-summary.txt"
+grep -q '^case_axis_flips=true$' "$MULTI_DIR/outcome-summary.txt"
+grep -q '^lane_axis_flips=true$' "$MULTI_DIR/outcome-summary.txt"
+grep -q '^axis_classification=case_and_lane$' "$MULTI_DIR/outcome-summary.txt"
+grep -q '^inference=controlled_case_and_token_lane_changes_flip_outcome$' "$MULTI_DIR/outcome-summary.txt"
+grep -q '^successful_cases=compat-with-all-direct-deltas$' "$MULTI_DIR/outcome-summary.txt"
+grep -q '^successful_lanes=lane_alpha$' "$MULTI_DIR/outcome-summary.txt"
+grep -q $'^compat-with-all-direct-deltas\t2\t2\t200,400\trequest_succeeded,reproduced_invalid_request_error\tlane_alpha\tlane_beta$' "$MULTI_DIR/case-summary.tsv"
+grep -q $'^lane_alpha\t3\t3\t200,400\trequest_succeeded,reproduced_invalid_request_error\tcompat-with-all-direct-deltas\tcompat-exact,compat-with-direct-beta$' "$MULTI_DIR/lane-summary.tsv"
+grep -q '^summary_file=' "$MULTI_DIR/stdout.txt"
+grep -q '^case_summary_file=' "$MULTI_DIR/stdout.txt"
+grep -q '^lane_summary_file=' "$MULTI_DIR/stdout.txt"
+
+CASE_ONLY_DIR="$TMP_DIR/case-only"
+write_case_only_fixture "$CASE_ONLY_DIR"
+"$SCRIPT_PATH" "$CASE_ONLY_DIR" >"$CASE_ONLY_DIR/stdout.txt"
+
+[[ -f "$CASE_ONLY_DIR/outcome-summary.txt" ]]
+grep -q '^matrix_type=exact_case$' "$CASE_ONLY_DIR/outcome-summary.txt"
+grep -q '^lane_count=1$' "$CASE_ONLY_DIR/outcome-summary.txt"
+grep -q '^case_axis_flips=true$' "$CASE_ONLY_DIR/outcome-summary.txt"
+grep -q '^lane_axis_flips=false$' "$CASE_ONLY_DIR/outcome-summary.txt"
+grep -q '^axis_classification=case_only$' "$CASE_ONLY_DIR/outcome-summary.txt"
+grep -q '^inference=controlled_case_changes_flip_outcome$' "$CASE_ONLY_DIR/outcome-summary.txt"
+grep -q '^successful_lanes=single_lane$' "$CASE_ONLY_DIR/outcome-summary.txt"
+grep -q $'^single_lane\t2\t2\t200,400\trequest_succeeded,reproduced_invalid_request_error\tcompat-with-direct-identity\tcompat-exact$' "$CASE_ONLY_DIR/lane-summary.tsv"
+
+LANE_ONLY_DIR="$TMP_DIR/lane-only"
+write_lane_only_fixture "$LANE_ONLY_DIR"
+"$SCRIPT_PATH" "$LANE_ONLY_DIR/summary.txt" >"$LANE_ONLY_DIR/stdout.txt"
+
+grep -q '^axis_classification=lane_only$' "$LANE_ONLY_DIR/outcome-summary.txt"
+grep -q '^inference=controlled_token_lane_changes_flip_outcome$' "$LANE_ONLY_DIR/outcome-summary.txt"
+grep -q '^case_axis_flips=false$' "$LANE_ONLY_DIR/outcome-summary.txt"
+grep -q '^lane_axis_flips=true$' "$LANE_ONLY_DIR/outcome-summary.txt"
+grep -q '^successful_cases=compat-exact,compat-with-direct-beta$' "$LANE_ONLY_DIR/outcome-summary.txt"
+grep -q '^successful_lanes=lane_alpha$' "$LANE_ONLY_DIR/outcome-summary.txt"
+
+NO_FLIP_DIR="$TMP_DIR/no-flip"
+write_no_flip_fixture "$NO_FLIP_DIR"
+"$SCRIPT_PATH" "$NO_FLIP_DIR/summary.txt" >"$NO_FLIP_DIR/stdout.txt"
+
+grep -q '^axis_classification=no_controlled_axis_flip$' "$NO_FLIP_DIR/outcome-summary.txt"
+grep -q '^inference=remaining_delta_outside_controlled_case_or_lane_matrix$' "$NO_FLIP_DIR/outcome-summary.txt"
+grep -q '^all_runs_same_outcome=true$' "$NO_FLIP_DIR/outcome-summary.txt"
+grep -q '^successful_cases=none$' "$NO_FLIP_DIR/outcome-summary.txt"
+grep -q '^successful_lanes=none$' "$NO_FLIP_DIR/outcome-summary.txt"
+
+EMPTY_DIR="$TMP_DIR/empty"
+mkdir -p "$EMPTY_DIR"
+cat >"$EMPTY_DIR/summary.txt" <<'EOF'
+target_url=https://api.anthropic.com/v1/messages
+body_bytes=393038
+body_sha256=mno345
+case_count=0
+lane_count=0
+EOF
+
+set +e
+"$SCRIPT_PATH" "$EMPTY_DIR/summary.txt" >"$EMPTY_DIR/stdout.txt" 2>"$EMPTY_DIR/stderr.txt"
+STATUS=$?
+set -e
+
+if [[ "$STATUS" -eq 0 ]]; then
+  echo 'expected empty summary invocation to fail' >&2
+  exit 1
+fi
+
+grep -q 'no case outcome rows found' "$EMPTY_DIR/stderr.txt"


### PR DESCRIPTION
## Summary
- add `innies-compat-exact-case-outcome-summary` to classify exact-case matrix results as case-only, lane-only, both, or no controlled-axis flip
- emit `outcome-summary.txt`, `case-summary.tsv`, and `lane-summary.tsv` from either a matrix output directory or a direct `summary.txt`
- wire the helper into `scripts/install.sh` / `scripts/README.md` and cover the classification/output contract with a focused shell test

## Test Plan
- [x] `bash scripts/tests/innies-compat-exact-case-outcome-summary.test.sh`
- [x] `bash -n scripts/innies-compat-exact-case-outcome-summary.sh scripts/tests/innies-compat-exact-case-outcome-summary.test.sh scripts/install.sh`
- [x] `TMP_HOME="$(mktemp -d)" && HOME="$TMP_HOME" bash scripts/install.sh >/tmp/issue80-exact-case-outcome-summary-install.out && test -L "$TMP_HOME/.local/bin/innies-compat-exact-case-outcome-summary"`
- [x] `git diff --check origin/main...HEAD`

Refs #80
