### PR TITLE
chore: add issue 80 direct payload matrix helper

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -25,6 +25,7 @@ innies-buyer-preference-set
 innies-buyer-preference-get
 innies-buyer-preference-check
 innies-slo-check
+innies-compat-direct-payload-matrix
 ```
 
 What they do:
@@ -40,6 +41,7 @@ What they do:
 - `innies-buyer-preference-get`: read the current buyer key preference
 - `innies-buyer-preference-check`: run the provider-preference canary after prompting for the expected provider (`Claude Code` or `Codex`)
 - `innies-slo-check`: query analytics endpoints and report Phase 1 SLO pass/fail (TTFB p95, timeout rate, success rate, fallback rate); optional arg sets the window (default `24h`); exits 0 if all SLOs pass, 1 if any fail
+- `innies-compat-direct-payload-matrix`: replay multiple preserved Anthropic payloads directly against one fixed header lane so transcript-shape-specific outcomes are visible without changing the runtime proxy path
 
 Behavior:
 - org id auto-uses `INNIES_ORG_ID`
@@ -79,6 +81,7 @@ Behavior:
 - non-pinned buyer traffic always gets automatic cross-provider fallback to the other provider; flipping preference flips fallback order too
 - `innies-buyer-preference-set` prints the effective preferred provider plus the automatic fallback provider before sending the update
 - `innies-buyer-preference-check` now expects and validates the two-provider plan in DB evidence mode
+- `innies-compat-direct-payload-matrix` requires a payload-matrix TSV (`payload_name<TAB>/abs/path/payload.json`) plus a shared direct-header TSV; it sends every payload to direct Anthropic with the same non-auth headers and writes one artifact bundle per payload under `payloads/<payload>/`
 
 ## Env
 

--- a/scripts/innies-compat-direct-payload-matrix.sh
+++ b/scripts/innies-compat-direct-payload-matrix.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_PATH" ]]; do
+  SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+  SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"
+  [[ "$SCRIPT_PATH" != /* ]] && SCRIPT_PATH="${SCRIPT_DIR}/${SCRIPT_PATH}"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+source "${SCRIPT_DIR}/_common.sh"
+
+resolve_direct_base_url() {
+  if [[ -n "${ANTHROPIC_DIRECT_BASE_URL:-}" ]]; then
+    printf '%s' "${ANTHROPIC_DIRECT_BASE_URL%/}"
+    return
+  fi
+  if [[ -n "${ANTHROPIC_BASE_URL:-}" ]]; then
+    printf '%s' "${ANTHROPIC_BASE_URL%/}"
+    return
+  fi
+  printf '%s' 'https://api.anthropic.com'
+}
+
+resolve_access_token() {
+  if [[ -n "${ANTHROPIC_OAUTH_ACCESS_TOKEN:-}" ]]; then
+    printf '%s\t%s' "${ANTHROPIC_OAUTH_ACCESS_TOKEN}" 'anthropic_oauth_access_token'
+    return
+  fi
+  if [[ -n "${ANTHROPIC_ACCESS_TOKEN:-}" ]]; then
+    printf '%s\t%s' "${ANTHROPIC_ACCESS_TOKEN}" 'anthropic_access_token'
+    return
+  fi
+  if [[ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
+    printf '%s\t%s' "${CLAUDE_CODE_OAUTH_TOKEN}" 'claude_code_oauth_token'
+    return
+  fi
+  echo 'error: missing Anthropic OAuth access token (set ANTHROPIC_OAUTH_ACCESS_TOKEN, ANTHROPIC_ACCESS_TOKEN, or CLAUDE_CODE_OAUTH_TOKEN)' >&2
+  exit 1
+}
+
+extract_response_header() {
+  local name="$1"
+  local file="$2"
+  awk -F': ' -v header_name="$name" '
+    BEGIN { IGNORECASE = 1 }
+    tolower($1) == tolower(header_name) {
+      gsub("\r", "", $2)
+      print $2
+    }
+  ' "$file" | tail -1
+}
+
+extract_body_request_id() {
+  local file="$1"
+  sed -n 's/.*"request_id":"\([^"]*\)".*/\1/p' "$file" | head -n 1
+}
+
+write_lines() {
+  local file="$1"
+  shift
+  printf '%s\n' "$@" >"$file"
+}
+
+PAYLOADS_TSV_PATH="${1:-${INNIES_DIRECT_PAYLOAD_MATRIX_TSV:-}}"
+HEADERS_TSV_PATH="${2:-${INNIES_DIRECT_HEADERS_TSV:-}}"
+require_nonempty 'payload matrix tsv path' "$PAYLOADS_TSV_PATH"
+require_nonempty 'headers tsv path' "$HEADERS_TSV_PATH"
+
+if [[ ! -f "$PAYLOADS_TSV_PATH" ]]; then
+  echo "error: payload matrix TSV file not found: $PAYLOADS_TSV_PATH" >&2
+  exit 1
+fi
+
+if [[ ! -f "$HEADERS_TSV_PATH" ]]; then
+  echo "error: headers TSV file not found: $HEADERS_TSV_PATH" >&2
+  exit 1
+fi
+
+DIRECT_BASE_URL="$(resolve_direct_base_url)"
+DIRECT_PATH="${INNIES_DIRECT_PATH:-/v1/messages}"
+TARGET_URL="${DIRECT_BASE_URL}${DIRECT_PATH}"
+TOKEN_AND_SOURCE="$(resolve_access_token)"
+ACCESS_TOKEN="${TOKEN_AND_SOURCE%%$'\t'*}"
+DIRECT_ACCESS_TOKEN_SOURCE="${TOKEN_AND_SOURCE#*$'\t'}"
+REQUEST_ID_PREFIX="${INNIES_DIRECT_PAYLOAD_MATRIX_REQUEST_ID_PREFIX:-req_issue80_payload_matrix_$(date -u +%Y%m%dT%H%M%SZ)}"
+OUT_DIR="${INNIES_DIRECT_PAYLOAD_MATRIX_OUT_DIR:-${TMPDIR:-/tmp}/innies-compat-direct-payload-matrix-${REQUEST_ID_PREFIX}}"
+PAYLOAD_OUT_DIR="$OUT_DIR/payloads"
+SUMMARY_FILE="$OUT_DIR/summary.txt"
+mkdir -p "$PAYLOAD_OUT_DIR"
+
+SUMMARY_LINES=(
+  "target_url=$TARGET_URL"
+  "payload_matrix_tsv=$PAYLOADS_TSV_PATH"
+  "headers_tsv_path=$HEADERS_TSV_PATH"
+  "direct_access_token_source=$DIRECT_ACCESS_TOKEN_SOURCE"
+)
+write_lines "$SUMMARY_FILE" "${SUMMARY_LINES[@]}"
+
+run_payload() {
+  local payload_name="$1"
+  local payload_path="$2"
+  local request_id="${REQUEST_ID_PREFIX}_${payload_name}"
+  local payload_dir="$PAYLOAD_OUT_DIR/$payload_name"
+  local request_headers_tsv="$payload_dir/request-headers.tsv"
+  local response_headers_file="$payload_dir/response-headers.txt"
+  local response_body_file="$payload_dir/response-body.txt"
+  local meta_file="$payload_dir/meta.txt"
+  local payload_copy="$payload_dir/payload.json"
+
+  if [[ ! -f "$payload_path" ]]; then
+    echo "error: payload file not found for '$payload_name': $payload_path" >&2
+    exit 1
+  fi
+
+  mkdir -p "$payload_dir"
+  cp "$payload_path" "$payload_copy"
+
+  local payload_bytes
+  local payload_sha256
+  payload_bytes="$(wc -c <"$payload_path" | tr -d '[:space:]')"
+  payload_sha256="$(openssl dgst -sha256 -r "$payload_path" | awk '{print $1}')"
+
+  declare -a curl_args
+  curl_args=(
+    -sS
+    -D "$response_headers_file"
+    -o "$response_body_file"
+    -w '%{http_code}'
+    -X POST "$TARGET_URL"
+    --data-binary "@$payload_path"
+  )
+
+  printf 'authorization\tBearer <redacted>\n' >"$request_headers_tsv"
+  local have_request_id='false'
+  while IFS=$'\t' read -r raw_header_name raw_header_value; do
+    [[ -z "${raw_header_name:-}" ]] && continue
+    local header_name
+    local header_value
+    local normalized_name
+    header_name="$(trim "$raw_header_name")"
+    header_value="$(trim "${raw_header_value:-}")"
+    [[ -z "$header_name" ]] && continue
+    normalized_name="$(printf '%s' "$header_name" | tr '[:upper:]' '[:lower:]')"
+    case "$normalized_name" in
+      authorization|content-length|host|:*)
+        continue
+        ;;
+      x-request-id)
+        header_value="$request_id"
+        have_request_id='true'
+        ;;
+    esac
+
+    curl_args+=(-H "${normalized_name}: ${header_value}")
+    printf '%s\t%s\n' "$normalized_name" "$header_value" >>"$request_headers_tsv"
+  done <"$HEADERS_TSV_PATH"
+
+  if [[ "$have_request_id" != 'true' ]]; then
+    curl_args+=(-H "x-request-id: $request_id")
+    printf 'x-request-id\t%s\n' "$request_id" >>"$request_headers_tsv"
+  fi
+
+  curl_args+=(-H "authorization: Bearer $ACCESS_TOKEN")
+
+  local status
+  status="$(curl "${curl_args[@]}")"
+  local provider_request_id
+  provider_request_id="$(extract_response_header 'request-id' "$response_headers_file")"
+  if [[ -z "$provider_request_id" ]]; then
+    provider_request_id="$(extract_body_request_id "$response_body_file")"
+  fi
+
+  local outcome='unexpected_http_status'
+  if [[ "$status" =~ ^2 ]]; then
+    outcome='request_succeeded'
+  elif [[ "$status" == '400' ]] && grep -q '"type":"invalid_request_error"' "$response_body_file"; then
+    outcome='reproduced_invalid_request_error'
+  fi
+
+  local meta_lines=(
+    "payload=$payload_name"
+    "status=$status"
+    "outcome=$outcome"
+    "request_id=$request_id"
+    "provider_request_id=${provider_request_id:-}"
+    "token_source=$DIRECT_ACCESS_TOKEN_SOURCE"
+    "target_url=$TARGET_URL"
+    "payload_path=$payload_path"
+    "payload_copy=$payload_copy"
+    "payload_bytes=$payload_bytes"
+    "payload_sha256=$payload_sha256"
+    "headers_tsv_path=$HEADERS_TSV_PATH"
+    "request_headers_tsv=$request_headers_tsv"
+    "response_headers_file=$response_headers_file"
+    "response_body_file=$response_body_file"
+  )
+  write_lines "$meta_file" "${meta_lines[@]}"
+  printf 'payload=%s status=%s provider_request_id=%s request_id=%s token_source=%s payload_sha256=%s payload_bytes=%s\n' \
+    "$payload_name" \
+    "$status" \
+    "${provider_request_id:-}" \
+    "$request_id" \
+    "$DIRECT_ACCESS_TOKEN_SOURCE" \
+    "$payload_sha256" \
+    "$payload_bytes" >>"$SUMMARY_FILE"
+}
+
+payload_count=0
+while IFS=$'\t' read -r raw_payload_name raw_payload_path _; do
+  payload_name="$(trim "${raw_payload_name:-}")"
+  payload_path="$(trim "${raw_payload_path:-}")"
+  [[ -z "$payload_name" ]] && continue
+  [[ "$payload_name" == \#* ]] && continue
+  require_nonempty "payload path for '$payload_name'" "$payload_path"
+  if [[ ! "$payload_name" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    echo "error: invalid payload name '$payload_name' (use letters, numbers, dot, underscore, or dash)" >&2
+    exit 1
+  fi
+  run_payload "$payload_name" "$payload_path"
+  payload_count=$((payload_count + 1))
+done <"$PAYLOADS_TSV_PATH"
+
+if [[ "$payload_count" -eq 0 ]]; then
+  echo "error: no payload entries found in $PAYLOADS_TSV_PATH" >&2
+  exit 1
+fi
+
+printf 'payload_count=%s\n' "$payload_count" >>"$SUMMARY_FILE"
+cat "$SUMMARY_FILE"
+printf 'summary_file=%s\n' "$SUMMARY_FILE"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,6 +18,7 @@ ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-set.sh" "${BIN_DIR}/innies-b
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-get.sh" "${BIN_DIR}/innies-buyer-preference-get"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-check.sh" "${BIN_DIR}/innies-buyer-preference-check"
 ln -sf "${ROOT_DIR}/scripts/innies-slo-check.sh" "${BIN_DIR}/innies-slo-check"
+ln -sf "${ROOT_DIR}/scripts/innies-compat-direct-payload-matrix.sh" "${BIN_DIR}/innies-compat-direct-payload-matrix"
 
 rm -f \
   "${BIN_DIR}/innies-admin" \
@@ -49,6 +50,7 @@ echo "  ${BIN_DIR}/innies-buyer-preference-set -> ${ROOT_DIR}/scripts/innies-buy
 echo "  ${BIN_DIR}/innies-buyer-preference-get -> ${ROOT_DIR}/scripts/innies-buyer-preference-get.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-check -> ${ROOT_DIR}/scripts/innies-buyer-preference-check.sh"
 echo "  ${BIN_DIR}/innies-slo-check -> ${ROOT_DIR}/scripts/innies-slo-check.sh"
+echo "  ${BIN_DIR}/innies-compat-direct-payload-matrix -> ${ROOT_DIR}/scripts/innies-compat-direct-payload-matrix.sh"
 echo
 echo 'If command not found, add ~/.local/bin to PATH:'
 echo '  export PATH="$HOME/.local/bin:$PATH"'

--- a/scripts/tests/innies-compat-direct-payload-matrix.test.sh
+++ b/scripts/tests/innies-compat-direct-payload-matrix.test.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="$ROOT_DIR/scripts/innies-compat-direct-payload-matrix.sh"
+TMP_DIR="$(mktemp -d)"
+PAYLOADS_DIR="$TMP_DIR/payloads"
+PAYLOADS_TSV_PATH="$TMP_DIR/payloads.tsv"
+HEADERS_TSV_PATH="$TMP_DIR/direct-headers.tsv"
+REQUESTS_DIR="$TMP_DIR/requests"
+OUT_DIR="$TMP_DIR/out"
+STDOUT_PATH="$TMP_DIR/stdout.txt"
+STDERR_PATH="$TMP_DIR/stderr.txt"
+
+cleanup() {
+  if [[ -n "${SERVER_PID:-}" ]]; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$PAYLOADS_DIR" "$REQUESTS_DIR"
+
+cat >"$PAYLOADS_DIR/shape_good.json" <<'JSON'
+{"model":"claude-opus-4-6","stream":true,"max_tokens":32,"messages":[{"role":"user","content":[{"type":"text","text":"direct-payload-success"}]}]}
+JSON
+
+cat >"$PAYLOADS_DIR/shape_bad.json" <<'JSON'
+{"model":"claude-opus-4-6","stream":true,"max_tokens":32,"messages":[{"role":"user","content":[{"type":"text","text":"direct-payload-invalid-request"}]}]}
+JSON
+
+cat >"$PAYLOADS_TSV_PATH" <<TSV
+shape_good	$PAYLOADS_DIR/shape_good.json
+shape_bad	$PAYLOADS_DIR/shape_bad.json
+TSV
+
+cat >"$HEADERS_TSV_PATH" <<'TSV'
+accept	text/event-stream
+anthropic-beta	fine-grained-tool-streaming-2025-05-14
+anthropic-dangerous-direct-browser-access	true
+anthropic-version	2023-06-01
+content-type	application/json
+user-agent	OpenClawGateway/1.0
+x-app	cli
+x-request-id	req_original_should_be_replaced
+TSV
+
+cat >"$TMP_DIR/mock-server.mjs" <<'NODE'
+import { createServer } from 'node:http';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const port = Number(process.env.PORT);
+const requestsDir = process.env.REQUESTS_DIR;
+mkdirSync(requestsDir, { recursive: true });
+
+const server = createServer((req, res) => {
+  const chunks = [];
+  req.on('data', (chunk) => chunks.push(chunk));
+  req.on('end', () => {
+    const bodyBuffer = Buffer.concat(chunks);
+    const requestId = String(req.headers['x-request-id'] ?? `unknown-${Date.now()}`);
+    const bodyText = bodyBuffer.toString('utf8');
+
+    writeFileSync(join(requestsDir, `${requestId}.json`), JSON.stringify({
+      method: req.method,
+      url: req.url,
+      headers: req.headers,
+      bodyText,
+      bodyBytes: bodyBuffer.length
+    }, null, 2));
+
+    if (bodyText.includes('direct-payload-success')) {
+      res.statusCode = 200;
+      res.setHeader('content-type', 'application/json');
+      res.setHeader('request-id', 'req_provider_good');
+      res.end(JSON.stringify({
+        id: 'msg_payload_ok',
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'text', text: 'ok' }],
+        stop_reason: 'end_turn'
+      }));
+      return;
+    }
+
+    res.statusCode = 400;
+    res.setHeader('content-type', 'application/json');
+    res.setHeader('request-id', 'req_provider_bad');
+    res.end(JSON.stringify({
+      type: 'error',
+      error: {
+        type: 'invalid_request_error',
+        message: 'Error'
+      },
+      request_id: 'req_provider_bad'
+    }));
+  });
+});
+
+server.listen(port, '127.0.0.1', () => {
+  process.stdout.write(`ready:${port}\n`);
+});
+NODE
+
+PORT="$(node -e "const net=require('node:net');const s=net.createServer();s.listen(0,'127.0.0.1',()=>{const {port}=s.address();console.log(port);s.close();});")"
+PORT="$PORT" REQUESTS_DIR="$REQUESTS_DIR" node "$TMP_DIR/mock-server.mjs" >"$TMP_DIR/server.log" 2>&1 &
+SERVER_PID=$!
+
+for _ in $(seq 1 50); do
+  if grep -q '^ready:' "$TMP_DIR/server.log" 2>/dev/null; then
+    break
+  fi
+  sleep 0.1
+done
+
+if ! grep -q '^ready:' "$TMP_DIR/server.log" 2>/dev/null; then
+  echo 'server did not start' >&2
+  cat "$TMP_DIR/server.log" >&2
+  exit 1
+fi
+
+set +e
+CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat-payload-live-token" \
+ANTHROPIC_DIRECT_BASE_URL="http://127.0.0.1:$PORT" \
+INNIES_DIRECT_PAYLOAD_MATRIX_REQUEST_ID_PREFIX="req_issue80_payload_matrix" \
+INNIES_DIRECT_PAYLOAD_MATRIX_OUT_DIR="$OUT_DIR" \
+"$SCRIPT_PATH" "$PAYLOADS_TSV_PATH" "$HEADERS_TSV_PATH" >"$STDOUT_PATH" 2>"$STDERR_PATH"
+STATUS=$?
+set -e
+
+if [[ "$STATUS" -ne 0 ]]; then
+  cat "$STDERR_PATH" >&2
+  exit 1
+fi
+
+[[ -f "$OUT_DIR/summary.txt" ]]
+[[ -f "$OUT_DIR/payloads/shape_good/meta.txt" ]]
+[[ -f "$OUT_DIR/payloads/shape_good/request-headers.tsv" ]]
+[[ -f "$OUT_DIR/payloads/shape_good/response-headers.txt" ]]
+[[ -f "$OUT_DIR/payloads/shape_good/response-body.txt" ]]
+[[ -f "$OUT_DIR/payloads/shape_bad/meta.txt" ]]
+[[ -f "$OUT_DIR/payloads/shape_bad/request-headers.tsv" ]]
+[[ -f "$OUT_DIR/payloads/shape_bad/response-headers.txt" ]]
+[[ -f "$OUT_DIR/payloads/shape_bad/response-body.txt" ]]
+
+grep -q 'payload=shape_good status=200 provider_request_id=req_provider_good request_id=req_issue80_payload_matrix_shape_good token_source=claude_code_oauth_token' "$OUT_DIR/summary.txt"
+grep -q 'payload=shape_bad status=400 provider_request_id=req_provider_bad request_id=req_issue80_payload_matrix_shape_bad token_source=claude_code_oauth_token' "$OUT_DIR/summary.txt"
+grep -q '^authorization\tBearer <redacted>$' "$OUT_DIR/payloads/shape_good/request-headers.tsv"
+grep -q '^authorization\tBearer <redacted>$' "$OUT_DIR/payloads/shape_bad/request-headers.tsv"
+grep -q '^request_id=req_issue80_payload_matrix_shape_good$' "$OUT_DIR/payloads/shape_good/meta.txt"
+grep -q '^request_id=req_issue80_payload_matrix_shape_bad$' "$OUT_DIR/payloads/shape_bad/meta.txt"
+grep -q '^token_source=claude_code_oauth_token$' "$OUT_DIR/payloads/shape_good/meta.txt"
+grep -q '^outcome=request_succeeded$' "$OUT_DIR/payloads/shape_good/meta.txt"
+grep -q '^outcome=reproduced_invalid_request_error$' "$OUT_DIR/payloads/shape_bad/meta.txt"
+grep -q '^summary_file=' "$STDOUT_PATH"
+
+node - "$REQUESTS_DIR" <<'NODE'
+const fs = require('fs');
+const path = require('path');
+const requestsDir = process.argv[2];
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+const good = readJson(path.join(requestsDir, 'req_issue80_payload_matrix_shape_good.json'));
+const bad = readJson(path.join(requestsDir, 'req_issue80_payload_matrix_shape_bad.json'));
+
+if (good.headers.authorization !== 'Bearer sk-ant-oat-payload-live-token') {
+  throw new Error('good payload auth header mismatch');
+}
+if (bad.headers.authorization !== 'Bearer sk-ant-oat-payload-live-token') {
+  throw new Error('bad payload auth header mismatch');
+}
+if (good.headers['anthropic-beta'] !== 'fine-grained-tool-streaming-2025-05-14') {
+  throw new Error('good payload beta mismatch');
+}
+if (!good.bodyText.includes('direct-payload-success')) {
+  throw new Error('good payload body mismatch');
+}
+if (!bad.bodyText.includes('direct-payload-invalid-request')) {
+  throw new Error('bad payload body mismatch');
+}
+NODE
+
+EMPTY_PAYLOADS_TSV_PATH="$TMP_DIR/empty-payloads.tsv"
+printf '# no payloads yet\n' >"$EMPTY_PAYLOADS_TSV_PATH"
+
+set +e
+CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat-payload-live-token" \
+ANTHROPIC_DIRECT_BASE_URL="http://127.0.0.1:$PORT" \
+"$SCRIPT_PATH" "$EMPTY_PAYLOADS_TSV_PATH" "$HEADERS_TSV_PATH" >"$STDOUT_PATH" 2>"$STDERR_PATH"
+STATUS=$?
+set -e
+
+if [[ "$STATUS" -eq 0 ]]; then
+  echo 'expected empty payload matrix invocation to fail' >&2
+  exit 1
+fi
+
+grep -q 'no payload entries found' "$STDERR_PATH"


### PR DESCRIPTION
Refs #80

## Summary
- add `scripts/innies-compat-direct-payload-matrix.sh` to replay multiple preserved Anthropic payloads directly against one fixed direct header lane
- write per-payload request/response artifacts plus a merged `summary.txt` so issue `#80` can distinguish transcript-shape-specific outcomes from uniform/provider-side behavior
- wire the helper into `scripts/install.sh` / `scripts/README.md` and add focused shell coverage

## Why
The live `#80` helper swarm already covers header-case and credential-lane isolation, but it still lacked a narrow way to vary the payload while holding the direct header lane fixed. This slice addresses the issue body's open "transcript-shape specific" question without changing the runtime proxy path or weakening tools, thinking, or streaming behavior.

## Verification
- `bash scripts/tests/innies-compat-direct-payload-matrix.test.sh`
- `bash -n scripts/innies-compat-direct-payload-matrix.sh scripts/tests/innies-compat-direct-payload-matrix.test.sh scripts/install.sh`
- `TMP_HOME="$(mktemp -d)" && HOME="$TMP_HOME" bash scripts/install.sh >/tmp/issue80-direct-payload-matrix-install.out && test -L "$TMP_HOME/.local/bin/innies-compat-direct-payload-matrix"`
- `git diff --check`
