### PR TITLE
chore: add issue 80 exact-case minimal-delta helper

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -25,6 +25,7 @@ innies-buyer-preference-set
 innies-buyer-preference-get
 innies-buyer-preference-check
 innies-slo-check
+innies-compat-exact-case-minimal-delta
 ```
 
 What they do:
@@ -40,6 +41,7 @@ What they do:
 - `innies-buyer-preference-get`: read the current buyer key preference
 - `innies-buyer-preference-check`: run the provider-preference canary after prompting for the expected provider (`Claude Code` or `Codex`)
 - `innies-slo-check`: query analytics endpoints and report Phase 1 SLO pass/fail (TTFB p95, timeout rate, success rate, fallback rate); optional arg sets the window (default `24h`); exits 0 if all SLOs pass, 1 if any fail
+- `innies-compat-exact-case-minimal-delta`: read issue-80 exact-case matrix artifacts and identify the smallest successful controlled delta, or report that no controlled case flipped at all
 
 Behavior:
 - org id auto-uses `INNIES_ORG_ID`

--- a/scripts/innies-compat-exact-case-minimal-delta.mjs
+++ b/scripts/innies-compat-exact-case-minimal-delta.mjs
@@ -1,0 +1,282 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const [inputDirArg, outDirArg] = process.argv.slice(2);
+
+const CASE_PRIORITY = [
+  'compat-exact',
+  'shared',
+  'compat-with-direct-beta',
+  'compat-with-direct-identity',
+  'compat-with-direct-beta-and-identity',
+  'compat-with-all-direct-deltas',
+  'direct-exact'
+];
+
+const CASE_TO_DELTA = {
+  'compat-exact': 'none',
+  'shared': 'shared_headers_only',
+  'compat-with-direct-beta': 'beta_only',
+  'compat-with-direct-identity': 'identity_only',
+  'compat-with-direct-beta-and-identity': 'beta_and_identity',
+  'compat-with-all-direct-deltas': 'additional_direct_delta',
+  'direct-exact': 'direct_exact_only'
+};
+
+const CASE_TO_CONCLUSION = {
+  'shared': 'shared_headers_only_candidate',
+  'compat-with-direct-beta': 'beta_headers_only_candidate',
+  'compat-with-direct-identity': 'identity_headers_only_candidate',
+  'compat-with-direct-beta-and-identity': 'beta_and_identity_candidate',
+  'compat-with-all-direct-deltas': 'additional_direct_delta_candidate',
+  'direct-exact': 'direct_exact_only_candidate'
+};
+
+function fail(message) {
+  console.error(`error: ${message}`);
+  process.exit(1);
+}
+
+if (!inputDirArg) {
+  fail('missing matrix input dir');
+}
+
+if (!outDirArg) {
+  fail('missing minimal-delta output dir');
+}
+
+const inputDir = path.resolve(inputDirArg);
+const outDir = path.resolve(outDirArg);
+
+if (!fs.existsSync(inputDir) || !fs.statSync(inputDir).isDirectory()) {
+  fail(`matrix input dir not found: ${inputDirArg}`);
+}
+
+fs.mkdirSync(outDir, { recursive: true });
+
+function readKeyValueFile(filePath) {
+  const result = {};
+  const text = fs.readFileSync(filePath, 'utf8');
+  for (const line of text.split(/\r?\n/)) {
+    if (!line || !line.includes('=')) continue;
+    const index = line.indexOf('=');
+    const key = line.slice(0, index).trim();
+    const value = line.slice(index + 1).trim();
+    if (!key) continue;
+    result[key] = value;
+  }
+  return result;
+}
+
+function listDirectories(dirPath) {
+  if (!fs.existsSync(dirPath)) return [];
+  return fs.readdirSync(dirPath, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name);
+}
+
+function sortCaseNames(caseNames) {
+  return caseNames.slice().sort((left, right) => {
+    const leftIndex = CASE_PRIORITY.indexOf(left);
+    const rightIndex = CASE_PRIORITY.indexOf(right);
+    if (leftIndex >= 0 && rightIndex >= 0) return leftIndex - rightIndex;
+    if (leftIndex >= 0) return -1;
+    if (rightIndex >= 0) return 1;
+    return left.localeCompare(right);
+  });
+}
+
+function joinNames(values) {
+  return values.length > 0 ? values.join(',') : '-';
+}
+
+function parseCaseMatrix(caseNames) {
+  return caseNames.map((caseName) => {
+    const summaryPath = path.join(inputDir, 'cases', caseName, 'summary.txt');
+    if (!fs.existsSync(summaryPath)) {
+      fail(`missing case summary: ${summaryPath}`);
+    }
+    const summary = readKeyValueFile(summaryPath);
+    const status = Number(summary.status ?? NaN);
+    const outcome = summary.outcome ?? '';
+    if (!Number.isFinite(status) || !outcome) {
+      fail(`invalid case summary: ${summaryPath}`);
+    }
+    return {
+      lane: 'direct',
+      case: summary.case || caseName,
+      status,
+      outcome
+    };
+  });
+}
+
+function parseCaseLaneMatrix(laneNames) {
+  const runs = [];
+  for (const laneName of laneNames) {
+    const casesRoot = path.join(inputDir, 'lanes', laneName, 'cases');
+    const caseNames = listDirectories(casesRoot);
+    for (const caseName of caseNames) {
+      const summaryPath = ['meta.txt', 'summary.txt']
+        .map((fileName) => path.join(casesRoot, caseName, fileName))
+        .find((candidate) => fs.existsSync(candidate));
+      if (!summaryPath) continue;
+      const summary = readKeyValueFile(summaryPath);
+      const status = Number(summary.status ?? NaN);
+      const outcome = summary.outcome ?? '';
+      if (!Number.isFinite(status) || !outcome) {
+        fail(`invalid lane/case summary: ${summaryPath}`);
+      }
+      runs.push({
+        lane: summary.lane || laneName,
+        case: summary.case || caseName,
+        status,
+        outcome
+      });
+    }
+  }
+  return runs;
+}
+
+function deltaForCase(caseName) {
+  if (!caseName) return null;
+  return CASE_TO_DELTA[caseName] ?? 'custom_case';
+}
+
+function conclusionForSharedCase(caseName) {
+  if (!caseName) return 'no_controlled_case_success';
+  return CASE_TO_CONCLUSION[caseName] ?? 'custom_case_candidate';
+}
+
+const rootSummaryPath = path.join(inputDir, 'summary.txt');
+const rootSummary = fs.existsSync(rootSummaryPath) ? readKeyValueFile(rootSummaryPath) : {};
+
+const laneNames = listDirectories(path.join(inputDir, 'lanes')).sort();
+const caseNamesFromRoot = listDirectories(path.join(inputDir, 'cases'));
+
+let mode;
+let runs;
+
+if (laneNames.length > 0) {
+  mode = 'case_lane_matrix';
+  runs = parseCaseLaneMatrix(laneNames);
+} else if (caseNamesFromRoot.length > 0) {
+  mode = 'case_matrix';
+  runs = parseCaseMatrix(caseNamesFromRoot);
+} else {
+  fail(`no exact-case matrix artifacts found in ${inputDir}`);
+}
+
+if (runs.length === 0) {
+  fail(`no runnable matrix entries found in ${inputDir}`);
+}
+
+const caseNames = sortCaseNames([...new Set(runs.map((run) => run.case))]);
+const runLaneNames = [...new Set(runs.map((run) => run.lane))].sort();
+const baselineCase = caseNames.includes('compat-exact') ? 'compat-exact' : (caseNames[0] ?? null);
+
+function findRun(laneName, caseName) {
+  return runs.find((run) => run.lane === laneName && run.case === caseName) ?? null;
+}
+
+const laneAnalyses = runLaneNames.map((laneName) => {
+  const baselineRun = baselineCase ? findRun(laneName, baselineCase) : null;
+  const successfulCases = caseNames.filter((caseName) => {
+    const run = findRun(laneName, caseName);
+    return run?.outcome === 'request_succeeded';
+  });
+  const minimalSuccessCase = successfulCases[0] ?? null;
+  const baselineOutcome = baselineRun?.outcome ?? 'missing';
+
+  return {
+    lane: laneName,
+    baselineOutcome,
+    baselineReproduced: baselineOutcome === 'reproduced_invalid_request_error',
+    minimalSuccessCase,
+    minimalSuccessDelta: deltaForCase(minimalSuccessCase),
+    successfulCases
+  };
+});
+
+const baselineDoesNotReproduce = laneAnalyses.some((analysis) => analysis.baselineOutcome === 'request_succeeded');
+const successfulLaneAnalyses = laneAnalyses.filter((analysis) => analysis.minimalSuccessCase !== null);
+const blockedLanes = laneAnalyses
+  .filter((analysis) => analysis.minimalSuccessCase === null)
+  .map((analysis) => analysis.lane);
+const successfulLanes = successfulLaneAnalyses.map((analysis) => analysis.lane);
+
+const uniqueMinimalSuccessCases = [...new Set(successfulLaneAnalyses.map((analysis) => analysis.minimalSuccessCase))];
+const sharedMinimalSuccessCase = (
+  successfulLaneAnalyses.length > 0 &&
+  blockedLanes.length === 0 &&
+  uniqueMinimalSuccessCases.length === 1
+) ? uniqueMinimalSuccessCases[0] : null;
+
+let conclusion;
+if (baselineDoesNotReproduce) {
+  conclusion = 'baseline_does_not_reproduce';
+} else if (successfulLaneAnalyses.length === 0) {
+  conclusion = 'no_controlled_case_success';
+} else if (mode === 'case_lane_matrix' && (blockedLanes.length > 0 || uniqueMinimalSuccessCases.length > 1)) {
+  conclusion = 'lane_specific_followup_required';
+} else {
+  conclusion = conclusionForSharedCase(sharedMinimalSuccessCase ?? successfulLaneAnalyses[0].minimalSuccessCase);
+}
+
+const minimalSuccessCase = mode === 'case_matrix'
+  ? (laneAnalyses[0]?.minimalSuccessCase ?? null)
+  : sharedMinimalSuccessCase;
+
+const minimalSuccessDelta = deltaForCase(minimalSuccessCase);
+
+const output = {
+  mode,
+  inputDir,
+  outputDir: outDir,
+  caseCount: caseNames.length,
+  laneCount: runLaneNames.length,
+  baselineCase,
+  baselineReproduced: laneAnalyses.every((analysis) => analysis.baselineReproduced),
+  baselineDoesNotReproduce,
+  conclusion,
+  minimalSuccessCase,
+  minimalSuccessDelta,
+  sharedMinimalSuccessCase,
+  sharedMinimalSuccessDelta: deltaForCase(sharedMinimalSuccessCase),
+  successfulLanes,
+  blockedLanes,
+  bodyBytes: rootSummary.body_bytes ?? null,
+  bodySha256: rootSummary.body_sha256 ?? null,
+  laneAnalyses
+};
+
+const summaryLines = [
+  `mode=${mode}`,
+  `input_dir=${inputDir}`,
+  `case_count=${caseNames.length}`,
+  `lane_count=${runLaneNames.length}`,
+  `baseline_case=${baselineCase ?? '-'}`,
+  `baseline_reproduced=${String(output.baselineReproduced)}`,
+  `baseline_does_not_reproduce=${String(baselineDoesNotReproduce)}`,
+  `conclusion=${conclusion}`,
+  `minimal_success_case=${minimalSuccessCase ?? '-'}`,
+  `minimal_success_delta=${minimalSuccessDelta ?? '-'}`,
+  `shared_minimal_success_case=${sharedMinimalSuccessCase ?? '-'}`,
+  `shared_minimal_success_delta=${output.sharedMinimalSuccessDelta ?? '-'}`,
+  `successful_lanes=${joinNames(successfulLanes)}`,
+  `blocked_lanes=${joinNames(blockedLanes)}`
+];
+
+if (output.bodyBytes) summaryLines.push(`body_bytes=${output.bodyBytes}`);
+if (output.bodySha256) summaryLines.push(`body_sha256=${output.bodySha256}`);
+
+for (const analysis of laneAnalyses) {
+  summaryLines.push(
+    `lane=${analysis.lane} baseline_outcome=${analysis.baselineOutcome} minimal_success_case=${analysis.minimalSuccessCase ?? '-'} minimal_success_delta=${analysis.minimalSuccessDelta ?? '-'} successful_cases=${joinNames(analysis.successfulCases)}`
+  );
+}
+
+fs.writeFileSync(path.join(outDir, 'minimal-delta.json'), `${JSON.stringify(output, null, 2)}\n`);
+fs.writeFileSync(path.join(outDir, 'minimal-delta.txt'), `${summaryLines.join('\n')}\n`);

--- a/scripts/innies-compat-exact-case-minimal-delta.sh
+++ b/scripts/innies-compat-exact-case-minimal-delta.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $(basename "$0") <matrix-input-dir> <output-dir>" >&2
+  exit 1
+fi
+
+node "$ROOT_DIR/scripts/innies-compat-exact-case-minimal-delta.mjs" "$1" "$2"
+
+echo "summary_file=$(cd "$2" && pwd)/minimal-delta.txt"
+echo "json_file=$(cd "$2" && pwd)/minimal-delta.json"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,6 +18,7 @@ ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-set.sh" "${BIN_DIR}/innies-b
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-get.sh" "${BIN_DIR}/innies-buyer-preference-get"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-check.sh" "${BIN_DIR}/innies-buyer-preference-check"
 ln -sf "${ROOT_DIR}/scripts/innies-slo-check.sh" "${BIN_DIR}/innies-slo-check"
+ln -sf "${ROOT_DIR}/scripts/innies-compat-exact-case-minimal-delta.sh" "${BIN_DIR}/innies-compat-exact-case-minimal-delta"
 
 rm -f \
   "${BIN_DIR}/innies-admin" \
@@ -49,6 +50,7 @@ echo "  ${BIN_DIR}/innies-buyer-preference-set -> ${ROOT_DIR}/scripts/innies-buy
 echo "  ${BIN_DIR}/innies-buyer-preference-get -> ${ROOT_DIR}/scripts/innies-buyer-preference-get.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-check -> ${ROOT_DIR}/scripts/innies-buyer-preference-check.sh"
 echo "  ${BIN_DIR}/innies-slo-check -> ${ROOT_DIR}/scripts/innies-slo-check.sh"
+echo "  ${BIN_DIR}/innies-compat-exact-case-minimal-delta -> ${ROOT_DIR}/scripts/innies-compat-exact-case-minimal-delta.sh"
 echo
 echo 'If command not found, add ~/.local/bin to PATH:'
 echo '  export PATH="$HOME/.local/bin:$PATH"'

--- a/scripts/tests/innies-compat-exact-case-minimal-delta.test.sh
+++ b/scripts/tests/innies-compat-exact-case-minimal-delta.test.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="$ROOT_DIR/scripts/innies-compat-exact-case-minimal-delta.sh"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+write_summary() {
+  local target_dir="$1"
+  local case_name="$2"
+  local status="$3"
+  local outcome="$4"
+  local lane_name="${5:-}"
+
+  mkdir -p "$target_dir"
+  {
+    printf 'case=%s\n' "$case_name"
+    if [[ -n "$lane_name" ]]; then
+      printf 'lane=%s\n' "$lane_name"
+    fi
+    printf 'status=%s\n' "$status"
+    printf 'outcome=%s\n' "$outcome"
+  } >"$target_dir/summary.txt"
+}
+
+IDENTITY_MATRIX_DIR="$TMP_DIR/identity-matrix"
+IDENTITY_OUT_DIR="$TMP_DIR/identity-out"
+mkdir -p "$IDENTITY_MATRIX_DIR/cases"
+cat >"$IDENTITY_MATRIX_DIR/summary.txt" <<'EOF'
+body_bytes=393038
+body_sha256=1717a039bed013d162eb47daead7f7eea440bccc6fb2719b9233142976e9a093
+EOF
+write_summary "$IDENTITY_MATRIX_DIR/cases/compat-exact" "compat-exact" "400" "reproduced_invalid_request_error"
+write_summary "$IDENTITY_MATRIX_DIR/cases/compat-with-direct-beta" "compat-with-direct-beta" "400" "reproduced_invalid_request_error"
+write_summary "$IDENTITY_MATRIX_DIR/cases/compat-with-direct-identity" "compat-with-direct-identity" "200" "request_succeeded"
+write_summary "$IDENTITY_MATRIX_DIR/cases/compat-with-direct-beta-and-identity" "compat-with-direct-beta-and-identity" "200" "request_succeeded"
+write_summary "$IDENTITY_MATRIX_DIR/cases/compat-with-all-direct-deltas" "compat-with-all-direct-deltas" "200" "request_succeeded"
+write_summary "$IDENTITY_MATRIX_DIR/cases/direct-exact" "direct-exact" "200" "request_succeeded"
+
+"$SCRIPT_PATH" "$IDENTITY_MATRIX_DIR" "$IDENTITY_OUT_DIR" >"$TMP_DIR/identity-stdout.txt"
+
+[[ -f "$IDENTITY_OUT_DIR/minimal-delta.txt" ]]
+[[ -f "$IDENTITY_OUT_DIR/minimal-delta.json" ]]
+grep -q '^conclusion=identity_headers_only_candidate$' "$IDENTITY_OUT_DIR/minimal-delta.txt"
+grep -q '^minimal_success_case=compat-with-direct-identity$' "$IDENTITY_OUT_DIR/minimal-delta.txt"
+grep -q '^minimal_success_delta=identity_only$' "$IDENTITY_OUT_DIR/minimal-delta.txt"
+grep -q '^summary_file=' "$TMP_DIR/identity-stdout.txt"
+
+node - "$IDENTITY_OUT_DIR/minimal-delta.json" <<'NODE'
+const fs = require('fs');
+const data = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+if (data.conclusion !== 'identity_headers_only_candidate') {
+  throw new Error(`unexpected conclusion: ${data.conclusion}`);
+}
+if (data.minimalSuccessCase !== 'compat-with-direct-identity') {
+  throw new Error(`unexpected minimal success case: ${data.minimalSuccessCase}`);
+}
+if (data.baselineReproduced !== true) {
+  throw new Error(`expected baseline reproduction to be true, got ${data.baselineReproduced}`);
+}
+NODE
+
+LANE_MATRIX_DIR="$TMP_DIR/lane-matrix"
+LANE_OUT_DIR="$TMP_DIR/lane-out"
+mkdir -p "$LANE_MATRIX_DIR/lanes/lane_alpha/cases" "$LANE_MATRIX_DIR/lanes/lane_beta/cases"
+cat >"$LANE_MATRIX_DIR/summary.txt" <<'EOF'
+body_bytes=393038
+body_sha256=1717a039bed013d162eb47daead7f7eea440bccc6fb2719b9233142976e9a093
+EOF
+write_summary "$LANE_MATRIX_DIR/lanes/lane_alpha/cases/compat-exact" "compat-exact" "400" "reproduced_invalid_request_error" "lane_alpha"
+write_summary "$LANE_MATRIX_DIR/lanes/lane_alpha/cases/compat-with-direct-identity" "compat-with-direct-identity" "200" "request_succeeded" "lane_alpha"
+write_summary "$LANE_MATRIX_DIR/lanes/lane_alpha/cases/compat-with-all-direct-deltas" "compat-with-all-direct-deltas" "200" "request_succeeded" "lane_alpha"
+write_summary "$LANE_MATRIX_DIR/lanes/lane_beta/cases/compat-exact" "compat-exact" "400" "reproduced_invalid_request_error" "lane_beta"
+write_summary "$LANE_MATRIX_DIR/lanes/lane_beta/cases/compat-with-direct-identity" "compat-with-direct-identity" "400" "reproduced_invalid_request_error" "lane_beta"
+write_summary "$LANE_MATRIX_DIR/lanes/lane_beta/cases/compat-with-all-direct-deltas" "compat-with-all-direct-deltas" "200" "request_succeeded" "lane_beta"
+
+"$SCRIPT_PATH" "$LANE_MATRIX_DIR" "$LANE_OUT_DIR" >"$TMP_DIR/lane-stdout.txt"
+
+grep -q '^conclusion=lane_specific_followup_required$' "$LANE_OUT_DIR/minimal-delta.txt"
+grep -q '^shared_minimal_success_case=-$' "$LANE_OUT_DIR/minimal-delta.txt"
+grep -q '^successful_lanes=lane_alpha,lane_beta$' "$LANE_OUT_DIR/minimal-delta.txt"
+grep -q '^lane=lane_alpha baseline_outcome=reproduced_invalid_request_error minimal_success_case=compat-with-direct-identity minimal_success_delta=identity_only successful_cases=compat-with-direct-identity,compat-with-all-direct-deltas$' "$LANE_OUT_DIR/minimal-delta.txt"
+grep -q '^lane=lane_beta baseline_outcome=reproduced_invalid_request_error minimal_success_case=compat-with-all-direct-deltas minimal_success_delta=additional_direct_delta successful_cases=compat-with-all-direct-deltas$' "$LANE_OUT_DIR/minimal-delta.txt"
+
+node - "$LANE_OUT_DIR/minimal-delta.json" <<'NODE'
+const fs = require('fs');
+const data = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+if (data.conclusion !== 'lane_specific_followup_required') {
+  throw new Error(`unexpected lane conclusion: ${data.conclusion}`);
+}
+if (data.sharedMinimalSuccessCase !== null) {
+  throw new Error(`expected no shared minimal success case, got ${data.sharedMinimalSuccessCase}`);
+}
+const perLane = Object.fromEntries(data.laneAnalyses.map((entry) => [entry.lane, entry]));
+if (perLane.lane_alpha.minimalSuccessCase !== 'compat-with-direct-identity') {
+  throw new Error('lane_alpha minimal success case mismatch');
+}
+if (perLane.lane_beta.minimalSuccessCase !== 'compat-with-all-direct-deltas') {
+  throw new Error('lane_beta minimal success case mismatch');
+}
+NODE
+
+UNIFORM_MATRIX_DIR="$TMP_DIR/uniform-matrix"
+UNIFORM_OUT_DIR="$TMP_DIR/uniform-out"
+mkdir -p "$UNIFORM_MATRIX_DIR/cases"
+write_summary "$UNIFORM_MATRIX_DIR/cases/compat-exact" "compat-exact" "400" "reproduced_invalid_request_error"
+write_summary "$UNIFORM_MATRIX_DIR/cases/compat-with-direct-beta" "compat-with-direct-beta" "400" "reproduced_invalid_request_error"
+write_summary "$UNIFORM_MATRIX_DIR/cases/compat-with-direct-identity" "compat-with-direct-identity" "400" "reproduced_invalid_request_error"
+
+"$SCRIPT_PATH" "$UNIFORM_MATRIX_DIR" "$UNIFORM_OUT_DIR" >"$TMP_DIR/uniform-stdout.txt"
+
+grep -q '^conclusion=no_controlled_case_success$' "$UNIFORM_OUT_DIR/minimal-delta.txt"
+grep -q '^minimal_success_case=-$' "$UNIFORM_OUT_DIR/minimal-delta.txt"
+
+node - "$UNIFORM_OUT_DIR/minimal-delta.json" <<'NODE'
+const fs = require('fs');
+const data = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+if (data.conclusion !== 'no_controlled_case_success') {
+  throw new Error(`unexpected uniform conclusion: ${data.conclusion}`);
+}
+if (data.minimalSuccessCase !== null) {
+  throw new Error(`expected no minimal success case, got ${data.minimalSuccessCase}`);
+}
+NODE


### PR DESCRIPTION
## Summary
- add `scripts/innies-compat-exact-case-minimal-delta.{sh,mjs}` to read exact-case matrix artifacts and identify the smallest successful controlled case, or report that no controlled case flipped at all
- cover the current issue-80 decision points in a focused shell test: identity-only flip, lane-specific mixed flip, and uniform no-flip behavior
- wire the helper into `scripts/install.sh` and `scripts/README.md`

## Why
Issue #80 already has narrow helper lanes for generating exact-case replays and summarizing broad axes, but it still needs a concrete answer to the next question: which exact first-pass case is the first one that succeeds, if any? This helper keeps the support-tooling scope narrow while turning exact-case outputs into the smallest actionable delta for the next handoff.

## Testing
- `bash scripts/tests/innies-compat-exact-case-minimal-delta.test.sh`
- `bash -n scripts/innies-compat-exact-case-minimal-delta.sh scripts/tests/innies-compat-exact-case-minimal-delta.test.sh scripts/install.sh`
- `node --check scripts/innies-compat-exact-case-minimal-delta.mjs`
- `TMP_HOME="$(mktemp -d)" && HOME="$TMP_HOME" bash scripts/install.sh >/tmp/issue80-exact-case-minimal-delta-install.out && test -L "$TMP_HOME/.local/bin/innies-compat-exact-case-minimal-delta"`
- `git diff --check`

Refs #80
