### PR TITLE
chore: add issue 80 exact-case minimal delta helper

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -24,6 +24,7 @@ innies-buyer-key-create
 innies-buyer-preference-set
 innies-buyer-preference-get
 innies-buyer-preference-check
+innies-compat-exact-case-minimal-delta
 innies-slo-check
 ```
 
@@ -39,6 +40,7 @@ What they do:
 - `innies-buyer-preference-set`: set a buyer key preference to `Claude Code`, `Codex`, or `null`
 - `innies-buyer-preference-get`: read the current buyer key preference
 - `innies-buyer-preference-check`: run the provider-preference canary after prompting for the expected provider (`Claude Code` or `Codex`)
+- `innies-compat-exact-case-minimal-delta`: read issue-80 exact-case matrix artifacts plus their replay case TSVs and report the smallest replayable header delta that changes the outcome
 - `innies-slo-check`: query analytics endpoints and report Phase 1 SLO pass/fail (TTFB p95, timeout rate, success rate, fallback rate); optional arg sets the window (default `24h`); exits 0 if all SLOs pass, 1 if any fail
 
 Behavior:
@@ -79,6 +81,8 @@ Behavior:
 - non-pinned buyer traffic always gets automatic cross-provider fallback to the other provider; flipping preference flips fallback order too
 - `innies-buyer-preference-set` prints the effective preferred provider plus the automatic fallback provider before sending the update
 - `innies-buyer-preference-check` now expects and validates the two-provider plan in DB evidence mode
+- `innies-compat-exact-case-minimal-delta` accepts an exact-case matrix output directory plus an optional case-TSV directory override; if omitted, it reads `cases_dir` from the matrix `summary.txt`
+- `innies-compat-exact-case-minimal-delta` writes `summary.txt` plus `summary.json` and highlights the smallest case delta that succeeds overall and per token lane
 
 ## Env
 

--- a/scripts/innies-compat-exact-case-minimal-delta.mjs
+++ b/scripts/innies-compat-exact-case-minimal-delta.mjs
@@ -1,0 +1,408 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const [matrixDirArg, casesDirArgRaw = '', outDirArg] = process.argv.slice(2);
+
+if (!matrixDirArg) {
+  console.error('error: missing matrix dir');
+  process.exit(1);
+}
+
+if (!outDirArg) {
+  console.error('error: missing summary output dir');
+  process.exit(1);
+}
+
+const matrixDir = path.resolve(matrixDirArg);
+const outDir = path.resolve(outDirArg);
+
+if (!fs.existsSync(matrixDir) || !fs.statSync(matrixDir).isDirectory()) {
+  console.error(`error: matrix dir not found: ${matrixDirArg}`);
+  process.exit(1);
+}
+
+function readKeyValueFile(filePath) {
+  const result = {};
+  const text = fs.readFileSync(filePath, 'utf8');
+  for (const line of text.split(/\r?\n/)) {
+    if (!line || !line.includes('=')) continue;
+    const index = line.indexOf('=');
+    const key = line.slice(0, index).trim();
+    const value = line.slice(index + 1).trim();
+    if (!key) continue;
+    result[key] = value;
+  }
+  return result;
+}
+
+function listDirectories(dirPath) {
+  if (!fs.existsSync(dirPath)) return [];
+  return fs.readdirSync(dirPath, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort();
+}
+
+function listCaseFiles(dirPath) {
+  if (!fs.existsSync(dirPath) || !fs.statSync(dirPath).isDirectory()) {
+    return [];
+  }
+  return fs.readdirSync(dirPath, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.tsv'))
+    .map((entry) => entry.name)
+    .sort();
+}
+
+function joinNames(values) {
+  return values.length > 0 ? values.join(',') : '-';
+}
+
+function uniqueSorted(values) {
+  return [...new Set(values)].sort();
+}
+
+function normalizeHeaderName(name) {
+  return String(name ?? '').trim().toLowerCase();
+}
+
+function normalizeHeaderValue(value) {
+  return String(value ?? '').trim();
+}
+
+const IGNORED_DELTA_HEADERS = new Set([
+  'authorization',
+  'content-length',
+  'host',
+  'x-request-id'
+]);
+
+function isFunctionalHeader(name) {
+  if (!name) return false;
+  if (name.startsWith(':')) return false;
+  return !IGNORED_DELTA_HEADERS.has(name);
+}
+
+function readHeadersTsv(filePath) {
+  const headers = new Map();
+  const text = fs.readFileSync(filePath, 'utf8');
+  for (const line of text.split(/\r?\n/)) {
+    if (!line) continue;
+    const index = line.indexOf('\t');
+    const headerName = normalizeHeaderName(index === -1 ? line : line.slice(0, index));
+    const headerValue = normalizeHeaderValue(index === -1 ? '' : line.slice(index + 1));
+    if (!headerName || !isFunctionalHeader(headerName)) continue;
+    headers.set(headerName, headerValue);
+  }
+  return headers;
+}
+
+function selectBaselineCase(caseNames) {
+  const preferred = ['compat-exact', 'captured-baseline', 'shared'];
+  for (const caseName of preferred) {
+    if (caseNames.includes(caseName)) {
+      return caseName;
+    }
+  }
+  const compatLike = caseNames.find((caseName) => /compat|baseline/.test(caseName));
+  return compatLike ?? caseNames[0] ?? null;
+}
+
+function parseCaseMatrix() {
+  const caseNames = listDirectories(path.join(matrixDir, 'cases'));
+  const runs = [];
+  for (const caseName of caseNames) {
+    const summaryPath = path.join(matrixDir, 'cases', caseName, 'summary.txt');
+    const summary = readKeyValueFile(summaryPath);
+    const status = Number(summary.status ?? NaN);
+    const outcome = summary.outcome ?? '';
+    if (!Number.isFinite(status) || !outcome) {
+      console.error(`error: invalid case summary file: ${summaryPath}`);
+      process.exit(1);
+    }
+    runs.push({
+      lane: 'direct',
+      case: summary.case || caseName,
+      status,
+      outcome
+    });
+  }
+  return { mode: 'case_matrix', runs };
+}
+
+function parseCaseLaneMatrix() {
+  const laneNames = listDirectories(path.join(matrixDir, 'lanes'));
+  const runs = [];
+  for (const laneName of laneNames) {
+    const casesRoot = path.join(matrixDir, 'lanes', laneName, 'cases');
+    const caseNames = listDirectories(casesRoot);
+    for (const caseName of caseNames) {
+      const metaCandidates = [
+        path.join(casesRoot, caseName, 'meta.txt'),
+        path.join(casesRoot, caseName, 'summary.txt')
+      ];
+      const metaPath = metaCandidates.find((candidate) => fs.existsSync(candidate));
+      if (!metaPath) continue;
+      const summary = readKeyValueFile(metaPath);
+      const status = Number(summary.status ?? NaN);
+      const outcome = summary.outcome ?? '';
+      if (!Number.isFinite(status) || !outcome) {
+        console.error(`error: invalid lane/case summary file: ${metaPath}`);
+        process.exit(1);
+      }
+      runs.push({
+        lane: summary.lane || laneName,
+        case: summary.case || caseName,
+        status,
+        outcome
+      });
+    }
+  }
+  return { mode: 'case_lane_matrix', runs };
+}
+
+function parseMatrixRuns() {
+  if (listDirectories(path.join(matrixDir, 'lanes')).length > 0) {
+    return parseCaseLaneMatrix();
+  }
+  if (listDirectories(path.join(matrixDir, 'cases')).length > 0) {
+    return parseCaseMatrix();
+  }
+  console.error(`error: no exact-case matrix artifacts found in ${matrixDirArg}`);
+  process.exit(1);
+}
+
+function compareHeaders(baselineHeaders, candidateHeaders) {
+  const allNames = uniqueSorted([
+    ...baselineHeaders.keys(),
+    ...candidateHeaders.keys()
+  ]);
+
+  const added = [];
+  const removed = [];
+  const changed = [];
+
+  for (const name of allNames) {
+    const inBaseline = baselineHeaders.has(name);
+    const inCandidate = candidateHeaders.has(name);
+    if (!inBaseline && inCandidate) {
+      added.push(name);
+      continue;
+    }
+    if (inBaseline && !inCandidate) {
+      removed.push(name);
+      continue;
+    }
+    if (baselineHeaders.get(name) !== candidateHeaders.get(name)) {
+      changed.push(name);
+    }
+  }
+
+  const deltaHeaders = uniqueSorted([...added, ...removed, ...changed]);
+  return {
+    added,
+    removed,
+    changed,
+    deltaHeaders,
+    deltaHeaderCount: deltaHeaders.length
+  };
+}
+
+function choosePrimaryCandidate(candidates) {
+  if (candidates.length === 0) return null;
+  return candidates.slice().sort((left, right) => {
+    if (left.deltaHeaderCount !== right.deltaHeaderCount) {
+      return left.deltaHeaderCount - right.deltaHeaderCount;
+    }
+    if (left.successfulLanes.length !== right.successfulLanes.length) {
+      return right.successfulLanes.length - left.successfulLanes.length;
+    }
+    return left.case.localeCompare(right.case);
+  })[0];
+}
+
+const rootSummaryPath = path.join(matrixDir, 'summary.txt');
+const rootSummary = fs.existsSync(rootSummaryPath) ? readKeyValueFile(rootSummaryPath) : {};
+const resolvedCasesDir = path.resolve(casesDirArgRaw || rootSummary.cases_dir || '');
+
+if (!resolvedCasesDir || !fs.existsSync(resolvedCasesDir) || !fs.statSync(resolvedCasesDir).isDirectory()) {
+  console.error('error: missing exact-case TSV directory (pass it as arg 2 or set cases_dir in matrix summary.txt)');
+  process.exit(1);
+}
+
+const { mode, runs } = parseMatrixRuns();
+
+if (runs.length === 0) {
+  console.error(`error: no runnable matrix entries found in ${matrixDirArg}`);
+  process.exit(1);
+}
+
+const runCaseNames = uniqueSorted(runs.map((run) => run.case));
+const caseFiles = listCaseFiles(resolvedCasesDir);
+const caseHeadersByName = new Map();
+
+for (const fileName of caseFiles) {
+  const caseName = fileName.replace(/\.tsv$/, '');
+  caseHeadersByName.set(caseName, readHeadersTsv(path.join(resolvedCasesDir, fileName)));
+}
+
+for (const caseName of runCaseNames) {
+  if (!caseHeadersByName.has(caseName)) {
+    console.error(`error: missing case TSV for ${caseName} in ${resolvedCasesDir}`);
+    process.exit(1);
+  }
+}
+
+const baselineCase = selectBaselineCase(runCaseNames);
+if (!baselineCase) {
+  console.error('error: could not determine baseline case');
+  process.exit(1);
+}
+
+const baselineHeaders = caseHeadersByName.get(baselineCase);
+const laneNames = uniqueSorted(runs.map((run) => run.lane));
+const baselineOutcomeByLane = {};
+
+for (const laneName of laneNames) {
+  const baselineRun = runs.find((run) => run.lane === laneName && run.case === baselineCase);
+  if (!baselineRun) {
+    console.error(`error: baseline case ${baselineCase} missing for lane ${laneName}`);
+    process.exit(1);
+  }
+  baselineOutcomeByLane[laneName] = baselineRun.outcome;
+}
+
+const perCase = {};
+for (const caseName of runCaseNames) {
+  const comparison = compareHeaders(baselineHeaders, caseHeadersByName.get(caseName));
+  const caseRuns = runs.filter((run) => run.case === caseName);
+  const successfulLanes = uniqueSorted(caseRuns.filter((run) => run.outcome === 'request_succeeded').map((run) => run.lane));
+  const failingLanes = laneNames.filter((laneName) => !successfulLanes.includes(laneName));
+  const flippedLanes = uniqueSorted(
+    caseRuns
+      .filter((run) => run.outcome !== baselineOutcomeByLane[run.lane])
+      .map((run) => run.lane)
+  );
+
+  perCase[caseName] = {
+    case: caseName,
+    ...comparison,
+    successfulLanes,
+    failingLanes,
+    flippedLanes,
+    runs: caseRuns
+  };
+}
+
+const successCandidates = Object.values(perCase)
+  .filter((entry) => entry.case !== baselineCase)
+  .filter((entry) => entry.successfulLanes.length > 0);
+const primaryMinimalSuccess = choosePrimaryCandidate(successCandidates);
+const minimalSuccessCandidates = primaryMinimalSuccess === null
+  ? []
+  : successCandidates.filter((entry) => entry.deltaHeaderCount === primaryMinimalSuccess.deltaHeaderCount);
+
+const outcomeFlipCandidates = Object.values(perCase)
+  .filter((entry) => entry.case !== baselineCase)
+  .filter((entry) => entry.flippedLanes.length > 0);
+const primaryMinimalOutcomeFlip = choosePrimaryCandidate(outcomeFlipCandidates);
+const minimalOutcomeFlipCandidates = primaryMinimalOutcomeFlip === null
+  ? []
+  : outcomeFlipCandidates.filter((entry) => entry.deltaHeaderCount === primaryMinimalOutcomeFlip.deltaHeaderCount);
+
+const perLane = {};
+for (const laneName of laneNames) {
+  const laneSuccessCandidates = Object.values(perCase)
+    .filter((entry) => entry.case !== baselineCase)
+    .filter((entry) => entry.runs.some((run) => run.lane === laneName && run.outcome === 'request_succeeded'));
+  const minimalSuccess = choosePrimaryCandidate(laneSuccessCandidates);
+  perLane[laneName] = {
+    baselineOutcome: baselineOutcomeByLane[laneName],
+    minimalSuccess: minimalSuccess
+      ? {
+          case: minimalSuccess.case,
+          deltaHeaderCount: minimalSuccess.deltaHeaderCount,
+          deltaHeaders: minimalSuccess.deltaHeaders
+        }
+      : null
+  };
+}
+
+const output = {
+  mode,
+  matrixDir,
+  casesDir: resolvedCasesDir,
+  baselineCase,
+  baselineOutcomeByLane,
+  bodyBytes: rootSummary.body_bytes || '',
+  bodySha256: rootSummary.body_sha256 || '',
+  laneNames,
+  caseNames: runCaseNames,
+  minimalSuccess: primaryMinimalSuccess
+    ? {
+        case: primaryMinimalSuccess.case,
+        deltaHeaderCount: primaryMinimalSuccess.deltaHeaderCount,
+        deltaHeaders: primaryMinimalSuccess.deltaHeaders,
+        successfulLanes: primaryMinimalSuccess.successfulLanes
+      }
+    : null,
+  minimalSuccessCases: minimalSuccessCandidates.map((entry) => entry.case),
+  minimalOutcomeFlip: primaryMinimalOutcomeFlip
+    ? {
+        case: primaryMinimalOutcomeFlip.case,
+        deltaHeaderCount: primaryMinimalOutcomeFlip.deltaHeaderCount,
+        deltaHeaders: primaryMinimalOutcomeFlip.deltaHeaders,
+        flippedLanes: primaryMinimalOutcomeFlip.flippedLanes
+      }
+    : null,
+  minimalOutcomeFlipCases: minimalOutcomeFlipCandidates.map((entry) => entry.case),
+  perCase,
+  perLane
+};
+
+fs.mkdirSync(outDir, { recursive: true });
+
+const summaryLines = [
+  `mode=${mode}`,
+  `matrix_dir=${matrixDir}`,
+  `cases_dir=${resolvedCasesDir}`,
+  `baseline_case=${baselineCase}`,
+  `baseline_outcome=${baselineOutcomeByLane[laneNames[0]] ?? ''}`,
+  `case_count=${runCaseNames.length}`,
+  `lane_count=${laneNames.length}`
+];
+
+if (output.bodyBytes) summaryLines.push(`body_bytes=${output.bodyBytes}`);
+if (output.bodySha256) summaryLines.push(`body_sha256=${output.bodySha256}`);
+
+summaryLines.push(
+  `minimal_success_delta_header_count=${primaryMinimalSuccess ? primaryMinimalSuccess.deltaHeaderCount : 0}`
+);
+summaryLines.push(`minimal_success_cases=${joinNames(output.minimalSuccessCases)}`);
+summaryLines.push(
+  `minimal_success_lanes=${primaryMinimalSuccess ? joinNames(primaryMinimalSuccess.successfulLanes) : '-'}`
+);
+summaryLines.push(
+  `minimal_success_delta_headers=${primaryMinimalSuccess ? joinNames(primaryMinimalSuccess.deltaHeaders) : '-'}`
+);
+summaryLines.push(
+  `minimal_outcome_flip_cases=${joinNames(output.minimalOutcomeFlipCases)}`
+);
+
+for (const caseName of runCaseNames) {
+  const entry = perCase[caseName];
+  summaryLines.push(
+    `case=${caseName} delta_header_count=${entry.deltaHeaderCount} delta_headers=${joinNames(entry.deltaHeaders)} successful_lanes=${joinNames(entry.successfulLanes)} failing_lanes=${joinNames(entry.failingLanes)}`
+  );
+}
+
+for (const laneName of laneNames) {
+  const lane = perLane[laneName];
+  const minimal = lane.minimalSuccess;
+  summaryLines.push(
+    `lane=${laneName} minimal_success_case=${minimal ? minimal.case : '-'} minimal_success_delta_header_count=${minimal ? minimal.deltaHeaderCount : 0} minimal_success_delta_headers=${minimal ? joinNames(minimal.deltaHeaders) : '-'}`
+  );
+}
+
+fs.writeFileSync(path.join(outDir, 'summary.json'), `${JSON.stringify(output, null, 2)}\n`);
+fs.writeFileSync(path.join(outDir, 'summary.txt'), `${summaryLines.join('\n')}\n`);

--- a/scripts/innies-compat-exact-case-minimal-delta.sh
+++ b/scripts/innies-compat-exact-case-minimal-delta.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_PATH" ]]; do
+  SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+  SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"
+  [[ "$SCRIPT_PATH" != /* ]] && SCRIPT_PATH="${SCRIPT_DIR}/${SCRIPT_PATH}"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+source "${SCRIPT_DIR}/_common.sh"
+
+MATRIX_DIR="${1:-${INNIES_EXACT_CASE_MINIMAL_DELTA_MATRIX_DIR:-}}"
+CASES_DIR="${2:-${INNIES_EXACT_CASE_MINIMAL_DELTA_CASES_DIR:-}}"
+require_nonempty 'matrix dir' "$MATRIX_DIR"
+
+OUT_DIR="${INNIES_EXACT_CASE_MINIMAL_DELTA_OUT_DIR:-${MATRIX_DIR%/}/minimal-delta}"
+mkdir -p "$OUT_DIR"
+
+node "${SCRIPT_DIR}/innies-compat-exact-case-minimal-delta.mjs" "$MATRIX_DIR" "$CASES_DIR" "$OUT_DIR"
+
+cat "$OUT_DIR/summary.txt"
+printf 'summary_file=%s\n' "$OUT_DIR/summary.txt"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,6 +17,7 @@ ln -sf "${ROOT_DIR}/scripts/innies-buyer-key-create.sh" "${BIN_DIR}/innies-buyer
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-set.sh" "${BIN_DIR}/innies-buyer-preference-set"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-get.sh" "${BIN_DIR}/innies-buyer-preference-get"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-check.sh" "${BIN_DIR}/innies-buyer-preference-check"
+ln -sf "${ROOT_DIR}/scripts/innies-compat-exact-case-minimal-delta.sh" "${BIN_DIR}/innies-compat-exact-case-minimal-delta"
 ln -sf "${ROOT_DIR}/scripts/innies-slo-check.sh" "${BIN_DIR}/innies-slo-check"
 
 rm -f \
@@ -48,6 +49,7 @@ echo "  ${BIN_DIR}/innies-buyer-key-create -> ${ROOT_DIR}/scripts/innies-buyer-k
 echo "  ${BIN_DIR}/innies-buyer-preference-set -> ${ROOT_DIR}/scripts/innies-buyer-preference-set.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-get -> ${ROOT_DIR}/scripts/innies-buyer-preference-get.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-check -> ${ROOT_DIR}/scripts/innies-buyer-preference-check.sh"
+echo "  ${BIN_DIR}/innies-compat-exact-case-minimal-delta -> ${ROOT_DIR}/scripts/innies-compat-exact-case-minimal-delta.sh"
 echo "  ${BIN_DIR}/innies-slo-check -> ${ROOT_DIR}/scripts/innies-slo-check.sh"
 echo
 echo 'If command not found, add ~/.local/bin to PATH:'

--- a/scripts/tests/innies-compat-exact-case-minimal-delta.test.sh
+++ b/scripts/tests/innies-compat-exact-case-minimal-delta.test.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="$ROOT_DIR/scripts/innies-compat-exact-case-minimal-delta.sh"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+write_case() {
+  local file_path="$1"
+  shift
+  printf '%s\n' "$@" >"$file_path"
+}
+
+write_kv() {
+  local file_path="$1"
+  shift
+  printf '%s\n' "$@" >"$file_path"
+}
+
+run_single_lane_case() {
+  local case_root="$TMP_DIR/single-lane"
+  local cases_dir="$case_root/cases-input"
+  local matrix_dir="$case_root/matrix"
+  local out_dir="$case_root/out"
+  local stdout_path="$case_root/stdout.txt"
+  local stderr_path="$case_root/stderr.txt"
+
+  mkdir -p "$cases_dir" "$matrix_dir/cases/compat-exact" "$matrix_dir/cases/compat-with-direct-beta" "$matrix_dir/cases/compat-with-direct-identity" "$matrix_dir/cases/compat-with-direct-beta-and-identity"
+
+  write_case "$cases_dir/compat-exact.tsv" \
+    $'accept\ttext/event-stream' \
+    $'anthropic-beta\tfine-grained-tool-streaming-2025-05-14' \
+    $'anthropic-version\t2023-06-01' \
+    $'x-request-id\treq_compat_exact'
+
+  write_case "$cases_dir/compat-with-direct-beta.tsv" \
+    $'accept\ttext/event-stream' \
+    $'anthropic-beta\tfine-grained-tool-streaming-2025-05-14,oauth-2025-04-20' \
+    $'anthropic-version\t2023-06-01' \
+    $'x-request-id\treq_beta_only'
+
+  write_case "$cases_dir/compat-with-direct-identity.tsv" \
+    $'accept\ttext/event-stream' \
+    $'anthropic-beta\tfine-grained-tool-streaming-2025-05-14' \
+    $'anthropic-dangerous-direct-browser-access\ttrue' \
+    $'anthropic-version\t2023-06-01' \
+    $'user-agent\tOpenClawGateway/1.0' \
+    $'x-app\tcli' \
+    $'x-request-id\treq_identity_only'
+
+  write_case "$cases_dir/compat-with-direct-beta-and-identity.tsv" \
+    $'accept\ttext/event-stream' \
+    $'anthropic-beta\tfine-grained-tool-streaming-2025-05-14,oauth-2025-04-20' \
+    $'anthropic-dangerous-direct-browser-access\ttrue' \
+    $'anthropic-version\t2023-06-01' \
+    $'user-agent\tOpenClawGateway/1.0' \
+    $'x-app\tcli' \
+    $'x-request-id\treq_beta_and_identity'
+
+  write_kv "$matrix_dir/summary.txt" \
+    "body_bytes=398262" \
+    "body_sha256=1717a039bed013d162eb47daead7f7eea440bccc6fb2719b9233142976e9a093" \
+    "cases_dir=$cases_dir"
+
+  write_kv "$matrix_dir/cases/compat-exact/summary.txt" \
+    "case=compat-exact" \
+    "status=400" \
+    "outcome=reproduced_invalid_request_error"
+
+  write_kv "$matrix_dir/cases/compat-with-direct-beta/summary.txt" \
+    "case=compat-with-direct-beta" \
+    "status=400" \
+    "outcome=reproduced_invalid_request_error"
+
+  write_kv "$matrix_dir/cases/compat-with-direct-identity/summary.txt" \
+    "case=compat-with-direct-identity" \
+    "status=200" \
+    "outcome=request_succeeded"
+
+  write_kv "$matrix_dir/cases/compat-with-direct-beta-and-identity/summary.txt" \
+    "case=compat-with-direct-beta-and-identity" \
+    "status=200" \
+    "outcome=request_succeeded"
+
+  set +e
+  INNIES_EXACT_CASE_MINIMAL_DELTA_OUT_DIR="$out_dir" \
+    "$SCRIPT_PATH" "$matrix_dir" >"$stdout_path" 2>"$stderr_path"
+  local status=$?
+  set -e
+
+  if [[ "$status" -ne 0 ]]; then
+    cat "$stderr_path" >&2
+    exit 1
+  fi
+
+  [[ -f "$out_dir/summary.txt" ]]
+  [[ -f "$out_dir/summary.json" ]]
+
+  grep -q '^mode=case_matrix$' "$out_dir/summary.txt"
+  grep -q '^baseline_case=compat-exact$' "$out_dir/summary.txt"
+  grep -q '^baseline_outcome=reproduced_invalid_request_error$' "$out_dir/summary.txt"
+  grep -q '^minimal_success_delta_header_count=3$' "$out_dir/summary.txt"
+  grep -q '^minimal_success_cases=compat-with-direct-identity$' "$out_dir/summary.txt"
+  grep -q '^minimal_success_lanes=direct$' "$out_dir/summary.txt"
+  grep -q '^minimal_success_delta_headers=anthropic-dangerous-direct-browser-access,user-agent,x-app$' "$out_dir/summary.txt"
+  grep -q '^case=compat-with-direct-identity delta_header_count=3 delta_headers=anthropic-dangerous-direct-browser-access,user-agent,x-app successful_lanes=direct failing_lanes=-$' "$out_dir/summary.txt"
+
+  node - "$out_dir/summary.json" <<'NODE'
+const fs = require('fs');
+const summary = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+if (summary.minimalSuccess.case !== 'compat-with-direct-identity') {
+  throw new Error(`unexpected minimal success case: ${summary.minimalSuccess.case}`);
+}
+if (summary.minimalSuccess.deltaHeaderCount !== 3) {
+  throw new Error(`unexpected minimal success delta count: ${summary.minimalSuccess.deltaHeaderCount}`);
+}
+if (summary.minimalSuccess.deltaHeaders.join(',') !== 'anthropic-dangerous-direct-browser-access,user-agent,x-app') {
+  throw new Error(`unexpected minimal success delta headers: ${summary.minimalSuccess.deltaHeaders.join(',')}`);
+}
+NODE
+}
+
+run_multi_lane_case() {
+  local case_root="$TMP_DIR/multi-lane"
+  local cases_dir="$case_root/cases-input"
+  local matrix_dir="$case_root/matrix"
+  local out_dir="$case_root/out"
+
+  mkdir -p \
+    "$cases_dir" \
+    "$matrix_dir/lanes/claude-oauth/cases/compat-exact" \
+    "$matrix_dir/lanes/claude-oauth/cases/compat-with-direct-identity" \
+    "$matrix_dir/lanes/claude-oauth/cases/compat-with-direct-beta-and-identity" \
+    "$matrix_dir/lanes/openclaw-direct/cases/compat-exact" \
+    "$matrix_dir/lanes/openclaw-direct/cases/compat-with-direct-identity" \
+    "$matrix_dir/lanes/openclaw-direct/cases/compat-with-direct-beta-and-identity"
+
+  write_case "$cases_dir/compat-exact.tsv" \
+    $'accept\ttext/event-stream' \
+    $'anthropic-beta\tfine-grained-tool-streaming-2025-05-14' \
+    $'anthropic-version\t2023-06-01'
+
+  write_case "$cases_dir/compat-with-direct-identity.tsv" \
+    $'accept\ttext/event-stream' \
+    $'anthropic-beta\tfine-grained-tool-streaming-2025-05-14' \
+    $'anthropic-dangerous-direct-browser-access\ttrue' \
+    $'anthropic-version\t2023-06-01' \
+    $'user-agent\tOpenClawGateway/1.0' \
+    $'x-app\tcli'
+
+  write_case "$cases_dir/compat-with-direct-beta-and-identity.tsv" \
+    $'accept\ttext/event-stream' \
+    $'anthropic-beta\tfine-grained-tool-streaming-2025-05-14,oauth-2025-04-20' \
+    $'anthropic-dangerous-direct-browser-access\ttrue' \
+    $'anthropic-version\t2023-06-01' \
+    $'user-agent\tOpenClawGateway/1.0' \
+    $'x-app\tcli'
+
+  write_kv "$matrix_dir/summary.txt" \
+    "body_bytes=398262" \
+    "body_sha256=1717a039bed013d162eb47daead7f7eea440bccc6fb2719b9233142976e9a093" \
+    "cases_dir=$cases_dir"
+
+  write_kv "$matrix_dir/lanes/claude-oauth/cases/compat-exact/meta.txt" \
+    "lane=claude-oauth" \
+    "case=compat-exact" \
+    "status=400" \
+    "outcome=reproduced_invalid_request_error"
+
+  write_kv "$matrix_dir/lanes/claude-oauth/cases/compat-with-direct-identity/meta.txt" \
+    "lane=claude-oauth" \
+    "case=compat-with-direct-identity" \
+    "status=200" \
+    "outcome=request_succeeded"
+
+  write_kv "$matrix_dir/lanes/claude-oauth/cases/compat-with-direct-beta-and-identity/meta.txt" \
+    "lane=claude-oauth" \
+    "case=compat-with-direct-beta-and-identity" \
+    "status=200" \
+    "outcome=request_succeeded"
+
+  write_kv "$matrix_dir/lanes/openclaw-direct/cases/compat-exact/meta.txt" \
+    "lane=openclaw-direct" \
+    "case=compat-exact" \
+    "status=400" \
+    "outcome=reproduced_invalid_request_error"
+
+  write_kv "$matrix_dir/lanes/openclaw-direct/cases/compat-with-direct-identity/meta.txt" \
+    "lane=openclaw-direct" \
+    "case=compat-with-direct-identity" \
+    "status=400" \
+    "outcome=reproduced_invalid_request_error"
+
+  write_kv "$matrix_dir/lanes/openclaw-direct/cases/compat-with-direct-beta-and-identity/meta.txt" \
+    "lane=openclaw-direct" \
+    "case=compat-with-direct-beta-and-identity" \
+    "status=200" \
+    "outcome=request_succeeded"
+
+  INNIES_EXACT_CASE_MINIMAL_DELTA_OUT_DIR="$out_dir" \
+    "$SCRIPT_PATH" "$matrix_dir"
+
+  grep -q '^mode=case_lane_matrix$' "$out_dir/summary.txt"
+  grep -q '^minimal_success_cases=compat-with-direct-identity$' "$out_dir/summary.txt"
+  grep -q '^lane=claude-oauth minimal_success_case=compat-with-direct-identity minimal_success_delta_header_count=3 minimal_success_delta_headers=anthropic-dangerous-direct-browser-access,user-agent,x-app$' "$out_dir/summary.txt"
+  grep -q '^lane=openclaw-direct minimal_success_case=compat-with-direct-beta-and-identity minimal_success_delta_header_count=4 minimal_success_delta_headers=anthropic-beta,anthropic-dangerous-direct-browser-access,user-agent,x-app$' "$out_dir/summary.txt"
+
+  node - "$out_dir/summary.json" <<'NODE'
+const fs = require('fs');
+const summary = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+if (summary.mode !== 'case_lane_matrix') {
+  throw new Error(`unexpected mode: ${summary.mode}`);
+}
+if (!summary.perLane?.['claude-oauth']) {
+  throw new Error('missing claude-oauth lane details');
+}
+if (summary.perLane['claude-oauth'].minimalSuccess.case !== 'compat-with-direct-identity') {
+  throw new Error(`unexpected claude-oauth minimal success case: ${summary.perLane['claude-oauth'].minimalSuccess.case}`);
+}
+if (summary.perLane['openclaw-direct'].minimalSuccess.case !== 'compat-with-direct-beta-and-identity') {
+  throw new Error(`unexpected openclaw-direct minimal success case: ${summary.perLane['openclaw-direct'].minimalSuccess.case}`);
+}
+NODE
+}
+
+run_single_lane_case
+run_multi_lane_case


### PR DESCRIPTION
## Summary
- add `scripts/innies-compat-exact-case-minimal-delta.sh` plus a small Node parser that reads issue-80 exact-case matrix artifacts and reports the smallest replayable header delta that changes the outcome
- infer the replay case directory from the matrix `summary.txt` when available, while still allowing an explicit override for ad hoc runs
- wire the helper into `scripts/install.sh` / `scripts/README.md` and cover both single-lane and multi-lane matrix flows with a focused shell regression

## Why
- issue `#80` now has tooling to generate exact cases, run the matrix, and classify whether behavior varies by case or lane, but it still lacked a direct answer to the next question: which smallest header delta actually flips the result
- this keeps the investigation evidence-first and avoids another bundled workflow wrapper or runtime proxy change

## Verification
- `bash scripts/tests/innies-compat-exact-case-minimal-delta.test.sh`
- `bash -n scripts/innies-compat-exact-case-minimal-delta.sh scripts/tests/innies-compat-exact-case-minimal-delta.test.sh scripts/install.sh`
- `node --check scripts/innies-compat-exact-case-minimal-delta.mjs`
- `TMP_HOME="$(mktemp -d)"; HOME="$TMP_HOME" bash scripts/install.sh >/tmp/issue80-exact-case-minimal-delta-install.out && test -L "$TMP_HOME/.local/bin/innies-compat-exact-case-minimal-delta"`
- `git diff --check`

Refs #80
