### PR TITLE
chore: add issue 80 direct payload summary helper

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -25,6 +25,7 @@ innies-buyer-preference-set
 innies-buyer-preference-get
 innies-buyer-preference-check
 innies-slo-check
+innies-compat-direct-payload-summary
 ```
 
 What they do:
@@ -40,6 +41,7 @@ What they do:
 - `innies-buyer-preference-get`: read the current buyer key preference
 - `innies-buyer-preference-check`: run the provider-preference canary after prompting for the expected provider (`Claude Code` or `Codex`)
 - `innies-slo-check`: query analytics endpoints and report Phase 1 SLO pass/fail (TTFB p95, timeout rate, success rate, fallback rate); optional arg sets the window (default `24h`); exits 0 if all SLOs pass, 1 if any fail
+- `innies-compat-direct-payload-summary`: summarize issue-80 direct payload-matrix artifacts so transcript-shape-specific outcomes vs uniform/provider-side candidates are explicit without manual log inspection
 
 Behavior:
 - org id auto-uses `INNIES_ORG_ID`

--- a/scripts/innies-compat-direct-payload-summary.mjs
+++ b/scripts/innies-compat-direct-payload-summary.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const [inputPathArg, outDirArg] = process.argv.slice(2);
+
+if (!inputPathArg) {
+  console.error('error: missing payload matrix input path');
+  process.exit(1);
+}
+
+if (!outDirArg) {
+  console.error('error: missing summary output dir');
+  process.exit(1);
+}
+
+const inputPath = path.resolve(inputPathArg);
+const outDir = path.resolve(outDirArg);
+
+if (!fs.existsSync(inputPath)) {
+  console.error(`error: payload summary input path not found: ${inputPathArg}`);
+  process.exit(1);
+}
+
+const matrixDir = fs.statSync(inputPath).isDirectory() ? inputPath : path.dirname(inputPath);
+const payloadsDir = path.join(matrixDir, 'payloads');
+const rootSummaryPath = path.join(matrixDir, 'summary.txt');
+
+if (!fs.existsSync(payloadsDir) || !fs.statSync(payloadsDir).isDirectory()) {
+  console.error(`error: payload matrix artifacts not found in ${matrixDir}`);
+  process.exit(1);
+}
+
+fs.mkdirSync(outDir, { recursive: true });
+
+function readKeyValueFile(filePath) {
+  const result = {};
+  const text = fs.readFileSync(filePath, 'utf8');
+  for (const line of text.split(/\r?\n/)) {
+    if (!line || !line.includes('=')) continue;
+    const index = line.indexOf('=');
+    const key = line.slice(0, index).trim();
+    const value = line.slice(index + 1).trim();
+    if (!key) continue;
+    result[key] = value;
+  }
+  return result;
+}
+
+function listDirectories(dirPath) {
+  return fs.readdirSync(dirPath, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort();
+}
+
+function outcomeToken(run) {
+  return `${run.status}:${run.outcome}`;
+}
+
+function joinNames(values) {
+  return values.length > 0 ? values.join(',') : '-';
+}
+
+const rootSummary = fs.existsSync(rootSummaryPath) ? readKeyValueFile(rootSummaryPath) : {};
+const payloadNames = listDirectories(payloadsDir);
+
+if (payloadNames.length === 0) {
+  console.error(`error: no payload artifacts found in ${matrixDir}`);
+  process.exit(1);
+}
+
+const runs = payloadNames.map((payloadName) => {
+  const metaPath = path.join(payloadsDir, payloadName, 'meta.txt');
+  if (!fs.existsSync(metaPath)) {
+    console.error(`error: missing payload meta file: ${metaPath}`);
+    process.exit(1);
+  }
+  const summary = readKeyValueFile(metaPath);
+  const status = Number(summary.status ?? NaN);
+  const outcome = summary.outcome ?? '';
+  if (!Number.isFinite(status) || !outcome) {
+    console.error(`error: invalid payload meta file: ${metaPath}`);
+    process.exit(1);
+  }
+  return {
+    payload: summary.payload || payloadName,
+    status,
+    outcome,
+    providerRequestId: summary.provider_request_id || '',
+    requestId: summary.request_id || '',
+    tokenSource: summary.token_source || '',
+    payloadSha256: summary.payload_sha256 || '',
+    payloadBytes: summary.payload_bytes || ''
+  };
+});
+
+const runCount = runs.length;
+const successRuns = runs.filter((run) => run.outcome === 'request_succeeded');
+const invalidRuns = runs.filter((run) => run.outcome === 'reproduced_invalid_request_error');
+const otherRuns = runs.filter((run) => !['request_succeeded', 'reproduced_invalid_request_error'].includes(run.outcome));
+const uniqueOutcomeTokens = [...new Set(runs.map(outcomeToken))];
+const allSuccess = successRuns.length === runCount;
+const allInvalidRequest = invalidRuns.length === runCount;
+const payloadSensitive = runCount > 1 && uniqueOutcomeTokens.length > 1;
+const uniformFailure = runCount > 1 && !allSuccess && uniqueOutcomeTokens.length === 1;
+
+let classification = 'non_uniform_failure';
+if (allSuccess) {
+  classification = 'all_success';
+} else if (runCount === 1) {
+  classification = 'single_payload_only';
+} else if (payloadSensitive) {
+  classification = 'transcript_shape_specific';
+} else if (uniformFailure) {
+  classification = 'uniform_failure_provider_side_candidate';
+}
+
+const successfulPayloads = runs.filter((run) => run.outcome === 'request_succeeded').map((run) => run.payload);
+const failingPayloads = runs.filter((run) => run.outcome !== 'request_succeeded').map((run) => run.payload);
+
+const output = {
+  mode: 'payload_matrix',
+  inputPath,
+  inputDir: matrixDir,
+  outputDir: outDir,
+  payloadCount: runCount,
+  successCount: successRuns.length,
+  invalidRequestCount: invalidRuns.length,
+  otherCount: otherRuns.length,
+  classification,
+  payloadSensitive,
+  uniformFailure,
+  allInvalidRequest,
+  allSuccess,
+  successfulPayloads,
+  failingPayloads,
+  rootSummary,
+  payloadSummaries: runs
+};
+
+const summaryLines = [];
+summaryLines.push('mode=payload_matrix');
+summaryLines.push(`input_dir=${matrixDir}`);
+summaryLines.push(`payload_count=${runCount}`);
+if (rootSummary.target_url) summaryLines.push(`target_url=${rootSummary.target_url}`);
+if (rootSummary.payload_matrix_tsv) summaryLines.push(`payload_matrix_tsv=${rootSummary.payload_matrix_tsv}`);
+if (rootSummary.headers_tsv_path) summaryLines.push(`headers_tsv_path=${rootSummary.headers_tsv_path}`);
+if (rootSummary.direct_access_token_source) summaryLines.push(`direct_access_token_source=${rootSummary.direct_access_token_source}`);
+summaryLines.push(`success_count=${successRuns.length}`);
+summaryLines.push(`invalid_request_count=${invalidRuns.length}`);
+summaryLines.push(`other_count=${otherRuns.length}`);
+summaryLines.push(`classification=${classification}`);
+summaryLines.push(`payload_sensitive=${String(payloadSensitive)}`);
+summaryLines.push(`uniform_failure=${String(uniformFailure)}`);
+summaryLines.push(`all_invalid_request=${String(allInvalidRequest)}`);
+summaryLines.push(`all_success=${String(allSuccess)}`);
+summaryLines.push(`successful_payloads=${joinNames(successfulPayloads)}`);
+summaryLines.push(`failing_payloads=${joinNames(failingPayloads)}`);
+
+for (const run of runs) {
+  summaryLines.push(
+    `payload=${run.payload} status=${run.status} outcome=${run.outcome} provider_request_id=${run.providerRequestId || '-'} payload_bytes=${run.payloadBytes || '-'}`
+  );
+}
+
+fs.writeFileSync(path.join(outDir, 'summary.json'), `${JSON.stringify(output, null, 2)}\n`);
+fs.writeFileSync(path.join(outDir, 'summary.txt'), `${summaryLines.join('\n')}\n`);

--- a/scripts/innies-compat-direct-payload-summary.sh
+++ b/scripts/innies-compat-direct-payload-summary.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_PATH" ]]; do
+  SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+  SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"
+  [[ "$SCRIPT_PATH" != /* ]] && SCRIPT_PATH="${SCRIPT_DIR}/${SCRIPT_PATH}"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+source "${SCRIPT_DIR}/_common.sh"
+
+INPUT_PATH="${1:-${INNIES_DIRECT_PAYLOAD_SUMMARY_INPUT:-}}"
+require_nonempty 'direct payload summary input path' "$INPUT_PATH"
+
+if [[ ! -e "$INPUT_PATH" ]]; then
+  echo "error: payload summary input path not found: $INPUT_PATH" >&2
+  exit 1
+fi
+
+INPUT_DIR="$INPUT_PATH"
+if [[ -f "$INPUT_PATH" ]]; then
+  INPUT_DIR="$(cd "$(dirname "$INPUT_PATH")" && pwd)"
+fi
+
+OUT_DIR="${2:-${INNIES_DIRECT_PAYLOAD_SUMMARY_OUT_DIR:-${INPUT_DIR%/}/analysis}}"
+mkdir -p "$OUT_DIR"
+
+if ! command -v node >/dev/null 2>&1; then
+  echo 'error: node is required for innies-compat-direct-payload-summary.sh' >&2
+  exit 1
+fi
+
+node "${SCRIPT_DIR}/innies-compat-direct-payload-summary.mjs" "$INPUT_PATH" "$OUT_DIR"
+
+SUMMARY_FILE="$OUT_DIR/summary.txt"
+cat "$SUMMARY_FILE"
+printf 'summary_file=%s\n' "$SUMMARY_FILE"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,6 +18,7 @@ ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-set.sh" "${BIN_DIR}/innies-b
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-get.sh" "${BIN_DIR}/innies-buyer-preference-get"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-check.sh" "${BIN_DIR}/innies-buyer-preference-check"
 ln -sf "${ROOT_DIR}/scripts/innies-slo-check.sh" "${BIN_DIR}/innies-slo-check"
+ln -sf "${ROOT_DIR}/scripts/innies-compat-direct-payload-summary.sh" "${BIN_DIR}/innies-compat-direct-payload-summary"
 
 rm -f \
   "${BIN_DIR}/innies-admin" \
@@ -49,6 +50,7 @@ echo "  ${BIN_DIR}/innies-buyer-preference-set -> ${ROOT_DIR}/scripts/innies-buy
 echo "  ${BIN_DIR}/innies-buyer-preference-get -> ${ROOT_DIR}/scripts/innies-buyer-preference-get.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-check -> ${ROOT_DIR}/scripts/innies-buyer-preference-check.sh"
 echo "  ${BIN_DIR}/innies-slo-check -> ${ROOT_DIR}/scripts/innies-slo-check.sh"
+echo "  ${BIN_DIR}/innies-compat-direct-payload-summary -> ${ROOT_DIR}/scripts/innies-compat-direct-payload-summary.sh"
 echo
 echo 'If command not found, add ~/.local/bin to PATH:'
 echo '  export PATH="$HOME/.local/bin:$PATH"'

--- a/scripts/tests/innies-compat-direct-payload-summary.test.sh
+++ b/scripts/tests/innies-compat-direct-payload-summary.test.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="$ROOT_DIR/scripts/innies-compat-direct-payload-summary.sh"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+write_lines() {
+  local file="$1"
+  shift
+  mkdir -p "$(dirname "$file")"
+  printf '%s\n' "$@" >"$file"
+}
+
+payload_specific_dir="$TMP_DIR/payload-specific"
+write_lines "$payload_specific_dir/summary.txt" \
+  "target_url=https://api.anthropic.com/v1/messages" \
+  "headers_tsv_path=/tmp/direct-headers.tsv" \
+  "direct_access_token_source=claude_code_oauth_token" \
+  "payload=shape_good status=200 provider_request_id=req_provider_good request_id=req_issue80_payload_matrix_shape_good token_source=claude_code_oauth_token payload_sha256=sha_good payload_bytes=144" \
+  "payload=shape_bad status=400 provider_request_id=req_provider_bad request_id=req_issue80_payload_matrix_shape_bad token_source=claude_code_oauth_token payload_sha256=sha_bad payload_bytes=288" \
+  "payload_count=2"
+write_lines "$payload_specific_dir/payloads/shape_good/meta.txt" \
+  "payload=shape_good" \
+  "status=200" \
+  "outcome=request_succeeded" \
+  "provider_request_id=req_provider_good" \
+  "request_id=req_issue80_payload_matrix_shape_good" \
+  "token_source=claude_code_oauth_token" \
+  "payload_sha256=sha_good" \
+  "payload_bytes=144"
+write_lines "$payload_specific_dir/payloads/shape_bad/meta.txt" \
+  "payload=shape_bad" \
+  "status=400" \
+  "outcome=reproduced_invalid_request_error" \
+  "provider_request_id=req_provider_bad" \
+  "request_id=req_issue80_payload_matrix_shape_bad" \
+  "token_source=claude_code_oauth_token" \
+  "payload_sha256=sha_bad" \
+  "payload_bytes=288"
+
+uniform_failure_dir="$TMP_DIR/uniform-failure"
+write_lines "$uniform_failure_dir/summary.txt" \
+  "target_url=https://api.anthropic.com/v1/messages" \
+  "payload=preserved_fail status=400 provider_request_id=req_uniform request_id=req_issue80_payload_matrix_preserved_fail token_source=literal payload_sha256=sha_fail_a payload_bytes=398262" \
+  "payload=known_good_direct status=400 provider_request_id=req_uniform request_id=req_issue80_payload_matrix_known_good_direct token_source=literal payload_sha256=sha_fail_b payload_bytes=1552" \
+  "payload_count=2"
+write_lines "$uniform_failure_dir/payloads/preserved_fail/meta.txt" \
+  "payload=preserved_fail" \
+  "status=400" \
+  "outcome=reproduced_invalid_request_error" \
+  "provider_request_id=req_uniform" \
+  "request_id=req_issue80_payload_matrix_preserved_fail" \
+  "token_source=literal" \
+  "payload_sha256=sha_fail_a" \
+  "payload_bytes=398262"
+write_lines "$uniform_failure_dir/payloads/known_good_direct/meta.txt" \
+  "payload=known_good_direct" \
+  "status=400" \
+  "outcome=reproduced_invalid_request_error" \
+  "provider_request_id=req_uniform" \
+  "request_id=req_issue80_payload_matrix_known_good_direct" \
+  "token_source=literal" \
+  "payload_sha256=sha_fail_b" \
+  "payload_bytes=1552"
+
+single_payload_dir="$TMP_DIR/single-payload"
+write_lines "$single_payload_dir/summary.txt" \
+  "target_url=https://api.anthropic.com/v1/messages" \
+  "payload=only_payload status=400 provider_request_id=req_single request_id=req_issue80_payload_matrix_only_payload token_source=literal payload_sha256=sha_single payload_bytes=512" \
+  "payload_count=1"
+write_lines "$single_payload_dir/payloads/only_payload/meta.txt" \
+  "payload=only_payload" \
+  "status=400" \
+  "outcome=reproduced_invalid_request_error" \
+  "provider_request_id=req_single" \
+  "request_id=req_issue80_payload_matrix_only_payload" \
+  "token_source=literal" \
+  "payload_sha256=sha_single" \
+  "payload_bytes=512"
+
+all_success_dir="$TMP_DIR/all-success"
+write_lines "$all_success_dir/summary.txt" \
+  "target_url=https://api.anthropic.com/v1/messages" \
+  "payload=shape_alpha status=200 provider_request_id=req_alpha request_id=req_issue80_payload_matrix_shape_alpha token_source=claude_code_oauth_token payload_sha256=sha_alpha payload_bytes=1024" \
+  "payload=shape_beta status=200 provider_request_id=req_beta request_id=req_issue80_payload_matrix_shape_beta token_source=claude_code_oauth_token payload_sha256=sha_beta payload_bytes=2048" \
+  "payload_count=2"
+write_lines "$all_success_dir/payloads/shape_alpha/meta.txt" \
+  "payload=shape_alpha" \
+  "status=200" \
+  "outcome=request_succeeded" \
+  "provider_request_id=req_alpha" \
+  "request_id=req_issue80_payload_matrix_shape_alpha" \
+  "token_source=claude_code_oauth_token" \
+  "payload_sha256=sha_alpha" \
+  "payload_bytes=1024"
+write_lines "$all_success_dir/payloads/shape_beta/meta.txt" \
+  "payload=shape_beta" \
+  "status=200" \
+  "outcome=request_succeeded" \
+  "provider_request_id=req_beta" \
+  "request_id=req_issue80_payload_matrix_shape_beta" \
+  "token_source=claude_code_oauth_token" \
+  "payload_sha256=sha_beta" \
+  "payload_bytes=2048"
+
+run_summary() {
+  local input_path="$1"
+  local output_dir="$2"
+  local stdout_path="$3"
+  local stderr_path="$4"
+  INNIES_DIRECT_PAYLOAD_SUMMARY_OUT_DIR="$output_dir" "$SCRIPT_PATH" "$input_path" >"$stdout_path" 2>"$stderr_path"
+}
+
+run_summary "$payload_specific_dir/summary.txt" "$TMP_DIR/payload-specific-summary" "$TMP_DIR/payload-specific.stdout" "$TMP_DIR/payload-specific.stderr"
+run_summary "$uniform_failure_dir" "$TMP_DIR/uniform-failure-summary" "$TMP_DIR/uniform-failure.stdout" "$TMP_DIR/uniform-failure.stderr"
+run_summary "$single_payload_dir" "$TMP_DIR/single-payload-summary" "$TMP_DIR/single-payload.stdout" "$TMP_DIR/single-payload.stderr"
+run_summary "$all_success_dir" "$TMP_DIR/all-success-summary" "$TMP_DIR/all-success.stdout" "$TMP_DIR/all-success.stderr"
+
+[[ -f "$TMP_DIR/payload-specific-summary/summary.txt" ]]
+[[ -f "$TMP_DIR/payload-specific-summary/summary.json" ]]
+grep -q '^mode=payload_matrix$' "$TMP_DIR/payload-specific-summary/summary.txt"
+grep -q '^classification=transcript_shape_specific$' "$TMP_DIR/payload-specific-summary/summary.txt"
+grep -q '^payload_sensitive=true$' "$TMP_DIR/payload-specific-summary/summary.txt"
+grep -q '^uniform_failure=false$' "$TMP_DIR/payload-specific-summary/summary.txt"
+grep -q '^successful_payloads=shape_good$' "$TMP_DIR/payload-specific-summary/summary.txt"
+grep -q '^failing_payloads=shape_bad$' "$TMP_DIR/payload-specific-summary/summary.txt"
+grep -q '^payload=shape_good status=200 outcome=request_succeeded provider_request_id=req_provider_good payload_bytes=144$' "$TMP_DIR/payload-specific-summary/summary.txt"
+grep -q '^payload=shape_bad status=400 outcome=reproduced_invalid_request_error provider_request_id=req_provider_bad payload_bytes=288$' "$TMP_DIR/payload-specific-summary/summary.txt"
+grep -q '^summary_file=' "$TMP_DIR/payload-specific.stdout"
+
+[[ -f "$TMP_DIR/uniform-failure-summary/summary.txt" ]]
+[[ -f "$TMP_DIR/uniform-failure-summary/summary.json" ]]
+grep -q '^classification=uniform_failure_provider_side_candidate$' "$TMP_DIR/uniform-failure-summary/summary.txt"
+grep -q '^payload_sensitive=false$' "$TMP_DIR/uniform-failure-summary/summary.txt"
+grep -q '^uniform_failure=true$' "$TMP_DIR/uniform-failure-summary/summary.txt"
+grep -q '^all_invalid_request=true$' "$TMP_DIR/uniform-failure-summary/summary.txt"
+
+[[ -f "$TMP_DIR/single-payload-summary/summary.txt" ]]
+grep -q '^classification=single_payload_only$' "$TMP_DIR/single-payload-summary/summary.txt"
+grep -q '^payload_count=1$' "$TMP_DIR/single-payload-summary/summary.txt"
+
+[[ -f "$TMP_DIR/all-success-summary/summary.txt" ]]
+grep -q '^classification=all_success$' "$TMP_DIR/all-success-summary/summary.txt"
+grep -q '^all_success=true$' "$TMP_DIR/all-success-summary/summary.txt"
+
+node - "$TMP_DIR/payload-specific-summary/summary.json" "$TMP_DIR/uniform-failure-summary/summary.json" "$TMP_DIR/single-payload-summary/summary.json" "$TMP_DIR/all-success-summary/summary.json" <<'NODE'
+const fs = require('fs');
+
+const [payloadSpecificPath, uniformFailurePath, singlePayloadPath, allSuccessPath] = process.argv.slice(2);
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+const payloadSpecific = readJson(payloadSpecificPath);
+const uniformFailure = readJson(uniformFailurePath);
+const singlePayload = readJson(singlePayloadPath);
+const allSuccess = readJson(allSuccessPath);
+
+if (payloadSpecific.classification !== 'transcript_shape_specific') {
+  throw new Error('payload-specific classification mismatch');
+}
+if (payloadSpecific.payloadSummaries.length !== 2) {
+  throw new Error('payload-specific summary count mismatch');
+}
+if (uniformFailure.classification !== 'uniform_failure_provider_side_candidate') {
+  throw new Error('uniform failure classification mismatch');
+}
+if (uniformFailure.uniformFailure !== true) {
+  throw new Error('uniform failure flag mismatch');
+}
+if (singlePayload.classification !== 'single_payload_only') {
+  throw new Error('single payload classification mismatch');
+}
+if (allSuccess.classification !== 'all_success') {
+  throw new Error('all success classification mismatch');
+}
+if (allSuccess.successCount !== 2) {
+  throw new Error('all success count mismatch');
+}
+NODE


### PR DESCRIPTION
Refs #80

## Summary
- add `scripts/innies-compat-direct-payload-summary.sh` plus `scripts/innies-compat-direct-payload-summary.mjs` to classify direct payload-matrix artifacts as `transcript_shape_specific`, `uniform_failure_provider_side_candidate`, `all_success`, or `single_payload_only`
- emit both `summary.txt` and `summary.json` from either a payload-matrix output directory or its root `summary.txt`, so the payload-axis evidence from `#115` no longer needs manual interpretation
- wire the helper into `scripts/install.sh` / `scripts/README.md` and add focused shell coverage for payload-specific, uniform-failure, single-payload, and all-success cases

## Why
The live `#80` helper lanes now have a clean producer for the payload axis in `PR #115`, but the issue still lacks a narrow interpretation layer for deciding whether those outcomes point at transcript-shape-specific behavior or a uniform/provider-side candidate. This PR adds that analysis slice without rebundling the open payload-matrix producer or touching the runtime proxy path.

## Verification
- `bash scripts/tests/innies-compat-direct-payload-summary.test.sh`
- `bash -n scripts/innies-compat-direct-payload-summary.sh scripts/tests/innies-compat-direct-payload-summary.test.sh scripts/install.sh`
- `node --check scripts/innies-compat-direct-payload-summary.mjs`
- `TMP_HOME="$(mktemp -d)" && HOME="$TMP_HOME" bash scripts/install.sh >/tmp/issue80-direct-payload-summary-install.out && test -L "$TMP_HOME/.local/bin/innies-compat-direct-payload-summary"`
- `git diff --check HEAD~1..HEAD`
