### PR TITLE
chore: add issue 80 direct payload summary helper

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -41,6 +41,9 @@ What they do:
 - `innies-buyer-preference-check`: run the provider-preference canary after prompting for the expected provider (`Claude Code` or `Codex`)
 - `innies-slo-check`: query analytics endpoints and report Phase 1 SLO pass/fail (TTFB p95, timeout rate, success rate, fallback rate); optional arg sets the window (default `24h`); exits 0 if all SLOs pass, 1 if any fail
 
+Issue 80 helper:
+- `innies-compat-direct-payload-summary`: read direct payload-matrix artifacts and classify whether outcomes are payload-shape-specific, uniformly failing, or all succeeding under one fixed direct Anthropic lane
+
 Behavior:
 - org id auto-uses `INNIES_ORG_ID`
 - token expiry is auto-filled because the API still requires `expiresAt`

--- a/scripts/innies-compat-direct-payload-summary.mjs
+++ b/scripts/innies-compat-direct-payload-summary.mjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const [inputArg, outDirArg] = process.argv.slice(2);
+
+if (!inputArg) {
+  console.error('error: missing payload-matrix input path');
+  process.exit(1);
+}
+
+if (!outDirArg) {
+  console.error('error: missing summary output dir');
+  process.exit(1);
+}
+
+function resolveInputDir(inputPathArg) {
+  const resolved = path.resolve(inputPathArg);
+  if (!fs.existsSync(resolved)) {
+    console.error(`error: payload-matrix input path not found: ${inputPathArg}`);
+    process.exit(1);
+  }
+  const stats = fs.statSync(resolved);
+  if (stats.isDirectory()) {
+    return resolved;
+  }
+  if (stats.isFile()) {
+    return path.dirname(resolved);
+  }
+  console.error(`error: unsupported payload-matrix input path: ${inputPathArg}`);
+  process.exit(1);
+}
+
+function readKeyValueFile(filePath) {
+  const result = {};
+  const text = fs.readFileSync(filePath, 'utf8');
+  for (const line of text.split(/\r?\n/)) {
+    if (!line || !line.includes('=')) {
+      continue;
+    }
+    const index = line.indexOf('=');
+    const key = line.slice(0, index).trim();
+    const value = line.slice(index + 1).trim();
+    if (!key) {
+      continue;
+    }
+    result[key] = value;
+  }
+  return result;
+}
+
+function listDirectories(dirPath) {
+  if (!fs.existsSync(dirPath)) {
+    return [];
+  }
+  return fs.readdirSync(dirPath, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort();
+}
+
+function joinNames(values) {
+  return values.length > 0 ? values.join(',') : '-';
+}
+
+function outcomeToken(run) {
+  return `${run.status}:${run.outcome}`;
+}
+
+const inputDir = resolveInputDir(inputArg);
+const outDir = path.resolve(outDirArg);
+fs.mkdirSync(outDir, { recursive: true });
+
+const rootSummaryPath = path.join(inputDir, 'summary.txt');
+const rootSummary = fs.existsSync(rootSummaryPath) ? readKeyValueFile(rootSummaryPath) : {};
+
+const payloadRoot = path.join(inputDir, 'payloads');
+const payloadNames = listDirectories(payloadRoot);
+if (payloadNames.length === 0) {
+  console.error(`error: no payload matrix artifacts found in ${inputDir}`);
+  process.exit(1);
+}
+
+const payloadSummaries = payloadNames.map((payloadName) => {
+  const payloadDir = path.join(payloadRoot, payloadName);
+  const metaCandidates = [
+    path.join(payloadDir, 'meta.txt'),
+    path.join(payloadDir, 'summary.txt')
+  ];
+  const metaPath = metaCandidates.find((candidate) => fs.existsSync(candidate));
+  if (!metaPath) {
+    console.error(`error: missing payload metadata for ${payloadName} in ${payloadDir}`);
+    process.exit(1);
+  }
+  const meta = readKeyValueFile(metaPath);
+  const status = Number(meta.status ?? Number.NaN);
+  const outcome = meta.outcome ?? '';
+  if (!Number.isFinite(status) || !outcome) {
+    console.error(`error: invalid payload metadata: ${metaPath}`);
+    process.exit(1);
+  }
+  return {
+    payload: meta.payload || payloadName,
+    status,
+    outcome,
+    requestId: meta.request_id || '',
+    providerRequestId: meta.provider_request_id || '',
+    tokenSource: meta.token_source || '',
+    payloadSha256: meta.payload_sha256 || '',
+    payloadBytes: meta.payload_bytes || '',
+    metaPath
+  };
+});
+
+const runCount = payloadSummaries.length;
+const successRuns = payloadSummaries.filter((run) => run.outcome === 'request_succeeded');
+const invalidRuns = payloadSummaries.filter((run) => run.outcome === 'reproduced_invalid_request_error');
+const otherRuns = payloadSummaries.filter((run) => !['request_succeeded', 'reproduced_invalid_request_error'].includes(run.outcome));
+const uniqueOutcomeTokens = [...new Set(payloadSummaries.map(outcomeToken))];
+const comparisonPossible = runCount > 1;
+const payloadSensitive = comparisonPossible && uniqueOutcomeTokens.length > 1;
+const allSuccess = successRuns.length === runCount;
+const allInvalidRequest = invalidRuns.length === runCount;
+const uniformFailure = comparisonPossible && !allSuccess && uniqueOutcomeTokens.length === 1;
+
+let classification = 'single_payload_inconclusive';
+if (allSuccess) {
+  classification = comparisonPossible ? 'all_success' : 'single_payload_inconclusive';
+} else if (uniformFailure) {
+  classification = 'uniform_failure_provider_side_candidate';
+} else if (payloadSensitive) {
+  classification = 'payload_shape_specific';
+}
+
+const successfulPayloads = payloadSummaries
+  .filter((run) => run.outcome === 'request_succeeded')
+  .map((run) => run.payload);
+const failingPayloads = payloadSummaries
+  .filter((run) => run.outcome !== 'request_succeeded')
+  .map((run) => run.payload);
+
+const output = {
+  mode: 'direct_payload_matrix',
+  inputDir,
+  outputDir: outDir,
+  runCount,
+  payloadCount: runCount,
+  comparisonPossible,
+  successCount: successRuns.length,
+  invalidRequestCount: invalidRuns.length,
+  otherCount: otherRuns.length,
+  classification,
+  payloadSensitive,
+  uniformFailure,
+  allInvalidRequest,
+  allSuccess,
+  rootSummary,
+  successfulPayloads,
+  failingPayloads,
+  payloadSummaries
+};
+
+const summaryLines = [];
+summaryLines.push('mode=direct_payload_matrix');
+summaryLines.push(`input_dir=${inputDir}`);
+summaryLines.push(`run_count=${runCount}`);
+summaryLines.push(`payload_count=${runCount}`);
+summaryLines.push(`comparison_possible=${String(comparisonPossible)}`);
+if (rootSummary.target_url) {
+  summaryLines.push(`target_url=${rootSummary.target_url}`);
+}
+if (rootSummary.payload_matrix_tsv) {
+  summaryLines.push(`payload_matrix_tsv=${rootSummary.payload_matrix_tsv}`);
+}
+if (rootSummary.headers_tsv_path) {
+  summaryLines.push(`headers_tsv_path=${rootSummary.headers_tsv_path}`);
+}
+if (rootSummary.direct_access_token_source) {
+  summaryLines.push(`direct_access_token_source=${rootSummary.direct_access_token_source}`);
+}
+summaryLines.push(`success_count=${successRuns.length}`);
+summaryLines.push(`invalid_request_count=${invalidRuns.length}`);
+summaryLines.push(`other_count=${otherRuns.length}`);
+summaryLines.push(`classification=${classification}`);
+summaryLines.push(`payload_sensitive=${String(payloadSensitive)}`);
+summaryLines.push(`uniform_failure=${String(uniformFailure)}`);
+summaryLines.push(`all_invalid_request=${String(allInvalidRequest)}`);
+summaryLines.push(`all_success=${String(allSuccess)}`);
+summaryLines.push(`successful_payloads=${joinNames(successfulPayloads)}`);
+summaryLines.push(`failing_payloads=${joinNames(failingPayloads)}`);
+
+for (const summary of payloadSummaries) {
+  summaryLines.push(
+    `payload=${summary.payload} status=${summary.status} outcome=${summary.outcome} provider_request_id=${summary.providerRequestId} request_id=${summary.requestId}`
+  );
+}
+
+fs.writeFileSync(path.join(outDir, 'summary.json'), `${JSON.stringify(output, null, 2)}\n`);
+fs.writeFileSync(path.join(outDir, 'summary.txt'), `${summaryLines.join('\n')}\n`);

--- a/scripts/innies-compat-direct-payload-summary.sh
+++ b/scripts/innies-compat-direct-payload-summary.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_PATH" ]]; do
+  SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+  SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"
+  [[ "$SCRIPT_PATH" != /* ]] && SCRIPT_PATH="${SCRIPT_DIR}/${SCRIPT_PATH}"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+source "${SCRIPT_DIR}/_common.sh"
+
+INPUT_PATH="${1:-${INNIES_DIRECT_PAYLOAD_SUMMARY_INPUT:-}}"
+require_nonempty 'direct payload summary input path' "$INPUT_PATH"
+
+if [[ ! -e "$INPUT_PATH" ]]; then
+  echo "error: payload-matrix input path not found: $INPUT_PATH" >&2
+  exit 1
+fi
+
+if [[ -d "$INPUT_PATH" ]]; then
+  DEFAULT_OUT_DIR="${INPUT_PATH%/}/analysis"
+else
+  DEFAULT_OUT_DIR="$(cd "$(dirname "$INPUT_PATH")" && pwd)/analysis"
+fi
+
+OUT_DIR="${2:-${INNIES_DIRECT_PAYLOAD_SUMMARY_OUT_DIR:-$DEFAULT_OUT_DIR}}"
+mkdir -p "$OUT_DIR"
+
+if ! command -v node >/dev/null 2>&1; then
+  echo 'error: node is required for innies-compat-direct-payload-summary.sh' >&2
+  exit 1
+fi
+
+node "${SCRIPT_DIR}/innies-compat-direct-payload-summary.mjs" "$INPUT_PATH" "$OUT_DIR"
+
+SUMMARY_FILE="$OUT_DIR/summary.txt"
+cat "$SUMMARY_FILE"
+printf 'summary_file=%s\n' "$SUMMARY_FILE"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,6 +18,7 @@ ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-set.sh" "${BIN_DIR}/innies-b
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-get.sh" "${BIN_DIR}/innies-buyer-preference-get"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-check.sh" "${BIN_DIR}/innies-buyer-preference-check"
 ln -sf "${ROOT_DIR}/scripts/innies-slo-check.sh" "${BIN_DIR}/innies-slo-check"
+ln -sf "${ROOT_DIR}/scripts/innies-compat-direct-payload-summary.sh" "${BIN_DIR}/innies-compat-direct-payload-summary"
 
 rm -f \
   "${BIN_DIR}/innies-admin" \
@@ -49,6 +50,7 @@ echo "  ${BIN_DIR}/innies-buyer-preference-set -> ${ROOT_DIR}/scripts/innies-buy
 echo "  ${BIN_DIR}/innies-buyer-preference-get -> ${ROOT_DIR}/scripts/innies-buyer-preference-get.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-check -> ${ROOT_DIR}/scripts/innies-buyer-preference-check.sh"
 echo "  ${BIN_DIR}/innies-slo-check -> ${ROOT_DIR}/scripts/innies-slo-check.sh"
+echo "  ${BIN_DIR}/innies-compat-direct-payload-summary -> ${ROOT_DIR}/scripts/innies-compat-direct-payload-summary.sh"
 echo
 echo 'If command not found, add ~/.local/bin to PATH:'
 echo '  export PATH="$HOME/.local/bin:$PATH"'

--- a/scripts/tests/innies-compat-direct-payload-summary.test.sh
+++ b/scripts/tests/innies-compat-direct-payload-summary.test.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="$ROOT_DIR/scripts/innies-compat-direct-payload-summary.sh"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+write_lines() {
+  local file="$1"
+  shift
+  mkdir -p "$(dirname "$file")"
+  printf '%s\n' "$@" >"$file"
+}
+
+payload_specific_dir="$TMP_DIR/payload-specific"
+write_lines "$payload_specific_dir/summary.txt" \
+  "target_url=https://api.anthropic.com/v1/messages" \
+  "payload_matrix_tsv=/tmp/payloads.tsv" \
+  "headers_tsv_path=/tmp/direct-headers.tsv" \
+  "direct_access_token_source=claude_code_oauth_token" \
+  "payload=known_good_direct status=200 provider_request_id=req_provider_good request_id=req_issue80_payload_known_good token_source=claude_code_oauth_token payload_sha256=sha_good payload_bytes=111" \
+  "payload=preserved_fail status=400 provider_request_id=req_provider_bad request_id=req_issue80_payload_preserved token_source=claude_code_oauth_token payload_sha256=sha_bad payload_bytes=222" \
+  "payload_count=2"
+write_lines "$payload_specific_dir/payloads/known_good_direct/meta.txt" \
+  "payload=known_good_direct" \
+  "status=200" \
+  "outcome=request_succeeded" \
+  "request_id=req_issue80_payload_known_good" \
+  "provider_request_id=req_provider_good" \
+  "token_source=claude_code_oauth_token" \
+  "payload_sha256=sha_good" \
+  "payload_bytes=111"
+write_lines "$payload_specific_dir/payloads/preserved_fail/meta.txt" \
+  "payload=preserved_fail" \
+  "status=400" \
+  "outcome=reproduced_invalid_request_error" \
+  "request_id=req_issue80_payload_preserved" \
+  "provider_request_id=req_provider_bad" \
+  "token_source=claude_code_oauth_token" \
+  "payload_sha256=sha_bad" \
+  "payload_bytes=222"
+
+uniform_failure_dir="$TMP_DIR/uniform-failure"
+write_lines "$uniform_failure_dir/summary.txt" \
+  "target_url=https://api.anthropic.com/v1/messages" \
+  "payload_matrix_tsv=/tmp/payloads.tsv" \
+  "headers_tsv_path=/tmp/direct-headers.tsv" \
+  "direct_access_token_source=anthropic_oauth_access_token" \
+  "payload=preserved_fail status=400 provider_request_id=req_provider_bad_a request_id=req_issue80_payload_fail_a token_source=anthropic_oauth_access_token payload_sha256=sha_fail_a payload_bytes=333" \
+  "payload=second_fail status=400 provider_request_id=req_provider_bad_b request_id=req_issue80_payload_fail_b token_source=anthropic_oauth_access_token payload_sha256=sha_fail_b payload_bytes=444" \
+  "payload_count=2"
+write_lines "$uniform_failure_dir/payloads/preserved_fail/meta.txt" \
+  "payload=preserved_fail" \
+  "status=400" \
+  "outcome=reproduced_invalid_request_error" \
+  "request_id=req_issue80_payload_fail_a" \
+  "provider_request_id=req_provider_bad_a" \
+  "token_source=anthropic_oauth_access_token" \
+  "payload_sha256=sha_fail_a" \
+  "payload_bytes=333"
+write_lines "$uniform_failure_dir/payloads/second_fail/meta.txt" \
+  "payload=second_fail" \
+  "status=400" \
+  "outcome=reproduced_invalid_request_error" \
+  "request_id=req_issue80_payload_fail_b" \
+  "provider_request_id=req_provider_bad_b" \
+  "token_source=anthropic_oauth_access_token" \
+  "payload_sha256=sha_fail_b" \
+  "payload_bytes=444"
+
+all_success_dir="$TMP_DIR/all-success"
+write_lines "$all_success_dir/summary.txt" \
+  "target_url=https://api.anthropic.com/v1/messages" \
+  "payload_matrix_tsv=/tmp/payloads.tsv" \
+  "headers_tsv_path=/tmp/direct-headers.tsv" \
+  "direct_access_token_source=claude_code_oauth_token" \
+  "payload=known_good_a status=200 provider_request_id=req_provider_success_a request_id=req_issue80_payload_success_a token_source=claude_code_oauth_token payload_sha256=sha_success_a payload_bytes=555" \
+  "payload=known_good_b status=200 provider_request_id=req_provider_success_b request_id=req_issue80_payload_success_b token_source=claude_code_oauth_token payload_sha256=sha_success_b payload_bytes=666" \
+  "payload_count=2"
+write_lines "$all_success_dir/payloads/known_good_a/meta.txt" \
+  "payload=known_good_a" \
+  "status=200" \
+  "outcome=request_succeeded" \
+  "request_id=req_issue80_payload_success_a" \
+  "provider_request_id=req_provider_success_a" \
+  "token_source=claude_code_oauth_token" \
+  "payload_sha256=sha_success_a" \
+  "payload_bytes=555"
+write_lines "$all_success_dir/payloads/known_good_b/meta.txt" \
+  "payload=known_good_b" \
+  "status=200" \
+  "outcome=request_succeeded" \
+  "request_id=req_issue80_payload_success_b" \
+  "provider_request_id=req_provider_success_b" \
+  "token_source=claude_code_oauth_token" \
+  "payload_sha256=sha_success_b" \
+  "payload_bytes=666"
+
+run_summary() {
+  local input_path="$1"
+  local output_dir="$2"
+  local stdout_path="$3"
+  local stderr_path="$4"
+  INNIES_DIRECT_PAYLOAD_SUMMARY_OUT_DIR="$output_dir" "$SCRIPT_PATH" "$input_path" >"$stdout_path" 2>"$stderr_path"
+}
+
+run_summary "$payload_specific_dir" "$TMP_DIR/payload-specific-summary" "$TMP_DIR/payload-specific.stdout" "$TMP_DIR/payload-specific.stderr"
+run_summary "$uniform_failure_dir/summary.txt" "$TMP_DIR/uniform-failure-summary" "$TMP_DIR/uniform-failure.stdout" "$TMP_DIR/uniform-failure.stderr"
+run_summary "$all_success_dir" "$TMP_DIR/all-success-summary" "$TMP_DIR/all-success.stdout" "$TMP_DIR/all-success.stderr"
+
+[[ -f "$TMP_DIR/payload-specific-summary/summary.txt" ]]
+[[ -f "$TMP_DIR/payload-specific-summary/summary.json" ]]
+grep -q '^mode=direct_payload_matrix$' "$TMP_DIR/payload-specific-summary/summary.txt"
+grep -q '^classification=payload_shape_specific$' "$TMP_DIR/payload-specific-summary/summary.txt"
+grep -q '^payload_sensitive=true$' "$TMP_DIR/payload-specific-summary/summary.txt"
+grep -q '^uniform_failure=false$' "$TMP_DIR/payload-specific-summary/summary.txt"
+grep -q '^successful_payloads=known_good_direct$' "$TMP_DIR/payload-specific-summary/summary.txt"
+grep -q '^failing_payloads=preserved_fail$' "$TMP_DIR/payload-specific-summary/summary.txt"
+grep -q '^payload=known_good_direct status=200 outcome=request_succeeded provider_request_id=req_provider_good request_id=req_issue80_payload_known_good$' "$TMP_DIR/payload-specific-summary/summary.txt"
+grep -q '^summary_file=' "$TMP_DIR/payload-specific.stdout"
+
+[[ -f "$TMP_DIR/uniform-failure-summary/summary.txt" ]]
+[[ -f "$TMP_DIR/uniform-failure-summary/summary.json" ]]
+grep -q '^classification=uniform_failure_provider_side_candidate$' "$TMP_DIR/uniform-failure-summary/summary.txt"
+grep -q '^payload_sensitive=false$' "$TMP_DIR/uniform-failure-summary/summary.txt"
+grep -q '^uniform_failure=true$' "$TMP_DIR/uniform-failure-summary/summary.txt"
+grep -q '^all_invalid_request=true$' "$TMP_DIR/uniform-failure-summary/summary.txt"
+grep -q '^successful_payloads=-$' "$TMP_DIR/uniform-failure-summary/summary.txt"
+
+[[ -f "$TMP_DIR/all-success-summary/summary.txt" ]]
+[[ -f "$TMP_DIR/all-success-summary/summary.json" ]]
+grep -q '^classification=all_success$' "$TMP_DIR/all-success-summary/summary.txt"
+grep -q '^all_success=true$' "$TMP_DIR/all-success-summary/summary.txt"
+grep -q '^payload_sensitive=false$' "$TMP_DIR/all-success-summary/summary.txt"
+grep -q '^successful_payloads=known_good_a,known_good_b$' "$TMP_DIR/all-success-summary/summary.txt"
+
+node - "$TMP_DIR/payload-specific-summary/summary.json" "$TMP_DIR/uniform-failure-summary/summary.json" "$TMP_DIR/all-success-summary/summary.json" <<'NODE'
+const fs = require('fs');
+
+const [payloadSpecificPath, uniformFailurePath, allSuccessPath] = process.argv.slice(2);
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+const payloadSpecific = readJson(payloadSpecificPath);
+const uniformFailure = readJson(uniformFailurePath);
+const allSuccess = readJson(allSuccessPath);
+
+if (payloadSpecific.classification !== 'payload_shape_specific') {
+  throw new Error('payload-specific classification mismatch');
+}
+if (payloadSpecific.payloadSummaries.length !== 2) {
+  throw new Error('payload-specific summary count mismatch');
+}
+if (uniformFailure.classification !== 'uniform_failure_provider_side_candidate') {
+  throw new Error('uniform-failure classification mismatch');
+}
+if (uniformFailure.uniformFailure !== true) {
+  throw new Error('uniform-failure flag mismatch');
+}
+if (allSuccess.classification !== 'all_success') {
+  throw new Error('all-success classification mismatch');
+}
+if (allSuccess.allSuccess !== true) {
+  throw new Error('all-success flag mismatch');
+}
+NODE
+
+empty_dir="$TMP_DIR/empty"
+mkdir -p "$empty_dir"
+write_lines "$empty_dir/summary.txt" \
+  "target_url=https://api.anthropic.com/v1/messages" \
+  "payload_count=0"
+
+set +e
+"$SCRIPT_PATH" "$empty_dir" >"$TMP_DIR/empty.stdout" 2>"$TMP_DIR/empty.stderr"
+status=$?
+set -e
+
+if [[ "$status" -eq 0 ]]; then
+  echo 'expected missing payload artifacts to fail' >&2
+  exit 1
+fi
+
+grep -q 'no payload matrix artifacts found' "$TMP_DIR/empty.stderr"
+
+echo "PASS: innies-compat-direct-payload-summary classifies payload-axis results"


### PR DESCRIPTION
## Summary
- add `innies-compat-direct-payload-summary` to classify direct payload-matrix artifacts as `payload_shape_specific`, `uniform_failure_provider_side_candidate`, `all_success`, or `single_payload_inconclusive`
- emit both `summary.txt` and `summary.json` from per-payload matrix bundles so the issue thread can record whether the remaining first-pass behavior flips by transcript shape
- wire the helper into `scripts/install.sh` and `scripts/README.md`, with focused shell coverage for divergent, uniform-failure, all-success, and invalid-input cases

## Test Plan
- [x] `bash scripts/tests/innies-compat-direct-payload-summary.test.sh`
- [x] `bash -n scripts/innies-compat-direct-payload-summary.sh scripts/tests/innies-compat-direct-payload-summary.test.sh scripts/install.sh`
- [x] `node --check scripts/innies-compat-direct-payload-summary.mjs`
- [x] `TMP_HOME="$(mktemp -d)" && HOME="$TMP_HOME" bash scripts/install.sh >/tmp/issue80-direct-payload-summary-install.out && test -L "$TMP_HOME/.local/bin/innies-compat-direct-payload-summary"`
- [x] `git diff --check`

Refs #80
