### PR TITLE
chore: add issue 80 direct token lane summary helper

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -25,6 +25,7 @@ innies-buyer-preference-set
 innies-buyer-preference-get
 innies-buyer-preference-check
 innies-slo-check
+innies-compat-direct-token-lane-summary
 ```
 
 What they do:
@@ -40,6 +41,7 @@ What they do:
 - `innies-buyer-preference-get`: read the current buyer key preference
 - `innies-buyer-preference-check`: run the provider-preference canary after prompting for the expected provider (`Claude Code` or `Codex`)
 - `innies-slo-check`: query analytics endpoints and report Phase 1 SLO pass/fail (TTFB p95, timeout rate, success rate, fallback rate); optional arg sets the window (default `24h`); exits 0 if all SLOs pass, 1 if any fail
+- `innies-compat-direct-token-lane-summary`: summarize issue-80 direct token-lane matrix artifacts as credential-lane-specific, uniform-failure/provider-side candidate, all-success, or single-lane-only
 
 Behavior:
 - org id auto-uses `INNIES_ORG_ID`

--- a/scripts/innies-compat-direct-token-lane-summary.mjs
+++ b/scripts/innies-compat-direct-token-lane-summary.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const [inputPathArg, outDirArg] = process.argv.slice(2);
+
+if (!inputPathArg) {
+  console.error('error: missing direct token lane summary input path');
+  process.exit(1);
+}
+
+if (!outDirArg) {
+  console.error('error: missing summary output dir');
+  process.exit(1);
+}
+
+const inputPath = path.resolve(inputPathArg);
+const outDir = path.resolve(outDirArg);
+
+if (!fs.existsSync(inputPath)) {
+  console.error(`error: direct token lane summary input path not found: ${inputPathArg}`);
+  process.exit(1);
+}
+
+const matrixDir = fs.statSync(inputPath).isDirectory() ? inputPath : path.dirname(inputPath);
+const lanesDir = path.join(matrixDir, 'lanes');
+const rootSummaryPath = path.join(matrixDir, 'summary.txt');
+
+if (!fs.existsSync(lanesDir) || !fs.statSync(lanesDir).isDirectory()) {
+  console.error(`error: direct token lane artifacts not found in ${matrixDir}`);
+  process.exit(1);
+}
+
+fs.mkdirSync(outDir, { recursive: true });
+
+function readKeyValueFile(filePath) {
+  const result = {};
+  const text = fs.readFileSync(filePath, 'utf8');
+  for (const line of text.split(/\r?\n/)) {
+    if (!line || !line.includes('=')) continue;
+    const index = line.indexOf('=');
+    const key = line.slice(0, index).trim();
+    const value = line.slice(index + 1).trim();
+    if (!key) continue;
+    result[key] = value;
+  }
+  return result;
+}
+
+function listDirectories(dirPath) {
+  return fs.readdirSync(dirPath, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort();
+}
+
+function outcomeToken(run) {
+  return `${run.status}:${run.outcome}`;
+}
+
+function joinNames(values) {
+  return values.length > 0 ? values.join(',') : '-';
+}
+
+const rootSummary = fs.existsSync(rootSummaryPath) ? readKeyValueFile(rootSummaryPath) : {};
+const laneNames = listDirectories(lanesDir);
+
+if (laneNames.length === 0) {
+  console.error(`error: no token lane artifacts found in ${matrixDir}`);
+  process.exit(1);
+}
+
+const runs = laneNames.map((laneName) => {
+  const laneDir = path.join(lanesDir, laneName);
+  const metaCandidates = [
+    path.join(laneDir, 'meta.txt'),
+    path.join(laneDir, 'summary.txt')
+  ];
+  const metaPath = metaCandidates.find((candidate) => fs.existsSync(candidate));
+  if (!metaPath) {
+    console.error(`error: missing lane meta file: ${laneDir}`);
+    process.exit(1);
+  }
+  const summary = readKeyValueFile(metaPath);
+  const status = Number(summary.status ?? NaN);
+  const outcome = summary.outcome ?? '';
+  if (!Number.isFinite(status) || !outcome) {
+    console.error(`error: invalid lane meta file: ${metaPath}`);
+    process.exit(1);
+  }
+  return {
+    lane: summary.lane || laneName,
+    status,
+    outcome,
+    providerRequestId: summary.provider_request_id || '',
+    requestId: summary.request_id || '',
+    tokenSource: summary.token_source || '',
+    targetUrl: summary.target_url || '',
+    payloadPath: summary.payload_path || '',
+    headersTsvPath: summary.headers_tsv_path || ''
+  };
+});
+
+const runCount = runs.length;
+const successRuns = runs.filter((run) => run.outcome === 'request_succeeded');
+const invalidRuns = runs.filter((run) => run.outcome === 'reproduced_invalid_request_error');
+const otherRuns = runs.filter((run) => !['request_succeeded', 'reproduced_invalid_request_error'].includes(run.outcome));
+const uniqueOutcomeTokens = [...new Set(runs.map(outcomeToken))];
+const tokenLaneSensitive = runCount > 1 && uniqueOutcomeTokens.length > 1;
+const allSuccess = successRuns.length === runCount;
+const allInvalidRequest = invalidRuns.length === runCount;
+const uniformFailure = runCount > 1 && !allSuccess && uniqueOutcomeTokens.length === 1;
+
+let classification = 'non_uniform_failure';
+if (allSuccess) {
+  classification = 'all_success';
+} else if (runCount === 1) {
+  classification = 'single_lane_only';
+} else if (tokenLaneSensitive) {
+  classification = 'credential_lane_specific';
+} else if (uniformFailure) {
+  classification = 'uniform_failure_provider_side_candidate';
+}
+
+const successfulLanes = runs.filter((run) => run.outcome === 'request_succeeded').map((run) => run.lane);
+const failingLanes = runs.filter((run) => run.outcome !== 'request_succeeded').map((run) => run.lane);
+const summaryTargetUrl = rootSummary.target_url || runs[0]?.targetUrl || '';
+const summaryPayloadPath = rootSummary.payload_path || runs[0]?.payloadPath || '';
+const summaryHeadersTsvPath = rootSummary.headers_tsv_path || runs[0]?.headersTsvPath || '';
+const summaryTokenMatrixTsv = rootSummary.token_matrix_tsv || '';
+
+const output = {
+  mode: 'direct_token_lane_matrix',
+  inputPath,
+  inputDir: matrixDir,
+  outputDir: outDir,
+  laneCount: runCount,
+  successCount: successRuns.length,
+  invalidRequestCount: invalidRuns.length,
+  otherCount: otherRuns.length,
+  classification,
+  tokenLaneSensitive,
+  uniformFailure,
+  allInvalidRequest,
+  allSuccess,
+  successfulLanes,
+  failingLanes,
+  rootSummary,
+  laneSummaries: runs
+};
+
+const summaryLines = [];
+summaryLines.push('mode=direct_token_lane_matrix');
+summaryLines.push(`input_dir=${matrixDir}`);
+summaryLines.push(`lane_count=${runCount}`);
+if (summaryTargetUrl) summaryLines.push(`target_url=${summaryTargetUrl}`);
+if (summaryPayloadPath) summaryLines.push(`payload_path=${summaryPayloadPath}`);
+if (summaryHeadersTsvPath) summaryLines.push(`headers_tsv_path=${summaryHeadersTsvPath}`);
+if (summaryTokenMatrixTsv) summaryLines.push(`token_matrix_tsv=${summaryTokenMatrixTsv}`);
+summaryLines.push(`success_count=${successRuns.length}`);
+summaryLines.push(`invalid_request_count=${invalidRuns.length}`);
+summaryLines.push(`other_count=${otherRuns.length}`);
+summaryLines.push(`classification=${classification}`);
+summaryLines.push(`token_lane_sensitive=${String(tokenLaneSensitive)}`);
+summaryLines.push(`uniform_failure=${String(uniformFailure)}`);
+summaryLines.push(`all_invalid_request=${String(allInvalidRequest)}`);
+summaryLines.push(`all_success=${String(allSuccess)}`);
+summaryLines.push(`successful_lanes=${joinNames(successfulLanes)}`);
+summaryLines.push(`failing_lanes=${joinNames(failingLanes)}`);
+
+for (const run of runs) {
+  summaryLines.push(
+    `lane=${run.lane} status=${run.status} outcome=${run.outcome} provider_request_id=${run.providerRequestId || '-'} request_id=${run.requestId || '-'} token_source=${run.tokenSource || '-'}`
+  );
+}
+
+fs.writeFileSync(path.join(outDir, 'summary.json'), `${JSON.stringify(output, null, 2)}\n`);
+fs.writeFileSync(path.join(outDir, 'summary.txt'), `${summaryLines.join('\n')}\n`);

--- a/scripts/innies-compat-direct-token-lane-summary.sh
+++ b/scripts/innies-compat-direct-token-lane-summary.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_PATH" ]]; do
+  SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+  SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"
+  [[ "$SCRIPT_PATH" != /* ]] && SCRIPT_PATH="${SCRIPT_DIR}/${SCRIPT_PATH}"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+source "${SCRIPT_DIR}/_common.sh"
+
+INPUT_PATH="${1:-${INNIES_DIRECT_TOKEN_LANE_SUMMARY_INPUT:-}}"
+require_nonempty 'direct token lane summary input path' "$INPUT_PATH"
+
+if [[ ! -e "$INPUT_PATH" ]]; then
+  echo "error: direct token lane summary input path not found: $INPUT_PATH" >&2
+  exit 1
+fi
+
+INPUT_DIR="$INPUT_PATH"
+if [[ -f "$INPUT_PATH" ]]; then
+  INPUT_DIR="$(cd "$(dirname "$INPUT_PATH")" && pwd)"
+fi
+
+OUT_DIR="${2:-${INNIES_DIRECT_TOKEN_LANE_SUMMARY_OUT_DIR:-${INPUT_DIR%/}/analysis}}"
+mkdir -p "$OUT_DIR"
+
+if ! command -v node >/dev/null 2>&1; then
+  echo 'error: node is required for innies-compat-direct-token-lane-summary.sh' >&2
+  exit 1
+fi
+
+node "${SCRIPT_DIR}/innies-compat-direct-token-lane-summary.mjs" "$INPUT_PATH" "$OUT_DIR"
+
+SUMMARY_FILE="$OUT_DIR/summary.txt"
+cat "$SUMMARY_FILE"
+printf 'summary_file=%s\n' "$SUMMARY_FILE"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,6 +18,7 @@ ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-set.sh" "${BIN_DIR}/innies-b
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-get.sh" "${BIN_DIR}/innies-buyer-preference-get"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-check.sh" "${BIN_DIR}/innies-buyer-preference-check"
 ln -sf "${ROOT_DIR}/scripts/innies-slo-check.sh" "${BIN_DIR}/innies-slo-check"
+ln -sf "${ROOT_DIR}/scripts/innies-compat-direct-token-lane-summary.sh" "${BIN_DIR}/innies-compat-direct-token-lane-summary"
 
 rm -f \
   "${BIN_DIR}/innies-admin" \
@@ -49,6 +50,7 @@ echo "  ${BIN_DIR}/innies-buyer-preference-set -> ${ROOT_DIR}/scripts/innies-buy
 echo "  ${BIN_DIR}/innies-buyer-preference-get -> ${ROOT_DIR}/scripts/innies-buyer-preference-get.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-check -> ${ROOT_DIR}/scripts/innies-buyer-preference-check.sh"
 echo "  ${BIN_DIR}/innies-slo-check -> ${ROOT_DIR}/scripts/innies-slo-check.sh"
+echo "  ${BIN_DIR}/innies-compat-direct-token-lane-summary -> ${ROOT_DIR}/scripts/innies-compat-direct-token-lane-summary.sh"
 echo
 echo 'If command not found, add ~/.local/bin to PATH:'
 echo '  export PATH="$HOME/.local/bin:$PATH"'

--- a/scripts/tests/innies-compat-direct-token-lane-summary.test.sh
+++ b/scripts/tests/innies-compat-direct-token-lane-summary.test.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="$ROOT_DIR/scripts/innies-compat-direct-token-lane-summary.sh"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+write_lines() {
+  local file="$1"
+  shift
+  mkdir -p "$(dirname "$file")"
+  printf '%s\n' "$@" >"$file"
+}
+
+lane_specific_dir="$TMP_DIR/lane-specific"
+write_lines "$lane_specific_dir/summary.txt" \
+  "target_url=https://api.anthropic.com/v1/messages" \
+  "payload_path=/tmp/preserved-fail.json" \
+  "headers_tsv_path=/tmp/direct-headers.tsv" \
+  "token_matrix_tsv=/tmp/direct-token-matrix.tsv" \
+  "lane=lane_alpha status=200 provider_request_id=req_provider_alpha request_id=req_issue80_token_matrix_lane_alpha token_source=env:ANTHROPIC_TOKEN_ALPHA" \
+  "lane=lane_beta status=400 provider_request_id=req_provider_beta request_id=req_issue80_token_matrix_lane_beta token_source=literal"
+write_lines "$lane_specific_dir/lanes/lane_alpha/meta.txt" \
+  "lane=lane_alpha" \
+  "status=200" \
+  "outcome=request_succeeded" \
+  "provider_request_id=req_provider_alpha" \
+  "request_id=req_issue80_token_matrix_lane_alpha" \
+  "token_source=env:ANTHROPIC_TOKEN_ALPHA" \
+  "target_url=https://api.anthropic.com/v1/messages" \
+  "payload_path=/tmp/preserved-fail.json" \
+  "headers_tsv_path=/tmp/direct-headers.tsv"
+write_lines "$lane_specific_dir/lanes/lane_beta/meta.txt" \
+  "lane=lane_beta" \
+  "status=400" \
+  "outcome=reproduced_invalid_request_error" \
+  "provider_request_id=req_provider_beta" \
+  "request_id=req_issue80_token_matrix_lane_beta" \
+  "token_source=literal" \
+  "target_url=https://api.anthropic.com/v1/messages" \
+  "payload_path=/tmp/preserved-fail.json" \
+  "headers_tsv_path=/tmp/direct-headers.tsv"
+
+uniform_failure_dir="$TMP_DIR/uniform-failure"
+write_lines "$uniform_failure_dir/summary.txt" \
+  "target_url=https://api.anthropic.com/v1/messages" \
+  "payload_path=/tmp/preserved-fail.json" \
+  "headers_tsv_path=/tmp/direct-headers.tsv" \
+  "token_matrix_tsv=/tmp/direct-token-matrix.tsv"
+write_lines "$uniform_failure_dir/lanes/lane_alpha/meta.txt" \
+  "lane=lane_alpha" \
+  "status=400" \
+  "outcome=reproduced_invalid_request_error" \
+  "provider_request_id=req_provider_alpha" \
+  "request_id=req_issue80_token_matrix_lane_alpha" \
+  "token_source=env:ANTHROPIC_TOKEN_ALPHA"
+write_lines "$uniform_failure_dir/lanes/lane_beta/meta.txt" \
+  "lane=lane_beta" \
+  "status=400" \
+  "outcome=reproduced_invalid_request_error" \
+  "provider_request_id=req_provider_beta" \
+  "request_id=req_issue80_token_matrix_lane_beta" \
+  "token_source=literal"
+
+single_lane_dir="$TMP_DIR/single-lane"
+write_lines "$single_lane_dir/summary.txt" \
+  "target_url=https://api.anthropic.com/v1/messages"
+write_lines "$single_lane_dir/lanes/lane_only/meta.txt" \
+  "lane=lane_only" \
+  "status=400" \
+  "outcome=reproduced_invalid_request_error" \
+  "provider_request_id=req_provider_single" \
+  "request_id=req_issue80_token_matrix_lane_only" \
+  "token_source=literal"
+
+all_success_dir="$TMP_DIR/all-success"
+write_lines "$all_success_dir/summary.txt" \
+  "target_url=https://api.anthropic.com/v1/messages"
+write_lines "$all_success_dir/lanes/lane_alpha/meta.txt" \
+  "lane=lane_alpha" \
+  "status=200" \
+  "outcome=request_succeeded" \
+  "provider_request_id=req_provider_alpha" \
+  "request_id=req_issue80_token_matrix_lane_alpha" \
+  "token_source=env:ANTHROPIC_TOKEN_ALPHA"
+write_lines "$all_success_dir/lanes/lane_beta/meta.txt" \
+  "lane=lane_beta" \
+  "status=200" \
+  "outcome=request_succeeded" \
+  "provider_request_id=req_provider_beta" \
+  "request_id=req_issue80_token_matrix_lane_beta" \
+  "token_source=literal"
+
+invalid_dir="$TMP_DIR/invalid"
+write_lines "$invalid_dir/summary.txt" \
+  "target_url=https://api.anthropic.com/v1/messages"
+mkdir -p "$invalid_dir/lanes/lane_missing"
+
+run_summary() {
+  local input_path="$1"
+  local output_dir="$2"
+  local stdout_path="$3"
+  local stderr_path="$4"
+  INNIES_DIRECT_TOKEN_LANE_SUMMARY_OUT_DIR="$output_dir" "$SCRIPT_PATH" "$input_path" >"$stdout_path" 2>"$stderr_path"
+}
+
+run_summary "$lane_specific_dir/summary.txt" "$TMP_DIR/lane-specific-summary" "$TMP_DIR/lane-specific.stdout" "$TMP_DIR/lane-specific.stderr"
+run_summary "$uniform_failure_dir" "$TMP_DIR/uniform-failure-summary" "$TMP_DIR/uniform-failure.stdout" "$TMP_DIR/uniform-failure.stderr"
+run_summary "$single_lane_dir" "$TMP_DIR/single-lane-summary" "$TMP_DIR/single-lane.stdout" "$TMP_DIR/single-lane.stderr"
+run_summary "$all_success_dir" "$TMP_DIR/all-success-summary" "$TMP_DIR/all-success.stdout" "$TMP_DIR/all-success.stderr"
+
+[[ -f "$TMP_DIR/lane-specific-summary/summary.txt" ]]
+[[ -f "$TMP_DIR/lane-specific-summary/summary.json" ]]
+grep -q '^mode=direct_token_lane_matrix$' "$TMP_DIR/lane-specific-summary/summary.txt"
+grep -q '^classification=credential_lane_specific$' "$TMP_DIR/lane-specific-summary/summary.txt"
+grep -q '^token_lane_sensitive=true$' "$TMP_DIR/lane-specific-summary/summary.txt"
+grep -q '^uniform_failure=false$' "$TMP_DIR/lane-specific-summary/summary.txt"
+grep -q '^successful_lanes=lane_alpha$' "$TMP_DIR/lane-specific-summary/summary.txt"
+grep -q '^failing_lanes=lane_beta$' "$TMP_DIR/lane-specific-summary/summary.txt"
+grep -q '^lane=lane_alpha status=200 outcome=request_succeeded provider_request_id=req_provider_alpha request_id=req_issue80_token_matrix_lane_alpha token_source=env:ANTHROPIC_TOKEN_ALPHA$' "$TMP_DIR/lane-specific-summary/summary.txt"
+grep -q '^lane=lane_beta status=400 outcome=reproduced_invalid_request_error provider_request_id=req_provider_beta request_id=req_issue80_token_matrix_lane_beta token_source=literal$' "$TMP_DIR/lane-specific-summary/summary.txt"
+grep -q '^summary_file=' "$TMP_DIR/lane-specific.stdout"
+
+[[ -f "$TMP_DIR/uniform-failure-summary/summary.txt" ]]
+grep -q '^classification=uniform_failure_provider_side_candidate$' "$TMP_DIR/uniform-failure-summary/summary.txt"
+grep -q '^token_lane_sensitive=false$' "$TMP_DIR/uniform-failure-summary/summary.txt"
+grep -q '^uniform_failure=true$' "$TMP_DIR/uniform-failure-summary/summary.txt"
+grep -q '^all_invalid_request=true$' "$TMP_DIR/uniform-failure-summary/summary.txt"
+
+[[ -f "$TMP_DIR/single-lane-summary/summary.txt" ]]
+grep -q '^classification=single_lane_only$' "$TMP_DIR/single-lane-summary/summary.txt"
+grep -q '^lane_count=1$' "$TMP_DIR/single-lane-summary/summary.txt"
+
+[[ -f "$TMP_DIR/all-success-summary/summary.txt" ]]
+grep -q '^classification=all_success$' "$TMP_DIR/all-success-summary/summary.txt"
+grep -q '^all_success=true$' "$TMP_DIR/all-success-summary/summary.txt"
+
+node - "$TMP_DIR/lane-specific-summary/summary.json" "$TMP_DIR/uniform-failure-summary/summary.json" "$TMP_DIR/single-lane-summary/summary.json" "$TMP_DIR/all-success-summary/summary.json" <<'NODE'
+const fs = require('fs');
+
+const [laneSpecificPath, uniformFailurePath, singleLanePath, allSuccessPath] = process.argv.slice(2);
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+const laneSpecific = readJson(laneSpecificPath);
+const uniformFailure = readJson(uniformFailurePath);
+const singleLane = readJson(singleLanePath);
+const allSuccess = readJson(allSuccessPath);
+
+if (laneSpecific.classification !== 'credential_lane_specific') {
+  throw new Error('lane-specific classification mismatch');
+}
+if (laneSpecific.laneSummaries.length !== 2) {
+  throw new Error('lane-specific summary count mismatch');
+}
+if (uniformFailure.classification !== 'uniform_failure_provider_side_candidate') {
+  throw new Error('uniform failure classification mismatch');
+}
+if (uniformFailure.uniformFailure !== true) {
+  throw new Error('uniform failure flag mismatch');
+}
+if (singleLane.classification !== 'single_lane_only') {
+  throw new Error('single lane classification mismatch');
+}
+if (allSuccess.classification !== 'all_success') {
+  throw new Error('all success classification mismatch');
+}
+if (allSuccess.successCount !== 2) {
+  throw new Error('all success count mismatch');
+}
+NODE
+
+set +e
+INNIES_DIRECT_TOKEN_LANE_SUMMARY_OUT_DIR="$TMP_DIR/invalid-summary" \
+  "$SCRIPT_PATH" "$invalid_dir" >"$TMP_DIR/invalid.stdout" 2>"$TMP_DIR/invalid.stderr"
+STATUS=$?
+set -e
+
+if [[ "$STATUS" -eq 0 ]]; then
+  echo 'expected invalid direct token lane summary input to fail' >&2
+  exit 1
+fi
+
+grep -q 'missing lane meta file' "$TMP_DIR/invalid.stderr"


### PR DESCRIPTION
Refs #80

## Summary
- add `scripts/innies-compat-direct-token-lane-summary.{sh,mjs}` to classify direct token-lane matrix artifacts as credential-lane-specific, uniform-failure/provider-side candidate, all-success, or single-lane-only
- add focused shell regression coverage for lane-specific, uniform-failure, single-lane, all-success, and invalid-artifact cases
- wire the helper into `scripts/install.sh` and `scripts/README.md`

## Why
The issue-80 helper swarm already has a direct token-lane matrix producer in `PR #108`, but there is still no narrow interpretation layer for those artifacts. This helper lets the next issue handoff say explicitly whether the held-constant direct replay varies by credential lane or instead fails uniformly enough to look provider-side, without touching the runtime proxy path.

## Verification
- `bash scripts/tests/innies-compat-direct-token-lane-summary.test.sh`
- `node --check scripts/innies-compat-direct-token-lane-summary.mjs`
- `bash -n scripts/innies-compat-direct-token-lane-summary.sh scripts/tests/innies-compat-direct-token-lane-summary.test.sh scripts/install.sh`
- `TMP_HOME="$(mktemp -d)" && HOME="$TMP_HOME" bash scripts/install.sh >/tmp/issue80-direct-token-lane-summary-install.out && test -L "$TMP_HOME/.local/bin/innies-compat-direct-token-lane-summary"`
- `git diff --check`
