### PR TITLE
chore: add issue 80 compat artifact index helper

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -25,6 +25,7 @@ innies-buyer-preference-set
 innies-buyer-preference-get
 innies-buyer-preference-check
 innies-slo-check
+innies-compat-artifact-index
 ```
 
 What they do:
@@ -40,6 +41,7 @@ What they do:
 - `innies-buyer-preference-get`: read the current buyer key preference
 - `innies-buyer-preference-check`: run the provider-preference canary after prompting for the expected provider (`Claude Code` or `Codex`)
 - `innies-slo-check`: query analytics endpoints and report Phase 1 SLO pass/fail (TTFB p95, timeout rate, success rate, fallback rate); optional arg sets the window (default `24h`); exits 0 if all SLOs pass, 1 if any fail
+- `innies-compat-artifact-index`: scan a saved compat response HTML/log artifact and list reconstructable first-pass request bundles; optional second and third args filter by provider and upstream status
 
 Behavior:
 - org id auto-uses `INNIES_ORG_ID`

--- a/scripts/innies-compat-artifact-index.mjs
+++ b/scripts/innies-compat-artifact-index.mjs
@@ -1,0 +1,449 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const [artifactPathArg, outDirArg, providerFilterArg, statusFilterArg] = process.argv.slice(2);
+
+if (!artifactPathArg) {
+  console.error('error: missing compat artifact path');
+  process.exit(1);
+}
+
+if (!outDirArg) {
+  console.error('error: missing output dir');
+  process.exit(1);
+}
+
+const CHUNK_LABELS = new Set([
+  '[compat-invalid-request-debug-json-chunk]',
+  '[compat-invalid-request-payload-json-chunk]',
+  '[compat-upstream-request-json-chunk]',
+  '[compat-upstream-response-json-chunk]'
+]);
+
+function stripLogPrefix(line) {
+  const marker = ']: ';
+  const markerIndex = line.indexOf(marker);
+  if (markerIndex === -1) {
+    return null;
+  }
+  return line.slice(markerIndex + marker.length);
+}
+
+function decodeEscapeSequence(source, state) {
+  const next = source[state.index++];
+  switch (next) {
+    case undefined:
+      throw new Error('unterminated escape sequence');
+    case '\\':
+    case '\'':
+    case '"':
+    case '`':
+      return next;
+    case 'b':
+      return '\b';
+    case 'f':
+      return '\f';
+    case 'n':
+      return '\n';
+    case 'r':
+      return '\r';
+    case 't':
+      return '\t';
+    case 'v':
+      return '\v';
+    case '0':
+      return '\0';
+    case '\n':
+      return '';
+    case '\r':
+      if (source[state.index] === '\n') {
+        state.index += 1;
+      }
+      return '';
+    case 'x': {
+      const hex = source.slice(state.index, state.index + 2);
+      if (!/^[0-9a-fA-F]{2}$/.test(hex)) {
+        throw new Error('invalid hex escape');
+      }
+      state.index += 2;
+      return String.fromCodePoint(Number.parseInt(hex, 16));
+    }
+    case 'u': {
+      if (source[state.index] === '{') {
+        const end = source.indexOf('}', state.index + 1);
+        if (end === -1) {
+          throw new Error('invalid unicode escape');
+        }
+        const hex = source.slice(state.index + 1, end);
+        if (!/^[0-9a-fA-F]+$/.test(hex)) {
+          throw new Error('invalid unicode escape');
+        }
+        state.index = end + 1;
+        return String.fromCodePoint(Number.parseInt(hex, 16));
+      }
+
+      const hex = source.slice(state.index, state.index + 4);
+      if (!/^[0-9a-fA-F]{4}$/.test(hex)) {
+        throw new Error('invalid unicode escape');
+      }
+      state.index += 4;
+      return String.fromCodePoint(Number.parseInt(hex, 16));
+    }
+    default:
+      return next;
+  }
+}
+
+function decodeJsStringLiteral(source) {
+  const trimmed = source.trim();
+  const quote = trimmed[0];
+  if (!quote || ![`'`, '"', '`'].includes(quote)) {
+    throw new Error('unsupported json literal');
+  }
+
+  const state = { index: 1 };
+  let output = '';
+
+  while (state.index < trimmed.length) {
+    const char = trimmed[state.index++];
+    if (char === quote) {
+      const trailing = trimmed.slice(state.index).trim();
+      if (trailing.length > 0) {
+        throw new Error('unexpected trailing data after json literal');
+      }
+      return output;
+    }
+
+    if (char === '\\') {
+      output += decodeEscapeSequence(trimmed, state);
+      continue;
+    }
+
+    output += char;
+  }
+
+  throw new Error('unterminated json literal');
+}
+
+function parseChunkBlock(lines) {
+  const block = {
+    chunkIndex: null,
+    chunkCount: null,
+    jsonChunk: null
+  };
+
+  for (const line of lines) {
+    const stripped = stripLogPrefix(line);
+    if (!stripped) {
+      continue;
+    }
+
+    const chunkIndexMatch = stripped.match(/^\s*chunk_index:\s*(\d+),?\s*$/);
+    if (chunkIndexMatch) {
+      block.chunkIndex = Number.parseInt(chunkIndexMatch[1], 10);
+      continue;
+    }
+
+    const chunkCountMatch = stripped.match(/^\s*chunk_count:\s*(\d+),?\s*$/);
+    if (chunkCountMatch) {
+      block.chunkCount = Number.parseInt(chunkCountMatch[1], 10);
+      continue;
+    }
+
+    const jsonMatch = stripped.match(/^\s*json:\s*(.+)\s*$/);
+    if (jsonMatch) {
+      block.jsonChunk = decodeJsStringLiteral(jsonMatch[1]);
+    }
+  }
+
+  if (
+    !Number.isInteger(block.chunkIndex) ||
+    !Number.isInteger(block.chunkCount) ||
+    typeof block.jsonChunk !== 'string'
+  ) {
+    throw new Error('incomplete chunk block');
+  }
+
+  return block;
+}
+
+function collectChunkBlocks(contents) {
+  const lines = contents.split(/\r?\n/);
+  const chunkBlocks = new Map();
+  let activeLabel = null;
+  let activeLines = [];
+
+  const flushActive = () => {
+    if (!activeLabel) {
+      return;
+    }
+    const parsed = parseChunkBlock(activeLines);
+    const blocks = chunkBlocks.get(activeLabel) ?? [];
+    blocks.push(parsed);
+    chunkBlocks.set(activeLabel, blocks);
+    activeLabel = null;
+    activeLines = [];
+  };
+
+  for (const line of lines) {
+    const stripped = stripLogPrefix(line);
+    if (!stripped) {
+      continue;
+    }
+
+    if (stripped.endsWith(' {')) {
+      const candidateLabel = stripped.slice(0, -2);
+      if (CHUNK_LABELS.has(candidateLabel)) {
+        flushActive();
+        activeLabel = candidateLabel;
+        activeLines = [line];
+        continue;
+      }
+    }
+
+    if (!activeLabel) {
+      continue;
+    }
+
+    activeLines.push(line);
+    if (stripped === '}') {
+      flushActive();
+    }
+  }
+
+  flushActive();
+  return chunkBlocks;
+}
+
+function reconstructEntries(blocks) {
+  const completed = [];
+  let current = null;
+
+  for (const block of blocks) {
+    const shouldStartNew =
+      !current ||
+      block.chunkIndex === 0 ||
+      block.chunkCount !== current.chunkCount ||
+      block.chunkIndex <= current.lastChunkIndex ||
+      current.parts[block.chunkIndex] !== undefined;
+
+    if (shouldStartNew) {
+      current = {
+        chunkCount: block.chunkCount,
+        lastChunkIndex: -1,
+        parts: new Array(block.chunkCount)
+      };
+    }
+
+    current.parts[block.chunkIndex] = block.jsonChunk;
+    current.lastChunkIndex = block.chunkIndex;
+
+    const isComplete = Array.from({ length: current.chunkCount }, (_, index) => {
+      return typeof current.parts[index] === 'string';
+    }).every(Boolean);
+
+    if (isComplete) {
+      completed.push(current.parts.join(''));
+      current = null;
+    }
+  }
+
+  return completed;
+}
+
+function parseEntriesByLabel(chunkBlocks) {
+  const parsed = new Map();
+
+  for (const [label, blocks] of chunkBlocks.entries()) {
+    const entries = reconstructEntries(blocks)
+      .map((jsonText) => JSON.parse(jsonText))
+      .filter((entry) => entry && typeof entry === 'object' && typeof entry.request_id === 'string');
+    parsed.set(label, entries);
+  }
+
+  return parsed;
+}
+
+function getProviderRequestId(entry) {
+  if (!entry || typeof entry !== 'object') {
+    return '';
+  }
+
+  if (entry.parsed_body && typeof entry.parsed_body.request_id === 'string') {
+    return entry.parsed_body.request_id;
+  }
+
+  if (entry.response_headers && typeof entry.response_headers['request-id'] === 'string') {
+    return entry.response_headers['request-id'];
+  }
+
+  return '';
+}
+
+function parseStatusFilter(input) {
+  if (!input) {
+    return null;
+  }
+
+  if (!/^\d+$/.test(input)) {
+    console.error(`error: invalid upstream status filter: ${input}`);
+    process.exit(1);
+  }
+
+  return Number.parseInt(input, 10);
+}
+
+function buildEntry(requestId, bucket) {
+  const upstreamRequest = bucket.upstreamRequest ?? null;
+  const upstreamResponse = bucket.upstreamResponse ?? null;
+  const invalidDebug = bucket.invalidDebug ?? null;
+  const invalidPayload = bucket.invalidPayload ?? null;
+  const headers = upstreamRequest?.headers ?? {};
+
+  const provider =
+    upstreamRequest?.provider ??
+    upstreamResponse?.provider ??
+    invalidDebug?.provider ??
+    invalidPayload?.provider ??
+    'unknown';
+
+  const upstreamStatus =
+    typeof upstreamResponse?.upstream_status === 'number'
+      ? upstreamResponse.upstream_status
+      : null;
+
+  let candidateType = 'other';
+  if (provider === 'anthropic' && upstreamStatus === 200 && upstreamRequest && upstreamResponse) {
+    candidateType = 'known_good_candidate';
+  } else if (provider === 'anthropic' && upstreamStatus === 400 && upstreamRequest && upstreamResponse) {
+    candidateType = 'invalid_request_candidate';
+  }
+
+  return {
+    requestId,
+    provider,
+    proxiedPath: upstreamRequest?.proxied_path ?? invalidDebug?.proxied_path ?? '',
+    targetUrl: upstreamRequest?.target_url ?? invalidDebug?.target_url ?? '',
+    attemptNo: upstreamRequest?.attempt_no ?? invalidDebug?.attempt_no ?? null,
+    model: upstreamRequest?.model ?? invalidDebug?.model ?? '',
+    bodyBytes: upstreamRequest?.body_bytes ?? invalidDebug?.body_bytes ?? null,
+    bodySha256: upstreamRequest?.body_sha256 ?? invalidDebug?.body_sha256 ?? '',
+    upstreamStatus,
+    providerRequestId: getProviderRequestId(upstreamResponse),
+    upstreamAnthropicBeta: headers['anthropic-beta'] ?? '',
+    upstreamUserAgent: headers['user-agent'] ?? '',
+    xApp: headers['x-app'] ?? '',
+    xRequestId: headers['x-request-id'] ?? '',
+    hasUpstreamRequest: Boolean(upstreamRequest),
+    hasUpstreamResponse: Boolean(upstreamResponse),
+    hasInvalidDebug: Boolean(invalidDebug),
+    hasInvalidPayload: Boolean(invalidPayload),
+    candidateType
+  };
+}
+
+const artifactPath = path.resolve(artifactPathArg);
+if (!fs.existsSync(artifactPath)) {
+  console.error(`error: artifact not found: ${artifactPathArg}`);
+  process.exit(1);
+}
+
+const outDir = path.resolve(outDirArg);
+const providerFilter = providerFilterArg || '';
+const statusFilter = parseStatusFilter(statusFilterArg || '');
+
+const artifactContents = fs.readFileSync(artifactPath, 'utf8');
+const chunkBlocks = collectChunkBlocks(artifactContents);
+const entriesByLabel = parseEntriesByLabel(chunkBlocks);
+
+const buckets = new Map();
+
+function upsertEntry(labelKey, entry) {
+  const requestId = entry.request_id;
+  const bucket = buckets.get(requestId) ?? {};
+  bucket[labelKey] = entry;
+  buckets.set(requestId, bucket);
+}
+
+for (const entry of entriesByLabel.get('[compat-upstream-request-json-chunk]') ?? []) {
+  upsertEntry('upstreamRequest', entry);
+}
+
+for (const entry of entriesByLabel.get('[compat-upstream-response-json-chunk]') ?? []) {
+  upsertEntry('upstreamResponse', entry);
+}
+
+for (const entry of entriesByLabel.get('[compat-invalid-request-debug-json-chunk]') ?? []) {
+  upsertEntry('invalidDebug', entry);
+}
+
+for (const entry of entriesByLabel.get('[compat-invalid-request-payload-json-chunk]') ?? []) {
+  upsertEntry('invalidPayload', entry);
+}
+
+const entries = Array.from(buckets.entries())
+  .map(([requestId, bucket]) => buildEntry(requestId, bucket))
+  .sort((left, right) => left.requestId.localeCompare(right.requestId));
+
+const matchingEntries = entries.filter((entry) => {
+  if (providerFilter && entry.provider !== providerFilter) {
+    return false;
+  }
+  if (statusFilter !== null && entry.upstreamStatus !== statusFilter) {
+    return false;
+  }
+  return true;
+});
+
+if (matchingEntries.length === 0) {
+  console.error(
+    `error: no matching compat artifact entries found in ${artifactPath} for provider=${providerFilter || '*'} status=${
+      statusFilter === null ? '*' : statusFilter
+    }`
+  );
+  process.exit(1);
+}
+
+const summary = {
+  mode: 'compat_artifact_index',
+  artifactPath,
+  outputDir: outDir,
+  providerFilter: providerFilter || null,
+  statusFilter,
+  entryCount: entries.length,
+  matchingEntryCount: matchingEntries.length,
+  knownGoodCandidateCount: matchingEntries.filter((entry) => entry.candidateType === 'known_good_candidate').length,
+  invalidRequestCandidateCount: matchingEntries.filter((entry) => entry.candidateType === 'invalid_request_candidate').length,
+  entries: matchingEntries
+};
+
+const summaryLines = [];
+summaryLines.push('mode=compat_artifact_index');
+summaryLines.push(`artifact_path=${artifactPath}`);
+summaryLines.push(`entry_count=${entries.length}`);
+summaryLines.push(`matching_entry_count=${matchingEntries.length}`);
+if (providerFilter) {
+  summaryLines.push(`provider_filter=${providerFilter}`);
+}
+if (statusFilter !== null) {
+  summaryLines.push(`status_filter=${statusFilter}`);
+}
+summaryLines.push(`known_good_candidate_count=${summary.knownGoodCandidateCount}`);
+summaryLines.push(`invalid_request_candidate_count=${summary.invalidRequestCandidateCount}`);
+
+for (const entry of matchingEntries) {
+  summaryLines.push(
+    `request_id=${entry.requestId} provider=${entry.provider} upstream_status=${
+      entry.upstreamStatus === null ? '' : entry.upstreamStatus
+    } candidate_type=${entry.candidateType} provider_request_id=${entry.providerRequestId} body_sha256=${entry.bodySha256} has_upstream_request=${String(
+      entry.hasUpstreamRequest
+    )} has_upstream_response=${String(entry.hasUpstreamResponse)} has_invalid_debug=${String(
+      entry.hasInvalidDebug
+    )} has_invalid_payload=${String(entry.hasInvalidPayload)}`
+  );
+}
+
+fs.mkdirSync(outDir, { recursive: true });
+fs.writeFileSync(path.join(outDir, 'summary.json'), `${JSON.stringify(summary, null, 2)}\n`);
+fs.writeFileSync(path.join(outDir, 'summary.txt'), `${summaryLines.join('\n')}\n`);

--- a/scripts/innies-compat-artifact-index.sh
+++ b/scripts/innies-compat-artifact-index.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_PATH" ]]; do
+  SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+  SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"
+  [[ "$SCRIPT_PATH" != /* ]] && SCRIPT_PATH="${SCRIPT_DIR}/${SCRIPT_PATH}"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+source "${SCRIPT_DIR}/_common.sh"
+
+ARTIFACT_PATH="${1:-${INNIES_COMPAT_ARTIFACT_INDEX_INPUT:-}}"
+PROVIDER_FILTER="${2:-${INNIES_COMPAT_ARTIFACT_INDEX_PROVIDER:-}}"
+STATUS_FILTER="${3:-${INNIES_COMPAT_ARTIFACT_INDEX_STATUS:-}}"
+
+require_nonempty 'compat artifact path' "$ARTIFACT_PATH"
+
+if [[ ! -f "$ARTIFACT_PATH" ]]; then
+  echo "error: artifact not found: $ARTIFACT_PATH" >&2
+  exit 1
+fi
+
+artifact_dir="$(cd "$(dirname "$ARTIFACT_PATH")" && pwd)"
+artifact_name="$(basename "$ARTIFACT_PATH")"
+artifact_stem="${artifact_name%.*}"
+DEFAULT_OUT_DIR="${artifact_dir}/${artifact_stem}-artifact-index"
+OUT_DIR="${INNIES_COMPAT_ARTIFACT_INDEX_OUT_DIR:-$DEFAULT_OUT_DIR}"
+mkdir -p "$OUT_DIR"
+
+if ! command -v node >/dev/null 2>&1; then
+  echo 'error: node is required for innies-compat-artifact-index.sh' >&2
+  exit 1
+fi
+
+node "${SCRIPT_DIR}/innies-compat-artifact-index.mjs" \
+  "$ARTIFACT_PATH" \
+  "$OUT_DIR" \
+  "$PROVIDER_FILTER" \
+  "$STATUS_FILTER"
+
+SUMMARY_FILE="$OUT_DIR/summary.txt"
+cat "$SUMMARY_FILE"
+printf 'summary_file=%s\n' "$SUMMARY_FILE"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,6 +18,7 @@ ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-set.sh" "${BIN_DIR}/innies-b
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-get.sh" "${BIN_DIR}/innies-buyer-preference-get"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-check.sh" "${BIN_DIR}/innies-buyer-preference-check"
 ln -sf "${ROOT_DIR}/scripts/innies-slo-check.sh" "${BIN_DIR}/innies-slo-check"
+ln -sf "${ROOT_DIR}/scripts/innies-compat-artifact-index.sh" "${BIN_DIR}/innies-compat-artifact-index"
 
 rm -f \
   "${BIN_DIR}/innies-admin" \
@@ -49,6 +50,7 @@ echo "  ${BIN_DIR}/innies-buyer-preference-set -> ${ROOT_DIR}/scripts/innies-buy
 echo "  ${BIN_DIR}/innies-buyer-preference-get -> ${ROOT_DIR}/scripts/innies-buyer-preference-get.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-check -> ${ROOT_DIR}/scripts/innies-buyer-preference-check.sh"
 echo "  ${BIN_DIR}/innies-slo-check -> ${ROOT_DIR}/scripts/innies-slo-check.sh"
+echo "  ${BIN_DIR}/innies-compat-artifact-index -> ${ROOT_DIR}/scripts/innies-compat-artifact-index.sh"
 echo
 echo 'If command not found, add ~/.local/bin to PATH:'
 echo '  export PATH="$HOME/.local/bin:$PATH"'

--- a/scripts/tests/innies-compat-artifact-index.test.sh
+++ b/scripts/tests/innies-compat-artifact-index.test.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="$ROOT_DIR/scripts/innies-compat-artifact-index.sh"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+write_lines() {
+  local file="$1"
+  shift
+  mkdir -p "$(dirname "$file")"
+  printf '%s\n' "$@" >"$file"
+}
+
+artifact_path="$TMP_DIR/response_issue80_sample.html"
+write_lines "$artifact_path" \
+  "Mar 17 12:00:00 host bash[1]: [compat-upstream-request-json-chunk] {" \
+  "Mar 17 12:00:00 host bash[1]:   chunk_index: 0," \
+  "Mar 17 12:00:00 host bash[1]:   chunk_count: 1," \
+  "Mar 17 12:00:00 host bash[1]:   json: '{\"request_id\":\"req_success\",\"attempt_no\":1,\"provider\":\"anthropic\",\"proxied_path\":\"/v1/messages\",\"target_url\":\"https://api.anthropic.com/v1/messages\",\"model\":\"claude-opus-4-6\",\"body_bytes\":111,\"body_sha256\":\"sha_success\",\"headers\":{\"anthropic-beta\":\"beta_success\",\"user-agent\":\"OpenClawGateway/1.0\",\"x-app\":\"cli\",\"x-request-id\":\"req_success\"}}'" \
+  "Mar 17 12:00:00 host bash[1]: }" \
+  "Mar 17 12:00:00 host bash[1]: [compat-upstream-response-json-chunk] {" \
+  "Mar 17 12:00:00 host bash[1]:   chunk_index: 0," \
+  "Mar 17 12:00:00 host bash[1]:   chunk_count: 1," \
+  "Mar 17 12:00:00 host bash[1]:   json: '{\"request_id\":\"req_success\",\"provider\":\"anthropic\",\"upstream_status\":200,\"parsed_body\":{\"request_id\":\"req_provider_success\"},\"response_headers\":{\"request-id\":\"req_provider_success\"}}'" \
+  "Mar 17 12:00:00 host bash[1]: }" \
+  "Mar 17 12:00:00 host bash[1]: [compat-upstream-request-json-chunk] {" \
+  "Mar 17 12:00:00 host bash[1]:   chunk_index: 0," \
+  "Mar 17 12:00:00 host bash[1]:   chunk_count: 1," \
+  "Mar 17 12:00:00 host bash[1]:   json: '{\"request_id\":\"req_fail\",\"attempt_no\":1,\"provider\":\"anthropic\",\"proxied_path\":\"/v1/messages\",\"target_url\":\"https://api.anthropic.com/v1/messages\",\"model\":\"claude-opus-4-6\",\"body_bytes\":222,\"body_sha256\":\"sha_fail\",\"headers\":{\"anthropic-beta\":\"beta_fail\",\"user-agent\":\"OpenClawGateway/1.0\",\"x-app\":\"cli\",\"x-request-id\":\"req_fail\"}}'" \
+  "Mar 17 12:00:00 host bash[1]: }" \
+  "Mar 17 12:00:00 host bash[1]: [compat-upstream-response-json-chunk] {" \
+  "Mar 17 12:00:00 host bash[1]:   chunk_index: 0," \
+  "Mar 17 12:00:00 host bash[1]:   chunk_count: 1," \
+  "Mar 17 12:00:00 host bash[1]:   json: '{\"request_id\":\"req_fail\",\"provider\":\"anthropic\",\"upstream_status\":400,\"parsed_body\":{\"request_id\":\"req_provider_fail\"},\"response_headers\":{\"request-id\":\"req_provider_fail\"}}'" \
+  "Mar 17 12:00:00 host bash[1]: }" \
+  "Mar 17 12:00:00 host bash[1]: [compat-invalid-request-debug-json-chunk] {" \
+  "Mar 17 12:00:00 host bash[1]:   chunk_index: 0," \
+  "Mar 17 12:00:00 host bash[1]:   chunk_count: 1," \
+  "Mar 17 12:00:00 host bash[1]:   json: '{\"request_id\":\"req_fail\",\"provider\":\"anthropic\"}'" \
+  "Mar 17 12:00:00 host bash[1]: }" \
+  "Mar 17 12:00:00 host bash[1]: [compat-invalid-request-payload-json-chunk] {" \
+  "Mar 17 12:00:00 host bash[1]:   chunk_index: 0," \
+  "Mar 17 12:00:00 host bash[1]:   chunk_count: 1," \
+  "Mar 17 12:00:00 host bash[1]:   json: '{\"request_id\":\"req_fail\",\"payload\":{\"model\":\"claude-opus-4-6\"}}'" \
+  "Mar 17 12:00:00 host bash[1]: }" \
+  "Mar 17 12:00:00 host bash[1]: [compat-upstream-request-json-chunk] {" \
+  "Mar 17 12:00:00 host bash[1]:   chunk_index: 0," \
+  "Mar 17 12:00:00 host bash[1]:   chunk_count: 1," \
+  "Mar 17 12:00:00 host bash[1]:   json: '{\"request_id\":\"req_openai\",\"attempt_no\":1,\"provider\":\"openai\",\"proxied_path\":\"/v1/messages\",\"target_url\":\"https://api.openai.com/v1/responses\",\"model\":\"gpt-5.4\",\"body_bytes\":333,\"body_sha256\":\"sha_openai\",\"headers\":{\"x-request-id\":\"req_openai\"}}'" \
+  "Mar 17 12:00:00 host bash[1]: }" \
+  "Mar 17 12:00:00 host bash[1]: [compat-upstream-response-json-chunk] {" \
+  "Mar 17 12:00:00 host bash[1]:   chunk_index: 0," \
+  "Mar 17 12:00:00 host bash[1]:   chunk_count: 1," \
+  "Mar 17 12:00:00 host bash[1]:   json: '{\"request_id\":\"req_openai\",\"provider\":\"openai\",\"upstream_status\":200,\"parsed_body\":{\"request_id\":\"req_provider_openai\"},\"response_headers\":{\"request-id\":\"req_provider_openai\"}}'" \
+  "Mar 17 12:00:00 host bash[1]: }"
+
+run_index() {
+  local output_dir="$1"
+  local stdout_path="$2"
+  local stderr_path="$3"
+  shift 3
+  INNIES_COMPAT_ARTIFACT_INDEX_OUT_DIR="$output_dir" "$SCRIPT_PATH" "$artifact_path" "$@" >"$stdout_path" 2>"$stderr_path"
+}
+
+run_index "$TMP_DIR/all" "$TMP_DIR/all.stdout" "$TMP_DIR/all.stderr"
+run_index "$TMP_DIR/anthropic-200" "$TMP_DIR/anthropic-200.stdout" "$TMP_DIR/anthropic-200.stderr" anthropic 200
+
+[[ -f "$TMP_DIR/all/summary.txt" ]]
+[[ -f "$TMP_DIR/all/summary.json" ]]
+grep -q '^mode=compat_artifact_index$' "$TMP_DIR/all/summary.txt"
+grep -q '^entry_count=3$' "$TMP_DIR/all/summary.txt"
+grep -q '^matching_entry_count=3$' "$TMP_DIR/all/summary.txt"
+grep -q '^known_good_candidate_count=1$' "$TMP_DIR/all/summary.txt"
+grep -q '^invalid_request_candidate_count=1$' "$TMP_DIR/all/summary.txt"
+grep -q '^request_id=req_success provider=anthropic upstream_status=200 candidate_type=known_good_candidate provider_request_id=req_provider_success body_sha256=sha_success has_upstream_request=true has_upstream_response=true has_invalid_debug=false has_invalid_payload=false$' "$TMP_DIR/all/summary.txt"
+grep -q '^request_id=req_fail provider=anthropic upstream_status=400 candidate_type=invalid_request_candidate provider_request_id=req_provider_fail body_sha256=sha_fail has_upstream_request=true has_upstream_response=true has_invalid_debug=true has_invalid_payload=true$' "$TMP_DIR/all/summary.txt"
+grep -q '^request_id=req_openai provider=openai upstream_status=200 candidate_type=other provider_request_id=req_provider_openai body_sha256=sha_openai has_upstream_request=true has_upstream_response=true has_invalid_debug=false has_invalid_payload=false$' "$TMP_DIR/all/summary.txt"
+grep -q '^summary_file=' "$TMP_DIR/all.stdout"
+
+[[ -f "$TMP_DIR/anthropic-200/summary.txt" ]]
+[[ -f "$TMP_DIR/anthropic-200/summary.json" ]]
+grep -q '^provider_filter=anthropic$' "$TMP_DIR/anthropic-200/summary.txt"
+grep -q '^status_filter=200$' "$TMP_DIR/anthropic-200/summary.txt"
+grep -q '^entry_count=3$' "$TMP_DIR/anthropic-200/summary.txt"
+grep -q '^matching_entry_count=1$' "$TMP_DIR/anthropic-200/summary.txt"
+grep -q '^request_id=req_success provider=anthropic upstream_status=200 candidate_type=known_good_candidate provider_request_id=req_provider_success body_sha256=sha_success has_upstream_request=true has_upstream_response=true has_invalid_debug=false has_invalid_payload=false$' "$TMP_DIR/anthropic-200/summary.txt"
+if grep -q '^request_id=req_fail ' "$TMP_DIR/anthropic-200/summary.txt"; then
+  echo 'expected anthropic 200 filter to exclude req_fail' >&2
+  exit 1
+fi
+
+node - "$TMP_DIR/all/summary.json" "$TMP_DIR/anthropic-200/summary.json" <<'NODE'
+const fs = require('fs');
+
+const [allPath, filteredPath] = process.argv.slice(2);
+const allSummary = JSON.parse(fs.readFileSync(allPath, 'utf8'));
+const filteredSummary = JSON.parse(fs.readFileSync(filteredPath, 'utf8'));
+
+if (allSummary.entries.length !== 3) {
+  throw new Error('expected three indexed entries');
+}
+
+const successEntry = allSummary.entries.find((entry) => entry.requestId === 'req_success');
+if (!successEntry || successEntry.candidateType !== 'known_good_candidate') {
+  throw new Error('missing success candidate');
+}
+
+const failureEntry = allSummary.entries.find((entry) => entry.requestId === 'req_fail');
+if (!failureEntry || failureEntry.candidateType !== 'invalid_request_candidate') {
+  throw new Error('missing failure candidate');
+}
+
+if (filteredSummary.entries.length !== 1 || filteredSummary.entries[0].requestId !== 'req_success') {
+  throw new Error('expected one filtered anthropic 200 entry');
+}
+NODE
+
+set +e
+run_index "$TMP_DIR/no-match" "$TMP_DIR/no-match.stdout" "$TMP_DIR/no-match.stderr" anthropic 204
+status=$?
+set -e
+
+if [[ "$status" -eq 0 ]]; then
+  echo 'expected no-match filter to fail' >&2
+  exit 1
+fi
+
+grep -q 'no matching compat artifact entries found' "$TMP_DIR/no-match.stderr"
+
+echo "PASS: innies-compat-artifact-index indexes saved compat artifacts"


### PR DESCRIPTION
## Summary
- add `innies-compat-artifact-index` to scan saved compat HTML/log artifacts and reconstruct first-pass request bundles from safe chunk-log decoding
- emit `summary.txt` and `summary.json`, with optional provider and upstream-status filters plus Anthropic candidate classification
- install and document the helper and cover it with a focused shell test

## Test Plan
- `bash scripts/tests/innies-compat-artifact-index.test.sh`
- `bash -n scripts/innies-compat-artifact-index.sh scripts/tests/innies-compat-artifact-index.test.sh scripts/install.sh`
- `node --check scripts/innies-compat-artifact-index.mjs`
- `TMP_HOME="$(mktemp -d)" && HOME="$TMP_HOME" bash scripts/install.sh >/tmp/issue80-artifact-index-install.out && test -L "$TMP_HOME/.local/bin/innies-compat-artifact-index"`
- `cd cli && npm run test:unit`
- `cd api && npm ci && npm test`
- `INNIES_COMPAT_ARTIFACT_INDEX_OUT_DIR=/tmp/issue80-artifact-index-400 scripts/innies-compat-artifact-index.sh /Users/dylanvu/Downloads/response_1773768207701.html anthropic 400`
- `INNIES_COMPAT_ARTIFACT_INDEX_OUT_DIR=/tmp/issue80-artifact-index-1773770803299 scripts/innies-compat-artifact-index.sh /Users/dylanvu/Downloads/response_1773770803299.html`
- `INNIES_COMPAT_ARTIFACT_INDEX_OUT_DIR=/tmp/issue80-artifact-index-1773763965680 scripts/innies-compat-artifact-index.sh /Users/dylanvu/Downloads/response_1773763965680.html`
- `INNIES_COMPAT_ARTIFACT_INDEX_OUT_DIR=/tmp/issue80-artifact-index-200 scripts/innies-compat-artifact-index.sh /Users/dylanvu/Downloads/response_1773766706663.html anthropic 200` (expected failure: no match)
- `INNIES_COMPAT_ARTIFACT_INDEX_OUT_DIR=/tmp/issue80-artifact-index-empty scripts/innies-compat-artifact-index.sh /Users/dylanvu/Downloads/response_1773771475344.html` (expected failure: no match)

Related to #80.
