### PR TITLE
chore: add issue 80 evidence report helper

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -25,6 +25,7 @@ innies-buyer-preference-set
 innies-buyer-preference-get
 innies-buyer-preference-check
 innies-slo-check
+innies-compat-evidence-report
 ```
 
 What they do:
@@ -40,6 +41,7 @@ What they do:
 - `innies-buyer-preference-get`: read the current buyer key preference
 - `innies-buyer-preference-check`: run the provider-preference canary after prompting for the expected provider (`Claude Code` or `Codex`)
 - `innies-slo-check`: query analytics endpoints and report Phase 1 SLO pass/fail (TTFB p95, timeout rate, success rate, fallback rate); optional arg sets the window (default `24h`); exits 0 if all SLOs pass, 1 if any fail
+- `innies-compat-evidence-report`: combine issue-80 exact-case, minimal-delta, payload, and token-lane summary artifacts into one report plus issue-comment draft
 
 Behavior:
 - org id auto-uses `INNIES_ORG_ID`
@@ -79,6 +81,8 @@ Behavior:
 - non-pinned buyer traffic always gets automatic cross-provider fallback to the other provider; flipping preference flips fallback order too
 - `innies-buyer-preference-set` prints the effective preferred provider plus the automatic fallback provider before sending the update
 - `innies-buyer-preference-check` now expects and validates the two-provider plan in DB evidence mode
+- `innies-compat-evidence-report` accepts `--exact-case-summary`, `--exact-case-minimal-delta`, `--payload-summary`, and `--token-lane-summary`; each input may be either a summary file or its parent output directory
+- `innies-compat-evidence-report` writes `summary.txt`, `summary.json`, and `issue-comment.md`; set `INNIES_COMPAT_EVIDENCE_REPORT_OUT_DIR` or pass `--out-dir` to control the destination
 
 ## Env
 

--- a/scripts/innies-compat-evidence-report.mjs
+++ b/scripts/innies-compat-evidence-report.mjs
@@ -1,0 +1,296 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const [
+  exactCaseArg,
+  minimalDeltaArg,
+  payloadArg,
+  tokenLaneArg,
+  outDirArg
+] = process.argv.slice(2);
+
+function fail(message) {
+  console.error(`error: ${message}`);
+  process.exit(1);
+}
+
+if (!outDirArg) {
+  fail('missing report output dir');
+}
+
+const outDir = path.resolve(outDirArg);
+fs.mkdirSync(outDir, { recursive: true });
+
+function readKeyValueFile(filePath) {
+  const result = {};
+  const text = fs.readFileSync(filePath, 'utf8');
+  for (const line of text.split(/\r?\n/)) {
+    if (!line || !line.includes('=')) continue;
+    const index = line.indexOf('=');
+    const key = line.slice(0, index).trim();
+    const value = line.slice(index + 1).trim();
+    if (!key) continue;
+    result[key] = value;
+  }
+  return result;
+}
+
+function resolveSummaryPath(inputArg, fallbacks) {
+  if (!inputArg || inputArg === '-') return null;
+  const resolved = path.resolve(inputArg);
+  if (!fs.existsSync(resolved)) {
+    fail(`evidence input path not found: ${inputArg}`);
+  }
+  if (fs.statSync(resolved).isFile()) {
+    return resolved;
+  }
+  for (const fileName of fallbacks) {
+    const candidate = path.join(resolved, fileName);
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+      return candidate;
+    }
+  }
+  fail(`summary file not found in ${resolved}`);
+}
+
+function joinNames(values) {
+  return values.length > 0 ? values.join(',') : '-';
+}
+
+function parseSummary(axis, inputArg, fallbacks) {
+  const summaryPath = resolveSummaryPath(inputArg, fallbacks);
+  if (!summaryPath) return null;
+  const data = readKeyValueFile(summaryPath);
+  return {
+    axis,
+    summaryPath,
+    inputPath: path.resolve(inputArg),
+    data
+  };
+}
+
+const exactCase = parseSummary('exact_case', exactCaseArg, ['summary.txt']);
+const minimalDelta = parseSummary('minimal_delta', minimalDeltaArg, ['summary.txt', 'minimal-delta.txt']);
+const payload = parseSummary('payload', payloadArg, ['summary.txt']);
+const tokenLane = parseSummary('token_lane', tokenLaneArg, ['summary.txt']);
+
+const presentAxes = [exactCase, minimalDelta, payload, tokenLane]
+  .filter(Boolean)
+  .map((entry) => entry.axis);
+
+if (presentAxes.length === 0) {
+  fail('at least one evidence input path is required');
+}
+
+const exactCaseClassification = exactCase?.data.classification ?? '';
+const minimalDeltaConclusion = minimalDelta?.data.conclusion ?? '';
+const payloadClassification = payload?.data.classification ?? '';
+const tokenLaneClassification = tokenLane?.data.classification ?? '';
+const minimalSuccessCase = minimalDelta?.data.minimal_success_case ?? '';
+const minimalSuccessDelta = minimalDelta?.data.minimal_success_delta ?? '';
+const bodySha256 =
+  exactCase?.data.body_sha256 ??
+  minimalDelta?.data.body_sha256 ??
+  payload?.data.body_sha256 ??
+  tokenLane?.data.body_sha256 ??
+  '';
+
+let overallClassification = 'insufficient_evidence';
+let nextHypothesis = 'collect_more_evidence';
+
+const explicitHeaderCandidate = [
+  'shared_headers_only_candidate',
+  'beta_headers_only_candidate',
+  'identity_headers_only_candidate',
+  'beta_and_identity_candidate',
+  'additional_direct_delta_candidate',
+  'direct_exact_only_candidate'
+].includes(minimalDeltaConclusion);
+
+if (explicitHeaderCandidate) {
+  overallClassification = 'header_delta_specific';
+  nextHypothesis = minimalDeltaConclusion;
+} else if (exactCaseClassification === 'header_case_specific') {
+  overallClassification = 'header_delta_specific';
+  nextHypothesis = 'header_delta_followup_required';
+} else if (
+  exactCaseClassification === 'mixed_case_and_lane_specific' ||
+  minimalDeltaConclusion === 'lane_specific_followup_required'
+) {
+  overallClassification = 'mixed_header_and_lane_specific';
+  nextHypothesis = 'lane_specific_followup_required';
+} else if (
+  exactCaseClassification === 'credential_lane_specific' ||
+  tokenLaneClassification === 'credential_lane_specific'
+ ) {
+  overallClassification = 'credential_lane_specific';
+  nextHypothesis = 'credential_lane_specific';
+} else if (payloadClassification === 'transcript_shape_specific') {
+  overallClassification = 'transcript_shape_specific';
+  nextHypothesis = 'transcript_shape_specific';
+} else {
+  const providerSideSignals = [
+    exactCaseClassification === 'uniform_failure_provider_side_candidate',
+    payloadClassification === 'uniform_failure_provider_side_candidate',
+    tokenLaneClassification === 'uniform_failure_provider_side_candidate',
+    minimalDeltaConclusion === 'no_controlled_case_success'
+  ].filter(Boolean).length;
+
+  const conflictingSignals = [
+    exactCaseClassification,
+    payloadClassification,
+    tokenLaneClassification,
+    minimalDeltaConclusion
+  ].filter((value) => value && ![
+    'uniform_failure_provider_side_candidate',
+    'no_controlled_case_success',
+    'single_payload_only',
+    'single_lane_only',
+    'all_success'
+  ].includes(value));
+
+  if (providerSideSignals > 0 && conflictingSignals.length === 0) {
+    overallClassification = 'provider_side_candidate';
+    nextHypothesis = 'provider_side_candidate';
+  }
+}
+
+const providerSideCandidate = overallClassification === 'provider_side_candidate';
+
+const output = {
+  mode: 'issue80_evidence_report',
+  evidenceAxes: presentAxes,
+  overallClassification,
+  nextHypothesis,
+  providerSideCandidate,
+  bodySha256: bodySha256 || null,
+  axes: {
+    exactCase: exactCase ? {
+      summaryPath: exactCase.summaryPath,
+      classification: exactCaseClassification || null,
+      headerSensitive: exactCase.data.header_sensitive ?? null,
+      tokenLaneSensitive: exactCase.data.token_lane_sensitive ?? null,
+      successfulCases: exactCase.data.successful_cases ?? null,
+      failingCases: exactCase.data.failing_cases ?? null
+    } : null,
+    minimalDelta: minimalDelta ? {
+      summaryPath: minimalDelta.summaryPath,
+      conclusion: minimalDeltaConclusion || null,
+      baselineCase: minimalDelta.data.baseline_case ?? null,
+      minimalSuccessCase: minimalSuccessCase || null,
+      minimalSuccessDelta: minimalSuccessDelta || null,
+      blockedLanes: minimalDelta.data.blocked_lanes ?? null
+    } : null,
+    payload: payload ? {
+      summaryPath: payload.summaryPath,
+      classification: payloadClassification || null,
+      payloadSensitive: payload.data.payload_sensitive ?? null,
+      uniformFailure: payload.data.uniform_failure ?? null
+    } : null,
+    tokenLane: tokenLane ? {
+      summaryPath: tokenLane.summaryPath,
+      classification: tokenLaneClassification || null,
+      tokenLaneSensitive: tokenLane.data.token_lane_sensitive ?? null,
+      uniformFailure: tokenLane.data.uniform_failure ?? null
+    } : null
+  }
+};
+
+const summaryLines = [
+  'mode=issue80_evidence_report',
+  `evidence_axes=${joinNames(presentAxes)}`,
+  `overall_classification=${overallClassification}`,
+  `next_hypothesis=${nextHypothesis}`,
+  `provider_side_candidate=${String(providerSideCandidate)}`
+];
+
+if (bodySha256) {
+  summaryLines.push(`body_sha256=${bodySha256}`);
+}
+if (exactCaseClassification) {
+  summaryLines.push(`exact_case_classification=${exactCaseClassification}`);
+}
+if (minimalDeltaConclusion) {
+  summaryLines.push(`minimal_delta_conclusion=${minimalDeltaConclusion}`);
+}
+if (minimalSuccessCase) {
+  summaryLines.push(`minimal_success_case=${minimalSuccessCase}`);
+}
+if (minimalSuccessDelta) {
+  summaryLines.push(`minimal_success_delta=${minimalSuccessDelta}`);
+}
+if (payloadClassification) {
+  summaryLines.push(`payload_classification=${payloadClassification}`);
+}
+if (tokenLaneClassification) {
+  summaryLines.push(`token_lane_classification=${tokenLaneClassification}`);
+}
+if (exactCase?.summaryPath) {
+  summaryLines.push(`exact_case_summary=${exactCase.summaryPath}`);
+}
+if (minimalDelta?.summaryPath) {
+  summaryLines.push(`minimal_delta_summary=${minimalDelta.summaryPath}`);
+}
+if (payload?.summaryPath) {
+  summaryLines.push(`payload_summary=${payload.summaryPath}`);
+}
+if (tokenLane?.summaryPath) {
+  summaryLines.push(`token_lane_summary=${tokenLane.summaryPath}`);
+}
+
+const issueCommentLines = [
+  '# Issue 80 Evidence Report',
+  '',
+  `- Overall classification: \`${overallClassification}\``,
+  `- Recommended next hypothesis: \`${nextHypothesis}\``,
+  `- Evidence axes included: \`${joinNames(presentAxes)}\``
+];
+
+if (bodySha256) {
+  issueCommentLines.push(`- Body sha256: \`${bodySha256}\``);
+}
+
+issueCommentLines.push('', '## Findings', '');
+
+if (overallClassification === 'header_delta_specific') {
+  issueCommentLines.push('- Exact-case evidence points at a remaining header delta.');
+  if (minimalSuccessCase) {
+    issueCommentLines.push(`- Smallest successful controlled case: \`${minimalSuccessCase}\` (\`${minimalSuccessDelta || 'unknown_delta'}\`).`);
+  }
+} else if (overallClassification === 'provider_side_candidate') {
+  issueCommentLines.push('- All available controlled axes stayed uniform, so the remaining candidate is provider-side behavior or an unmodeled delta.');
+} else if (overallClassification === 'credential_lane_specific') {
+  issueCommentLines.push('- Credential-lane evidence still flips outcome while the held-constant body/header lane stays fixed.');
+} else if (overallClassification === 'transcript_shape_specific') {
+  issueCommentLines.push('- Payload-shape evidence still flips outcome while the direct header/token lane stays fixed.');
+} else if (overallClassification === 'mixed_header_and_lane_specific') {
+  issueCommentLines.push('- Current evidence mixes header-case and credential-lane sensitivity, so the next follow-up should isolate lane-specific header deltas.');
+} else {
+  issueCommentLines.push('- Current artifact set does not yet isolate one dominant explanation.');
+}
+
+if (exactCaseClassification) {
+  issueCommentLines.push(`- Exact-case summary: \`${exactCaseClassification}\`.`);
+}
+if (minimalDeltaConclusion) {
+  issueCommentLines.push(`- Minimal-delta conclusion: \`${minimalDeltaConclusion}\`.`);
+}
+if (payloadClassification) {
+  issueCommentLines.push(`- Direct payload summary: \`${payloadClassification}\`.`);
+}
+if (tokenLaneClassification) {
+  issueCommentLines.push(`- Direct token-lane summary: \`${tokenLaneClassification}\`.`);
+}
+
+issueCommentLines.push('', '## Next Step', '');
+issueCommentLines.push(`Recommended next hypothesis: \`${nextHypothesis}\``);
+
+const summaryPath = path.join(outDir, 'summary.txt');
+const jsonPath = path.join(outDir, 'summary.json');
+const commentPath = path.join(outDir, 'issue-comment.md');
+
+fs.writeFileSync(summaryPath, `${summaryLines.join('\n')}\n`);
+fs.writeFileSync(jsonPath, `${JSON.stringify(output, null, 2)}\n`);
+fs.writeFileSync(commentPath, `${issueCommentLines.join('\n')}\n`);

--- a/scripts/innies-compat-evidence-report.sh
+++ b/scripts/innies-compat-evidence-report.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_PATH" ]]; do
+  SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+  SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"
+  [[ "$SCRIPT_PATH" != /* ]] && SCRIPT_PATH="${SCRIPT_DIR}/${SCRIPT_PATH}"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+source "${SCRIPT_DIR}/_common.sh"
+
+EXACT_CASE_SUMMARY="${INNIES_EXACT_CASE_SUMMARY:-}"
+EXACT_CASE_MINIMAL_DELTA="${INNIES_EXACT_CASE_MINIMAL_DELTA:-}"
+PAYLOAD_SUMMARY="${INNIES_DIRECT_PAYLOAD_SUMMARY:-}"
+TOKEN_LANE_SUMMARY="${INNIES_DIRECT_TOKEN_LANE_SUMMARY:-}"
+OUT_DIR="${INNIES_COMPAT_EVIDENCE_REPORT_OUT_DIR:-}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --exact-case-summary)
+      EXACT_CASE_SUMMARY="${2:-}"
+      shift 2
+      ;;
+    --exact-case-minimal-delta)
+      EXACT_CASE_MINIMAL_DELTA="${2:-}"
+      shift 2
+      ;;
+    --payload-summary)
+      PAYLOAD_SUMMARY="${2:-}"
+      shift 2
+      ;;
+    --token-lane-summary)
+      TOKEN_LANE_SUMMARY="${2:-}"
+      shift 2
+      ;;
+    --out-dir)
+      OUT_DIR="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$EXACT_CASE_SUMMARY" && -z "$EXACT_CASE_MINIMAL_DELTA" && -z "$PAYLOAD_SUMMARY" && -z "$TOKEN_LANE_SUMMARY" ]]; then
+  echo 'error: at least one evidence input path is required' >&2
+  exit 1
+fi
+
+for input_path in "$EXACT_CASE_SUMMARY" "$EXACT_CASE_MINIMAL_DELTA" "$PAYLOAD_SUMMARY" "$TOKEN_LANE_SUMMARY"; do
+  if [[ -n "$input_path" && ! -e "$input_path" ]]; then
+    echo "error: evidence input path not found: $input_path" >&2
+    exit 1
+  fi
+done
+
+if [[ -z "$OUT_DIR" ]]; then
+  for input_path in "$EXACT_CASE_SUMMARY" "$EXACT_CASE_MINIMAL_DELTA" "$PAYLOAD_SUMMARY" "$TOKEN_LANE_SUMMARY"; do
+    if [[ -n "$input_path" ]]; then
+      if [[ -d "$input_path" ]]; then
+        OUT_DIR="${input_path%/}/report"
+      else
+        OUT_DIR="$(cd "$(dirname "$input_path")" && pwd)/report"
+      fi
+      break
+    fi
+  done
+fi
+
+mkdir -p "$OUT_DIR"
+
+if ! command -v node >/dev/null 2>&1; then
+  echo 'error: node is required for innies-compat-evidence-report.sh' >&2
+  exit 1
+fi
+
+node "${SCRIPT_DIR}/innies-compat-evidence-report.mjs" \
+  "${EXACT_CASE_SUMMARY:-"-"}" \
+  "${EXACT_CASE_MINIMAL_DELTA:-"-"}" \
+  "${PAYLOAD_SUMMARY:-"-"}" \
+  "${TOKEN_LANE_SUMMARY:-"-"}" \
+  "$OUT_DIR"
+
+SUMMARY_FILE="$OUT_DIR/summary.txt"
+ISSUE_COMMENT_FILE="$OUT_DIR/issue-comment.md"
+cat "$SUMMARY_FILE"
+printf 'summary_file=%s\n' "$SUMMARY_FILE"
+printf 'issue_comment_file=%s\n' "$ISSUE_COMMENT_FILE"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,6 +18,7 @@ ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-set.sh" "${BIN_DIR}/innies-b
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-get.sh" "${BIN_DIR}/innies-buyer-preference-get"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-check.sh" "${BIN_DIR}/innies-buyer-preference-check"
 ln -sf "${ROOT_DIR}/scripts/innies-slo-check.sh" "${BIN_DIR}/innies-slo-check"
+ln -sf "${ROOT_DIR}/scripts/innies-compat-evidence-report.sh" "${BIN_DIR}/innies-compat-evidence-report"
 
 rm -f \
   "${BIN_DIR}/innies-admin" \
@@ -49,6 +50,7 @@ echo "  ${BIN_DIR}/innies-buyer-preference-set -> ${ROOT_DIR}/scripts/innies-buy
 echo "  ${BIN_DIR}/innies-buyer-preference-get -> ${ROOT_DIR}/scripts/innies-buyer-preference-get.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-check -> ${ROOT_DIR}/scripts/innies-buyer-preference-check.sh"
 echo "  ${BIN_DIR}/innies-slo-check -> ${ROOT_DIR}/scripts/innies-slo-check.sh"
+echo "  ${BIN_DIR}/innies-compat-evidence-report -> ${ROOT_DIR}/scripts/innies-compat-evidence-report.sh"
 echo
 echo 'If command not found, add ~/.local/bin to PATH:'
 echo '  export PATH="$HOME/.local/bin:$PATH"'

--- a/scripts/tests/innies-compat-evidence-report.test.sh
+++ b/scripts/tests/innies-compat-evidence-report.test.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="$ROOT_DIR/scripts/innies-compat-evidence-report.sh"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+write_lines() {
+  local file="$1"
+  shift
+  mkdir -p "$(dirname "$file")"
+  printf '%s\n' "$@" >"$file"
+}
+
+header_case_dir="$TMP_DIR/header-case"
+write_lines "$header_case_dir/summary.txt" \
+  "mode=case_matrix" \
+  "classification=header_case_specific" \
+  "header_sensitive=true" \
+  "token_lane_sensitive=false" \
+  "uniform_failure=false" \
+  "body_sha256=1717a039bed013d162eb47daead7f7eea440bccc6fb2719b9233142976e9a093" \
+  "successful_cases=compat-with-direct-beta-and-identity" \
+  "failing_cases=compat-exact,compat-with-direct-beta,compat-with-direct-identity"
+
+minimal_delta_dir="$TMP_DIR/minimal-delta"
+write_lines "$minimal_delta_dir/summary.txt" \
+  "mode=case_matrix" \
+  "conclusion=beta_and_identity_candidate" \
+  "baseline_case=compat-exact" \
+  "baseline_reproduced=true" \
+  "minimal_success_case=compat-with-direct-beta-and-identity" \
+  "minimal_success_delta=beta_and_identity" \
+  "successful_lanes=direct" \
+  "blocked_lanes=-"
+
+payload_uniform_dir="$TMP_DIR/payload-uniform"
+write_lines "$payload_uniform_dir/summary.txt" \
+  "mode=payload_matrix" \
+  "classification=uniform_failure_provider_side_candidate" \
+  "payload_sensitive=false" \
+  "uniform_failure=true" \
+  "all_invalid_request=true"
+
+token_uniform_dir="$TMP_DIR/token-uniform"
+write_lines "$token_uniform_dir/summary.txt" \
+  "mode=direct_token_lane_matrix" \
+  "classification=uniform_failure_provider_side_candidate" \
+  "token_lane_sensitive=false" \
+  "uniform_failure=true" \
+  "all_invalid_request=true"
+
+provider_exact_dir="$TMP_DIR/provider-exact"
+write_lines "$provider_exact_dir/summary.txt" \
+  "mode=case_matrix" \
+  "classification=uniform_failure_provider_side_candidate" \
+  "header_sensitive=false" \
+  "token_lane_sensitive=false" \
+  "uniform_failure=true" \
+  "body_sha256=1717a039bed013d162eb47daead7f7eea440bccc6fb2719b9233142976e9a093"
+
+provider_payload_dir="$TMP_DIR/provider-payload"
+write_lines "$provider_payload_dir/summary.txt" \
+  "mode=payload_matrix" \
+  "classification=uniform_failure_provider_side_candidate" \
+  "payload_sensitive=false" \
+  "uniform_failure=true" \
+  "all_invalid_request=true"
+
+provider_token_dir="$TMP_DIR/provider-token"
+write_lines "$provider_token_dir/summary.txt" \
+  "mode=direct_token_lane_matrix" \
+  "classification=uniform_failure_provider_side_candidate" \
+  "token_lane_sensitive=false" \
+  "uniform_failure=true" \
+  "all_invalid_request=true"
+
+run_report() {
+  local output_dir="$1"
+  shift
+  local stdout_path="$1"
+  shift
+  local stderr_path="$1"
+  shift
+  INNIES_COMPAT_EVIDENCE_REPORT_OUT_DIR="$output_dir" \
+    "$SCRIPT_PATH" "$@" >"$stdout_path" 2>"$stderr_path"
+}
+
+run_report "$TMP_DIR/header-report" "$TMP_DIR/header.stdout" "$TMP_DIR/header.stderr" \
+  --exact-case-summary "$header_case_dir/summary.txt" \
+  --exact-case-minimal-delta "$minimal_delta_dir/summary.txt" \
+  --payload-summary "$payload_uniform_dir/summary.txt" \
+  --token-lane-summary "$token_uniform_dir/summary.txt"
+
+[[ -f "$TMP_DIR/header-report/summary.txt" ]]
+[[ -f "$TMP_DIR/header-report/summary.json" ]]
+[[ -f "$TMP_DIR/header-report/issue-comment.md" ]]
+grep -q '^mode=issue80_evidence_report$' "$TMP_DIR/header-report/summary.txt"
+grep -q '^evidence_axes=exact_case,minimal_delta,payload,token_lane$' "$TMP_DIR/header-report/summary.txt"
+grep -q '^overall_classification=header_delta_specific$' "$TMP_DIR/header-report/summary.txt"
+grep -q '^next_hypothesis=beta_and_identity_candidate$' "$TMP_DIR/header-report/summary.txt"
+grep -q '^exact_case_classification=header_case_specific$' "$TMP_DIR/header-report/summary.txt"
+grep -q '^minimal_delta_conclusion=beta_and_identity_candidate$' "$TMP_DIR/header-report/summary.txt"
+grep -q '^minimal_success_case=compat-with-direct-beta-and-identity$' "$TMP_DIR/header-report/summary.txt"
+grep -q '^summary_file=' "$TMP_DIR/header.stdout"
+grep -q '^issue_comment_file=' "$TMP_DIR/header.stdout"
+grep -q 'Recommended next hypothesis: `beta_and_identity_candidate`' "$TMP_DIR/header-report/issue-comment.md"
+grep -q 'Exact-case evidence points at a remaining header delta' "$TMP_DIR/header-report/issue-comment.md"
+
+run_report "$TMP_DIR/provider-report" "$TMP_DIR/provider.stdout" "$TMP_DIR/provider.stderr" \
+  --exact-case-summary "$provider_exact_dir/summary.txt" \
+  --payload-summary "$provider_payload_dir/summary.txt" \
+  --token-lane-summary "$provider_token_dir/summary.txt"
+
+[[ -f "$TMP_DIR/provider-report/summary.txt" ]]
+[[ -f "$TMP_DIR/provider-report/issue-comment.md" ]]
+grep -q '^overall_classification=provider_side_candidate$' "$TMP_DIR/provider-report/summary.txt"
+grep -q '^next_hypothesis=provider_side_candidate$' "$TMP_DIR/provider-report/summary.txt"
+grep -q '^provider_side_candidate=true$' "$TMP_DIR/provider-report/summary.txt"
+grep -q 'All available controlled axes stayed uniform' "$TMP_DIR/provider-report/issue-comment.md"
+
+set +e
+INNIES_COMPAT_EVIDENCE_REPORT_OUT_DIR="$TMP_DIR/invalid-report" \
+  "$SCRIPT_PATH" >"$TMP_DIR/invalid.stdout" 2>"$TMP_DIR/invalid.stderr"
+STATUS=$?
+set -e
+
+if [[ "$STATUS" -eq 0 ]]; then
+  echo 'expected evidence report helper without inputs to fail' >&2
+  exit 1
+fi
+
+grep -q 'at least one evidence input path is required' "$TMP_DIR/invalid.stderr"


### PR DESCRIPTION
## Summary
- add `scripts/innies-compat-evidence-report.{sh,mjs}` to combine issue-80 exact-case, minimal-delta, payload, and token-lane summary artifacts into one report
- emit `summary.txt`, `summary.json`, and `issue-comment.md` with one recommended next hypothesis plus per-axis rollups
- wire the helper into `scripts/install.sh` and `scripts/README.md`, and add focused shell coverage in `scripts/tests/innies-compat-evidence-report.test.sh`

## Test Plan
- `bash scripts/tests/innies-compat-evidence-report.test.sh`
- `bash -n scripts/innies-compat-evidence-report.sh scripts/tests/innies-compat-evidence-report.test.sh scripts/install.sh scripts/_common.sh`
- `node --check scripts/innies-compat-evidence-report.mjs`
- `TMP_HOME="$(mktemp -d)" && HOME="$TMP_HOME" bash scripts/install.sh >/tmp/issue80-evidence-report-install.out && test -L "$TMP_HOME/.local/bin/innies-compat-evidence-report"`
- `git diff --check`

## Notes
- this stays in the issue-80 support-tooling lane and does not touch the runtime proxy path
- the helper accepts either summary files or their parent output directories for each evidence axis

Refs #80