### PR TITLE
chore: add issue 80 evidence report helper

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -25,6 +25,7 @@ innies-buyer-preference-set
 innies-buyer-preference-get
 innies-buyer-preference-check
 innies-slo-check
+innies-compat-evidence-report
 ```
 
 What they do:
@@ -40,6 +41,7 @@ What they do:
 - `innies-buyer-preference-get`: read the current buyer key preference
 - `innies-buyer-preference-check`: run the provider-preference canary after prompting for the expected provider (`Claude Code` or `Codex`)
 - `innies-slo-check`: query analytics endpoints and report Phase 1 SLO pass/fail (TTFB p95, timeout rate, success rate, fallback rate); optional arg sets the window (default `24h`); exits 0 if all SLOs pass, 1 if any fail
+- `innies-compat-evidence-report`: ingest issue-80 wire-diff plus payload/token/header summary artifacts and emit one consolidated classification with the next evidence step
 
 Behavior:
 - org id auto-uses `INNIES_ORG_ID`

--- a/scripts/innies-compat-evidence-report.mjs
+++ b/scripts/innies-compat-evidence-report.mjs
@@ -1,0 +1,317 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const args = process.argv.slice(2);
+
+if (args.length < 2) {
+  console.error('error: usage: innies-compat-evidence-report.mjs <out-dir> <input-path> [<input-path> ...]');
+  process.exit(1);
+}
+
+const [outDirArg, ...inputPathArgs] = args;
+const outDir = path.resolve(outDirArg);
+const inputPaths = inputPathArgs.map((value) => path.resolve(value));
+
+const ARTIFACT_TYPES = [
+  'direct_payload_summary',
+  'direct_token_lane_summary',
+  'exact_case_summary',
+  'first_pass_bundle_diff'
+];
+
+function readKeyValueFile(filePath) {
+  const result = {};
+  const text = fs.readFileSync(filePath, 'utf8');
+  for (const line of text.split(/\r?\n/)) {
+    if (!line || !line.includes('=')) continue;
+    const index = line.indexOf('=');
+    const key = line.slice(0, index).trim();
+    const value = line.slice(index + 1).trim();
+    if (!key) continue;
+    result[key] = value;
+  }
+  return result;
+}
+
+function parseBoolean(value) {
+  return value === 'true';
+}
+
+function normalizeList(value) {
+  if (!value || value === '-') return [];
+  return value.split(',').map((item) => item.trim()).filter(Boolean);
+}
+
+function joinList(values) {
+  return values.length > 0 ? values.join(',') : '-';
+}
+
+function walkSummaryFiles(rootPath) {
+  const pending = [rootPath];
+  const files = [];
+
+  while (pending.length > 0) {
+    const currentPath = pending.pop();
+    const stat = fs.statSync(currentPath);
+
+    if (stat.isFile()) {
+      files.push(currentPath);
+      continue;
+    }
+
+    for (const entry of fs.readdirSync(currentPath, { withFileTypes: true })) {
+      const childPath = path.join(currentPath, entry.name);
+      if (entry.isDirectory()) {
+        pending.push(childPath);
+      } else if (entry.isFile() && entry.name === 'summary.txt') {
+        files.push(childPath);
+      }
+    }
+  }
+
+  return files.sort();
+}
+
+function inferArtifactType(summary) {
+  if (summary.left_label && summary.right_label) {
+    return 'first_pass_bundle_diff';
+  }
+
+  switch (summary.mode) {
+    case 'case_matrix':
+    case 'case_lane_matrix':
+      return 'exact_case_summary';
+    case 'payload_matrix':
+      return 'direct_payload_summary';
+    case 'direct_token_lane_matrix':
+      return 'direct_token_lane_summary';
+    default:
+      return null;
+  }
+}
+
+function ensureSingleArtifact(artifacts, type, filePath, summary) {
+  if (artifacts[type]) {
+    console.error(`error: multiple ${type} artifacts found: ${artifacts[type].path} and ${filePath}`);
+    process.exit(1);
+  }
+
+  artifacts[type] = { type, path: filePath, summary };
+}
+
+function buildArtifactIndex(paths) {
+  const candidateFiles = [];
+
+  for (const inputPath of paths) {
+    if (!fs.existsSync(inputPath)) {
+      console.error(`error: evidence report input path not found: ${inputPath}`);
+      process.exit(1);
+    }
+
+    const stat = fs.statSync(inputPath);
+    if (stat.isDirectory()) {
+      candidateFiles.push(...walkSummaryFiles(inputPath));
+    } else {
+      candidateFiles.push(inputPath);
+    }
+  }
+
+  const uniqueCandidates = [...new Set(candidateFiles)];
+  const artifacts = {};
+
+  for (const filePath of uniqueCandidates) {
+    const summary = readKeyValueFile(filePath);
+    const type = inferArtifactType(summary);
+    if (!type) continue;
+    ensureSingleArtifact(artifacts, type, filePath, summary);
+  }
+
+  return artifacts;
+}
+
+function buildBundleDiffArtifact(artifact) {
+  if (!artifact) return null;
+  return {
+    ...artifact,
+    payloadCanonicalEqual: parseBoolean(artifact.summary.payload_canonical_equal),
+    headerValueMismatches: normalizeList(artifact.summary.header_value_mismatches),
+    headerOnlyInLeft: normalizeList(artifact.summary.header_only_in_left),
+    headerOnlyInRight: normalizeList(artifact.summary.header_only_in_right),
+    leftLabel: artifact.summary.left_label || '',
+    rightLabel: artifact.summary.right_label || '',
+    bodySha256Left: artifact.summary.body_sha256_left || '',
+    bodySha256Right: artifact.summary.body_sha256_right || ''
+  };
+}
+
+function buildExactCaseArtifact(artifact) {
+  if (!artifact) return null;
+  return {
+    ...artifact,
+    mode: artifact.summary.mode || '',
+    classification: artifact.summary.classification || 'unknown',
+    headerSensitive: parseBoolean(artifact.summary.header_sensitive),
+    tokenLaneSensitive: parseBoolean(artifact.summary.token_lane_sensitive),
+    uniformFailure: parseBoolean(artifact.summary.uniform_failure),
+    allInvalidRequest: parseBoolean(artifact.summary.all_invalid_request),
+    successfulCases: normalizeList(artifact.summary.successful_cases),
+    failingCases: normalizeList(artifact.summary.failing_cases),
+    successfulLanes: normalizeList(artifact.summary.successful_lanes),
+    failingLanes: normalizeList(artifact.summary.failing_lanes),
+    allSuccess: parseBoolean(artifact.summary.all_success)
+  };
+}
+
+function buildPayloadArtifact(artifact) {
+  if (!artifact) return null;
+  return {
+    ...artifact,
+    mode: artifact.summary.mode || '',
+    classification: artifact.summary.classification || 'unknown',
+    payloadSensitive: parseBoolean(artifact.summary.payload_sensitive),
+    uniformFailure: parseBoolean(artifact.summary.uniform_failure),
+    allInvalidRequest: parseBoolean(artifact.summary.all_invalid_request),
+    allSuccess: parseBoolean(artifact.summary.all_success),
+    successfulPayloads: normalizeList(artifact.summary.successful_payloads),
+    failingPayloads: normalizeList(artifact.summary.failing_payloads)
+  };
+}
+
+function buildTokenLaneArtifact(artifact) {
+  if (!artifact) return null;
+  return {
+    ...artifact,
+    mode: artifact.summary.mode || '',
+    classification: artifact.summary.classification || 'unknown',
+    tokenLaneSensitive: parseBoolean(artifact.summary.token_lane_sensitive),
+    uniformFailure: parseBoolean(artifact.summary.uniform_failure),
+    allInvalidRequest: parseBoolean(artifact.summary.all_invalid_request),
+    allSuccess: parseBoolean(artifact.summary.all_success),
+    successfulLanes: normalizeList(artifact.summary.successful_lanes),
+    failingLanes: normalizeList(artifact.summary.failing_lanes)
+  };
+}
+
+function buildSummaryLine(artifact) {
+  switch (artifact.type) {
+    case 'first_pass_bundle_diff':
+      return `artifact=${artifact.type} path=${artifact.path} payload_canonical_equal=${String(artifact.payloadCanonicalEqual)} header_value_mismatches=${joinList(artifact.headerValueMismatches)} header_only_in_right=${joinList(artifact.headerOnlyInRight)}`;
+    case 'exact_case_summary':
+      return `artifact=${artifact.type} path=${artifact.path} classification=${artifact.classification} header_sensitive=${String(artifact.headerSensitive)} token_lane_sensitive=${String(artifact.tokenLaneSensitive)} uniform_failure=${String(artifact.uniformFailure)}`;
+    case 'direct_payload_summary':
+      return `artifact=${artifact.type} path=${artifact.path} classification=${artifact.classification} payload_sensitive=${String(artifact.payloadSensitive)} uniform_failure=${String(artifact.uniformFailure)} successful_payloads=${joinList(artifact.successfulPayloads)} failing_payloads=${joinList(artifact.failingPayloads)}`;
+    case 'direct_token_lane_summary':
+      return `artifact=${artifact.type} path=${artifact.path} classification=${artifact.classification} token_lane_sensitive=${String(artifact.tokenLaneSensitive)} uniform_failure=${String(artifact.uniformFailure)} successful_lanes=${joinList(artifact.successfulLanes)} failing_lanes=${joinList(artifact.failingLanes)}`;
+    default:
+      return `artifact=${artifact.type} path=${artifact.path}`;
+  }
+}
+
+const discoveredArtifacts = buildArtifactIndex(inputPaths);
+
+if (Object.keys(discoveredArtifacts).length === 0) {
+  console.error('error: no recognized issue-80 summary artifacts found');
+  process.exit(1);
+}
+
+const bundleDiff = buildBundleDiffArtifact(discoveredArtifacts.first_pass_bundle_diff);
+const exactCase = buildExactCaseArtifact(discoveredArtifacts.exact_case_summary);
+const payloadSummary = buildPayloadArtifact(discoveredArtifacts.direct_payload_summary);
+const tokenLaneSummary = buildTokenLaneArtifact(discoveredArtifacts.direct_token_lane_summary);
+
+const availableArtifactTypes = ARTIFACT_TYPES.filter((type) => discoveredArtifacts[type]);
+const missingArtifactTypes = ARTIFACT_TYPES.filter((type) => !discoveredArtifacts[type]);
+const incompleteEvidence = missingArtifactTypes.length > 0;
+
+const headerSensitive = exactCase?.headerSensitive === true;
+const payloadSensitive = payloadSummary?.payloadSensitive === true;
+const credentialLaneSensitive = (tokenLaneSummary?.tokenLaneSensitive === true) || (exactCase?.tokenLaneSensitive === true);
+const specificSignalCount = [headerSensitive, payloadSensitive, credentialLaneSensitive].filter(Boolean).length;
+const uniformInputs = [exactCase, payloadSummary, tokenLaneSummary].filter(Boolean);
+const allUniformFailure = uniformInputs.length === 3 && uniformInputs.every((artifact) => artifact.uniformFailure === true);
+const allSuccess = uniformInputs.length > 0 && uniformInputs.every((artifact) => artifact.allSuccess === true);
+const bundleSupportsProviderSide = !bundleDiff || bundleDiff.payloadCanonicalEqual === true;
+
+let overallClassification = 'inconclusive_partial_evidence';
+let recommendedNextStep = 'fill_missing_axes';
+
+if (headerSensitive && credentialLaneSensitive && !payloadSensitive) {
+  overallClassification = 'mixed_header_and_lane_specific';
+  recommendedNextStep = 'split_header_vs_lane_minimal_delta';
+} else if (specificSignalCount >= 2) {
+  overallClassification = 'mixed_axis_specific';
+  recommendedNextStep = 'split_axes_before_runtime_change';
+} else if (headerSensitive) {
+  overallClassification = 'header_case_specific';
+  recommendedNextStep = 'focus_on_header_case_delta';
+} else if (payloadSensitive) {
+  overallClassification = 'transcript_shape_specific';
+  recommendedNextStep = 'focus_on_payload_shape_delta';
+} else if (credentialLaneSensitive) {
+  overallClassification = 'credential_lane_specific';
+  recommendedNextStep = 'focus_on_credential_lane_delta';
+} else if (allUniformFailure && bundleSupportsProviderSide) {
+  overallClassification = 'uniform_failure_provider_side_candidate';
+  recommendedNextStep = 'prepare_provider_escalation_bundle';
+} else if (allSuccess) {
+  overallClassification = 'all_success';
+  recommendedNextStep = 'capture_fresh_failing_bundle_before_comparing';
+}
+
+const providerSideCandidate = overallClassification === 'uniform_failure_provider_side_candidate';
+
+const output = {
+  inputPaths,
+  outputDir: outDir,
+  overallClassification,
+  recommendedNextStep,
+  providerSideCandidate,
+  incompleteEvidence,
+  availableArtifactTypes,
+  missingArtifactTypes,
+  flags: {
+    headerSensitive,
+    payloadSensitive,
+    credentialLaneSensitive
+  },
+  artifacts: {
+    firstPassBundleDiff: bundleDiff,
+    exactCaseSummary: exactCase,
+    directPayloadSummary: payloadSummary,
+    directTokenLaneSummary: tokenLaneSummary
+  }
+};
+
+fs.mkdirSync(outDir, { recursive: true });
+
+const summaryLines = [];
+summaryLines.push(`overall_classification=${overallClassification}`);
+summaryLines.push(`recommended_next_step=${recommendedNextStep}`);
+summaryLines.push(`provider_side_candidate=${String(providerSideCandidate)}`);
+summaryLines.push(`incomplete_evidence=${String(incompleteEvidence)}`);
+summaryLines.push(`available_artifact_types=${joinList(availableArtifactTypes)}`);
+summaryLines.push(`missing_artifact_types=${joinList(missingArtifactTypes)}`);
+summaryLines.push(`header_sensitive=${String(headerSensitive)}`);
+summaryLines.push(`payload_sensitive=${String(payloadSensitive)}`);
+summaryLines.push(`credential_lane_sensitive=${String(credentialLaneSensitive)}`);
+
+if (bundleDiff) {
+  summaryLines.push(`bundle_diff_payload_canonical_equal=${String(bundleDiff.payloadCanonicalEqual)}`);
+  summaryLines.push(`bundle_diff_header_value_mismatches=${joinList(bundleDiff.headerValueMismatches)}`);
+  summaryLines.push(`bundle_diff_header_only_in_left=${joinList(bundleDiff.headerOnlyInLeft)}`);
+  summaryLines.push(`bundle_diff_header_only_in_right=${joinList(bundleDiff.headerOnlyInRight)}`);
+}
+
+for (const type of ARTIFACT_TYPES) {
+  if (!discoveredArtifacts[type]) continue;
+  const artifact =
+    type === 'first_pass_bundle_diff' ? bundleDiff
+      : type === 'exact_case_summary' ? exactCase
+        : type === 'direct_payload_summary' ? payloadSummary
+          : tokenLaneSummary;
+  summaryLines.push(buildSummaryLine(artifact));
+}
+
+fs.writeFileSync(path.join(outDir, 'summary.json'), `${JSON.stringify(output, null, 2)}\n`);
+fs.writeFileSync(path.join(outDir, 'summary.txt'), `${summaryLines.join('\n')}\n`);

--- a/scripts/innies-compat-evidence-report.sh
+++ b/scripts/innies-compat-evidence-report.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_PATH" ]]; do
+  SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+  SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"
+  [[ "$SCRIPT_PATH" != /* ]] && SCRIPT_PATH="${SCRIPT_DIR}/${SCRIPT_PATH}"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+source "${SCRIPT_DIR}/_common.sh"
+
+if [[ "$#" -eq 0 ]]; then
+  echo 'error: provide at least one issue-80 summary file or artifact root' >&2
+  exit 1
+fi
+
+FIRST_INPUT="$1"
+if [[ ! -e "$FIRST_INPUT" ]]; then
+  echo "error: evidence report input path not found: $FIRST_INPUT" >&2
+  exit 1
+fi
+
+if [[ -f "$FIRST_INPUT" ]]; then
+  BASE_DIR="$(cd "$(dirname "$FIRST_INPUT")" && pwd)"
+else
+  BASE_DIR="$(cd "$FIRST_INPUT" && pwd)"
+fi
+
+OUT_DIR="${INNIES_COMPAT_EVIDENCE_REPORT_OUT_DIR:-${BASE_DIR%/}/analysis}"
+mkdir -p "$OUT_DIR"
+
+if ! command -v node >/dev/null 2>&1; then
+  echo 'error: node is required for innies-compat-evidence-report.sh' >&2
+  exit 1
+fi
+
+node "${SCRIPT_DIR}/innies-compat-evidence-report.mjs" "$OUT_DIR" "$@"
+
+SUMMARY_FILE="$OUT_DIR/summary.txt"
+cat "$SUMMARY_FILE"
+printf 'summary_file=%s\n' "$SUMMARY_FILE"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,6 +18,7 @@ ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-set.sh" "${BIN_DIR}/innies-b
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-get.sh" "${BIN_DIR}/innies-buyer-preference-get"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-check.sh" "${BIN_DIR}/innies-buyer-preference-check"
 ln -sf "${ROOT_DIR}/scripts/innies-slo-check.sh" "${BIN_DIR}/innies-slo-check"
+ln -sf "${ROOT_DIR}/scripts/innies-compat-evidence-report.sh" "${BIN_DIR}/innies-compat-evidence-report"
 
 rm -f \
   "${BIN_DIR}/innies-admin" \
@@ -49,6 +50,7 @@ echo "  ${BIN_DIR}/innies-buyer-preference-set -> ${ROOT_DIR}/scripts/innies-buy
 echo "  ${BIN_DIR}/innies-buyer-preference-get -> ${ROOT_DIR}/scripts/innies-buyer-preference-get.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-check -> ${ROOT_DIR}/scripts/innies-buyer-preference-check.sh"
 echo "  ${BIN_DIR}/innies-slo-check -> ${ROOT_DIR}/scripts/innies-slo-check.sh"
+echo "  ${BIN_DIR}/innies-compat-evidence-report -> ${ROOT_DIR}/scripts/innies-compat-evidence-report.sh"
 echo
 echo 'If command not found, add ~/.local/bin to PATH:'
 echo '  export PATH="$HOME/.local/bin:$PATH"'

--- a/scripts/tests/innies-compat-evidence-report.test.sh
+++ b/scripts/tests/innies-compat-evidence-report.test.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_PATH="$ROOT_DIR/scripts/innies-compat-evidence-report.sh"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+write_lines() {
+  local file="$1"
+  shift
+  mkdir -p "$(dirname "$file")"
+  printf '%s\n' "$@" >"$file"
+}
+
+run_report() {
+  local output_dir="$1"
+  local stdout_path="$2"
+  local stderr_path="$3"
+  shift 3
+  INNIES_COMPAT_EVIDENCE_REPORT_OUT_DIR="$output_dir" "$SCRIPT_PATH" "$@" >"$stdout_path" 2>"$stderr_path"
+}
+
+provider_side_root="$TMP_DIR/provider-side-root"
+write_lines "$provider_side_root/first-pass-bundle-diff/summary.txt" \
+  "left_label=issue80-bundle#upstream" \
+  "right_label=direct-bundle#upstream" \
+  "payload_canonical_equal=true" \
+  "header_value_mismatches=anthropic-beta" \
+  "header_only_in_right=accept,authorization,content-type,user-agent,x-app,x-request-id" \
+  "body_sha256_left=sha-preserved" \
+  "body_sha256_right=sha-direct"
+write_lines "$provider_side_root/exact-case/summary.txt" \
+  "mode=case_lane_matrix" \
+  "classification=uniform_failure_provider_side_candidate" \
+  "header_sensitive=false" \
+  "token_lane_sensitive=false" \
+  "uniform_failure=true" \
+  "all_invalid_request=true"
+write_lines "$provider_side_root/direct-payload/summary.txt" \
+  "mode=payload_matrix" \
+  "classification=uniform_failure_provider_side_candidate" \
+  "payload_sensitive=false" \
+  "uniform_failure=true" \
+  "all_invalid_request=true"
+write_lines "$provider_side_root/direct-token-lane/summary.txt" \
+  "mode=direct_token_lane_matrix" \
+  "classification=uniform_failure_provider_side_candidate" \
+  "token_lane_sensitive=false" \
+  "uniform_failure=true" \
+  "all_invalid_request=true"
+
+run_report \
+  "$TMP_DIR/provider-side-report" \
+  "$TMP_DIR/provider-side.stdout" \
+  "$TMP_DIR/provider-side.stderr" \
+  "$provider_side_root"
+
+[[ -f "$TMP_DIR/provider-side-report/summary.txt" ]]
+[[ -f "$TMP_DIR/provider-side-report/summary.json" ]]
+grep -q '^overall_classification=uniform_failure_provider_side_candidate$' "$TMP_DIR/provider-side-report/summary.txt"
+grep -q '^recommended_next_step=prepare_provider_escalation_bundle$' "$TMP_DIR/provider-side-report/summary.txt"
+grep -q '^provider_side_candidate=true$' "$TMP_DIR/provider-side-report/summary.txt"
+grep -q '^incomplete_evidence=false$' "$TMP_DIR/provider-side-report/summary.txt"
+grep -q '^available_artifact_types=direct_payload_summary,direct_token_lane_summary,exact_case_summary,first_pass_bundle_diff$' "$TMP_DIR/provider-side-report/summary.txt"
+grep -q '^missing_artifact_types=-$' "$TMP_DIR/provider-side-report/summary.txt"
+grep -q '^bundle_diff_payload_canonical_equal=true$' "$TMP_DIR/provider-side-report/summary.txt"
+grep -q '^bundle_diff_header_value_mismatches=anthropic-beta$' "$TMP_DIR/provider-side-report/summary.txt"
+grep -q '^summary_file=' "$TMP_DIR/provider-side.stdout"
+
+mixed_root="$TMP_DIR/mixed-root"
+write_lines "$mixed_root/diff-summary.txt" \
+  "left_label=issue80-bundle#upstream" \
+  "right_label=direct-bundle#upstream" \
+  "payload_canonical_equal=true" \
+  "header_value_mismatches=anthropic-beta,user-agent" \
+  "header_only_in_right=accept,authorization,content-type,x-app,x-request-id"
+write_lines "$mixed_root/exact-summary.txt" \
+  "mode=case_matrix" \
+  "classification=header_case_specific" \
+  "header_sensitive=true" \
+  "token_lane_sensitive=false" \
+  "uniform_failure=false"
+write_lines "$mixed_root/payload-summary.txt" \
+  "mode=payload_matrix" \
+  "classification=transcript_shape_specific" \
+  "payload_sensitive=true" \
+  "uniform_failure=false"
+write_lines "$mixed_root/token-summary.txt" \
+  "mode=direct_token_lane_matrix" \
+  "classification=credential_lane_specific" \
+  "token_lane_sensitive=true" \
+  "uniform_failure=false"
+
+run_report \
+  "$TMP_DIR/mixed-report" \
+  "$TMP_DIR/mixed.stdout" \
+  "$TMP_DIR/mixed.stderr" \
+  "$mixed_root/diff-summary.txt" \
+  "$mixed_root/exact-summary.txt" \
+  "$mixed_root/payload-summary.txt" \
+  "$mixed_root/token-summary.txt"
+
+grep -q '^overall_classification=mixed_axis_specific$' "$TMP_DIR/mixed-report/summary.txt"
+grep -q '^recommended_next_step=split_axes_before_runtime_change$' "$TMP_DIR/mixed-report/summary.txt"
+grep -q '^header_sensitive=true$' "$TMP_DIR/mixed-report/summary.txt"
+grep -q '^payload_sensitive=true$' "$TMP_DIR/mixed-report/summary.txt"
+grep -q '^credential_lane_sensitive=true$' "$TMP_DIR/mixed-report/summary.txt"
+grep -q '^provider_side_candidate=false$' "$TMP_DIR/mixed-report/summary.txt"
+grep -q '^incomplete_evidence=false$' "$TMP_DIR/mixed-report/summary.txt"
+
+partial_root="$TMP_DIR/partial-root"
+write_lines "$partial_root/summary.txt" \
+  "left_label=issue80-bundle#upstream" \
+  "right_label=direct-bundle#upstream" \
+  "payload_canonical_equal=true" \
+  "header_value_mismatches=anthropic-beta" \
+  "header_only_in_right=accept,authorization,content-type,user-agent,x-app,x-request-id"
+write_lines "$partial_root/exact-case-summary.txt" \
+  "mode=case_matrix" \
+  "classification=header_case_specific" \
+  "header_sensitive=true" \
+  "token_lane_sensitive=false" \
+  "uniform_failure=false"
+
+run_report \
+  "$TMP_DIR/partial-report" \
+  "$TMP_DIR/partial.stdout" \
+  "$TMP_DIR/partial.stderr" \
+  "$partial_root/summary.txt" \
+  "$partial_root/exact-case-summary.txt"
+
+grep -q '^overall_classification=header_case_specific$' "$TMP_DIR/partial-report/summary.txt"
+grep -q '^recommended_next_step=focus_on_header_case_delta$' "$TMP_DIR/partial-report/summary.txt"
+grep -q '^incomplete_evidence=true$' "$TMP_DIR/partial-report/summary.txt"
+grep -q '^missing_artifact_types=direct_payload_summary,direct_token_lane_summary$' "$TMP_DIR/partial-report/summary.txt"
+
+node - "$TMP_DIR/provider-side-report/summary.json" "$TMP_DIR/mixed-report/summary.json" "$TMP_DIR/partial-report/summary.json" <<'NODE'
+const fs = require('fs');
+
+const [providerSidePath, mixedPath, partialPath] = process.argv.slice(2);
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+const providerSide = readJson(providerSidePath);
+const mixed = readJson(mixedPath);
+const partial = readJson(partialPath);
+
+if (providerSide.overallClassification !== 'uniform_failure_provider_side_candidate') {
+  throw new Error('provider-side overall classification mismatch');
+}
+if (providerSide.providerSideCandidate !== true) {
+  throw new Error('provider-side candidate flag mismatch');
+}
+if (mixed.overallClassification !== 'mixed_axis_specific') {
+  throw new Error('mixed overall classification mismatch');
+}
+if (mixed.flags.headerSensitive !== true || mixed.flags.payloadSensitive !== true || mixed.flags.credentialLaneSensitive !== true) {
+  throw new Error('mixed flags mismatch');
+}
+if (partial.overallClassification !== 'header_case_specific') {
+  throw new Error('partial overall classification mismatch');
+}
+if (partial.incompleteEvidence !== true) {
+  throw new Error('partial incomplete evidence flag mismatch');
+}
+if (!partial.missingArtifactTypes.includes('direct_payload_summary')) {
+  throw new Error('missing payload summary artifact not recorded');
+}
+NODE


### PR DESCRIPTION
Refs #80

## Summary
- add `scripts/innies-compat-evidence-report.{sh,mjs}` to ingest issue-80 bundle-diff, exact-case, payload, and token-lane summaries and emit one consolidated classification plus the next evidence step
- support both artifact-root discovery and explicit summary-file inputs, including partial evidence, mixed-axis evidence, and uniform-failure/provider-side candidate rollups
- wire the helper into `scripts/install.sh` / `scripts/README.md` and add focused shell coverage for provider-side, mixed-axis, and partial-evidence cases

## Why
The current issue-80 helper swarm can produce several narrow evidence slices, but it still lacks one operator-facing synthesis layer that turns those artifacts into a single handoff-ready conclusion. This keeps the runtime proxy path untouched while making it easier to record whether the next hypothesis points at header deltas, payload shape, credential lanes, mixed axes, or a provider-side candidate.

## Verification
- `bash scripts/tests/innies-compat-evidence-report.test.sh`
- `node --check scripts/innies-compat-evidence-report.mjs`
- `bash -n scripts/innies-compat-evidence-report.sh scripts/tests/innies-compat-evidence-report.test.sh scripts/install.sh`
- `TMP_HOME="$(mktemp -d)" && HOME="$TMP_HOME" bash scripts/install.sh >/tmp/issue80-evidence-report-install.out && test -L "$TMP_HOME/.local/bin/innies-compat-evidence-report"`
- `git diff --check`