### PR TITLE
chore: add issue 80 artifact candidate helper

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -24,6 +24,7 @@ innies-buyer-key-create
 innies-buyer-preference-set
 innies-buyer-preference-get
 innies-buyer-preference-check
+innies-compat-artifact-candidates
 innies-slo-check
 ```
 
@@ -39,6 +40,7 @@ What they do:
 - `innies-buyer-preference-set`: set a buyer key preference to `Claude Code`, `Codex`, or `null`
 - `innies-buyer-preference-get`: read the current buyer key preference
 - `innies-buyer-preference-check`: run the provider-preference canary after prompting for the expected provider (`Claude Code` or `Codex`)
+- `innies-compat-artifact-candidates`: turn multiple issue-80 artifact summaries into exact-body and shape-match comparator shortlists, preferring an exact-body diff target when one exists
 - `innies-slo-check`: query analytics endpoints and report Phase 1 SLO pass/fail (TTFB p95, timeout rate, success rate, fallback rate); optional arg sets the window (default `24h`); exits 0 if all SLOs pass, 1 if any fail
 
 Behavior:
@@ -79,6 +81,7 @@ Behavior:
 - non-pinned buyer traffic always gets automatic cross-provider fallback to the other provider; flipping preference flips fallback order too
 - `innies-buyer-preference-set` prints the effective preferred provider plus the automatic fallback provider before sending the update
 - `innies-buyer-preference-check` now expects and validates the two-provider plan in DB evidence mode
+- `innies-compat-artifact-candidates` scans one or more directories recursively for `summary.json`, writes `summary.txt` plus `summary.json`, and recommends the best exact-body pair before any looser shape-only pair
 
 ## Env
 

--- a/scripts/innies-compat-artifact-candidates.mjs
+++ b/scripts/innies-compat-artifact-candidates.mjs
@@ -1,0 +1,359 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+function fail(message) {
+  console.error(`error: ${message}`);
+  process.exit(1);
+}
+
+function toNullableString(value) {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  const stringValue = String(value).trim();
+  return stringValue.length > 0 ? stringValue : null;
+}
+
+function toNullableNumber(value) {
+  if (value === undefined || value === null || value === '') {
+    return null;
+  }
+  const numberValue = Number(value);
+  return Number.isFinite(numberValue) ? numberValue : null;
+}
+
+function toNullableBoolean(value) {
+  if (value === undefined || value === null || value === '') {
+    return null;
+  }
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'number') {
+    return value !== 0;
+  }
+  const normalized = String(value).trim().toLowerCase();
+  if (normalized === 'true') {
+    return true;
+  }
+  if (normalized === 'false') {
+    return false;
+  }
+  return null;
+}
+
+function get(raw, ...keys) {
+  for (const key of keys) {
+    if (raw[key] !== undefined) {
+      return raw[key];
+    }
+  }
+  return undefined;
+}
+
+function normalizeEntry(filePath) {
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (error) {
+    fail(`failed to parse JSON from ${filePath}: ${error.message}`);
+  }
+
+  const requestShape = parsed.request_shape ?? parsed.requestShape ?? {};
+  const requestId = toNullableString(get(parsed, 'request_id', 'requestId'));
+  const providerRequestId = toNullableString(get(parsed, 'provider_request_id', 'providerRequestId'));
+  const upstreamStatus = toNullableNumber(get(parsed, 'upstream_status', 'upstreamStatus', 'status'));
+  const bodySha256 = toNullableString(get(parsed, 'body_sha256', 'bodySha256'));
+  const bodyBytes = toNullableNumber(get(parsed, 'body_bytes', 'bodyBytes'));
+  const provider = toNullableString(get(parsed, 'provider', 'original_provider', 'originalProvider'));
+  const model = toNullableString(get(parsed, 'model', 'original_model', 'originalModel'));
+  const classification = toNullableString(get(parsed, 'classification', 'candidate_classification', 'candidateClassification'));
+  const stream =
+    toNullableBoolean(get(parsed, 'stream', 'is_streaming', 'isStreaming', 'streaming', 'request_stream', 'requestStream')) ??
+    toNullableBoolean(requestShape.stream);
+  const messageCount = toNullableNumber(get(parsed, 'message_count', 'messageCount'));
+  const toolCount = toNullableNumber(get(parsed, 'tool_count', 'toolCount'));
+  const toolResultBlockCount = toNullableNumber(get(parsed, 'tool_result_block_count', 'toolResultBlockCount'));
+  const thinkingPresent = toNullableBoolean(get(parsed, 'thinking_present', 'thinkingPresent'));
+  const artifactPath = toNullableString(get(parsed, 'artifact_path', 'artifactPath'));
+
+  return {
+    artifactPath,
+    bodyBytes: bodyBytes ?? toNullableNumber(requestShape.body_bytes ?? requestShape.bodyBytes),
+    bodySha256,
+    classification,
+    filePath: path.resolve(filePath),
+    messageCount: messageCount ?? toNullableNumber(requestShape.message_count ?? requestShape.messageCount),
+    model,
+    provider,
+    providerRequestId,
+    requestId: requestId ?? path.basename(path.dirname(filePath)),
+    stream: stream ?? toNullableBoolean(requestShape.stream),
+    thinkingPresent: thinkingPresent ?? toNullableBoolean(requestShape.thinking_present ?? requestShape.thinkingPresent),
+    toolCount: toolCount ?? toNullableNumber(requestShape.tool_count ?? requestShape.toolCount),
+    toolResultBlockCount:
+      toolResultBlockCount ?? toNullableNumber(requestShape.tool_result_block_count ?? requestShape.toolResultBlockCount),
+    upstreamStatus
+  };
+}
+
+function isSuccess(entry) {
+  if (entry.upstreamStatus !== null && entry.upstreamStatus >= 200 && entry.upstreamStatus < 300) {
+    return true;
+  }
+  return entry.classification === 'known_good_candidate';
+}
+
+function isFailure(entry) {
+  if (entry.upstreamStatus !== null && entry.upstreamStatus >= 400) {
+    return true;
+  }
+  return entry.classification === 'invalid_request_candidate';
+}
+
+function entryScore(entry, desiredKind) {
+  let score = 0;
+  if (desiredKind === 'success') {
+    if (entry.upstreamStatus === 200) {
+      score += 10;
+    } else if (entry.upstreamStatus !== null && entry.upstreamStatus >= 200 && entry.upstreamStatus < 300) {
+      score += 5;
+    }
+    if (entry.classification === 'known_good_candidate') {
+      score += 6;
+    }
+  } else {
+    if (entry.upstreamStatus === 400) {
+      score += 10;
+    } else if (entry.upstreamStatus !== null && entry.upstreamStatus >= 400) {
+      score += 5;
+    }
+    if (entry.classification === 'invalid_request_candidate') {
+      score += 6;
+    }
+  }
+  if (entry.provider === 'anthropic') {
+    score += 2;
+  }
+  if (entry.bodySha256) {
+    score += 1;
+  }
+  return score;
+}
+
+function sortEntries(entries, desiredKind) {
+  return [...entries].sort((left, right) => {
+    const scoreDiff = entryScore(right, desiredKind) - entryScore(left, desiredKind);
+    if (scoreDiff !== 0) {
+      return scoreDiff;
+    }
+    return left.requestId.localeCompare(right.requestId);
+  });
+}
+
+function serializeEntry(entry) {
+  return {
+    artifactPath: entry.artifactPath,
+    bodyBytes: entry.bodyBytes,
+    bodySha256: entry.bodySha256,
+    classification: entry.classification,
+    filePath: entry.filePath,
+    model: entry.model,
+    provider: entry.provider,
+    providerRequestId: entry.providerRequestId,
+    requestId: entry.requestId,
+    stream: entry.stream,
+    thinkingPresent: entry.thinkingPresent,
+    toolCount: entry.toolCount,
+    toolResultBlockCount: entry.toolResultBlockCount,
+    upstreamStatus: entry.upstreamStatus
+  };
+}
+
+function groupBy(items, keyFn) {
+  const groups = new Map();
+  for (const item of items) {
+    const key = keyFn(item);
+    if (!key) {
+      continue;
+    }
+    const existing = groups.get(key);
+    if (existing) {
+      existing.push(item);
+      continue;
+    }
+    groups.set(key, [item]);
+  }
+  return groups;
+}
+
+function buildExactBodyCandidates(entries) {
+  const exactGroups = groupBy(entries.filter((entry) => entry.bodySha256), (entry) => entry.bodySha256);
+  const usedIds = new Set();
+  const candidates = [];
+
+  for (const [bodySha256, groupEntries] of exactGroups.entries()) {
+    const failures = sortEntries(groupEntries.filter(isFailure), 'failure');
+    const successes = sortEntries(groupEntries.filter(isSuccess), 'success');
+    if (failures.length === 0 || successes.length === 0) {
+      continue;
+    }
+
+    for (const entry of groupEntries) {
+      usedIds.add(entry.filePath);
+    }
+
+    candidates.push({
+      bodyBytes: failures[0]?.bodyBytes ?? successes[0]?.bodyBytes ?? null,
+      bodySha256,
+      failureCount: failures.length,
+      failures: failures.map(serializeEntry),
+      recommendedPair: {
+        failure: serializeEntry(failures[0]),
+        success: serializeEntry(successes[0])
+      },
+      successCount: successes.length,
+      successes: successes.map(serializeEntry)
+    });
+  }
+
+  candidates.sort((left, right) => {
+    const pairCountDiff = right.failureCount + right.successCount - (left.failureCount + left.successCount);
+    if (pairCountDiff !== 0) {
+      return pairCountDiff;
+    }
+    return String(right.bodyBytes ?? 0).localeCompare(String(left.bodyBytes ?? 0), undefined, { numeric: true });
+  });
+
+  return { candidates, usedIds };
+}
+
+function shapeKey(entry) {
+  if (
+    !entry.model ||
+    entry.stream === null ||
+    entry.messageCount === null ||
+    entry.toolCount === null ||
+    entry.toolResultBlockCount === null ||
+    entry.thinkingPresent === null
+  ) {
+    return null;
+  }
+
+  return [
+    `model=${entry.model}`,
+    `stream=${entry.stream}`,
+    `message_count=${entry.messageCount}`,
+    `tool_count=${entry.toolCount}`,
+    `tool_result_block_count=${entry.toolResultBlockCount}`,
+    `thinking_present=${entry.thinkingPresent}`
+  ].join('|');
+}
+
+function buildShapeCandidates(entries, excludedIds) {
+  const eligibleEntries = entries.filter((entry) => !excludedIds.has(entry.filePath));
+  const shapeGroups = groupBy(eligibleEntries, shapeKey);
+  const candidates = [];
+
+  for (const [key, groupEntries] of shapeGroups.entries()) {
+    const failures = sortEntries(groupEntries.filter(isFailure), 'failure');
+    const successes = sortEntries(groupEntries.filter(isSuccess), 'success');
+    if (failures.length === 0 || successes.length === 0) {
+      continue;
+    }
+
+    candidates.push({
+      failureCount: failures.length,
+      failures: failures.map(serializeEntry),
+      recommendedPair: {
+        failure: serializeEntry(failures[0]),
+        success: serializeEntry(successes[0])
+      },
+      shapeKey: key,
+      successCount: successes.length,
+      successes: successes.map(serializeEntry)
+    });
+  }
+
+  candidates.sort((left, right) => {
+    const pairCountDiff = right.failureCount + right.successCount - (left.failureCount + left.successCount);
+    if (pairCountDiff !== 0) {
+      return pairCountDiff;
+    }
+    return left.shapeKey.localeCompare(right.shapeKey);
+  });
+
+  return candidates;
+}
+
+function buildSummaryText(summary) {
+  const lines = [
+    `artifact_count=${summary.artifactCount}`,
+    `source_files=${summary.sourceFiles.length}`,
+    `exact_body_match_candidates=${summary.exactBodyCandidates.length}`,
+    `shape_match_candidates=${summary.shapeCandidates.length}`,
+    `recommended_exact_pair=${
+      summary.exactBodyCandidates[0]
+        ? `${summary.exactBodyCandidates[0].recommendedPair.failure.requestId} -> ${summary.exactBodyCandidates[0].recommendedPair.success.requestId}`
+        : 'none'
+    }`,
+    `recommended_shape_pair=${
+      summary.shapeCandidates[0]
+        ? `${summary.shapeCandidates[0].recommendedPair.failure.requestId} -> ${summary.shapeCandidates[0].recommendedPair.success.requestId}`
+        : 'none'
+    }`,
+    `recommended_next_action=${summary.recommendedNextAction}`
+  ];
+
+  for (const [index, candidate] of summary.exactBodyCandidates.entries()) {
+    lines.push(
+      `exact_body_candidate_${index + 1}=body_sha256:${candidate.bodySha256} failure:${candidate.recommendedPair.failure.requestId} success:${candidate.recommendedPair.success.requestId}`
+    );
+  }
+
+  for (const [index, candidate] of summary.shapeCandidates.entries()) {
+    lines.push(
+      `shape_candidate_${index + 1}=shape_key:${candidate.shapeKey} failure:${candidate.recommendedPair.failure.requestId} success:${candidate.recommendedPair.success.requestId}`
+    );
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+const [, , outDirArg, ...summaryPaths] = process.argv;
+if (!outDirArg || summaryPaths.length === 0) {
+  fail('usage: innies-compat-artifact-candidates.mjs <out-dir> <summary.json> [more summary.json files...]');
+}
+
+const outDir = path.resolve(outDirArg);
+fs.mkdirSync(outDir, { recursive: true });
+
+const resolvedPaths = [...new Set(summaryPaths.map((inputPath) => path.resolve(inputPath)))];
+const entries = resolvedPaths.map(normalizeEntry);
+if (entries.length === 0) {
+  fail('no summary entries were loaded');
+}
+
+const { candidates: exactBodyCandidates, usedIds } = buildExactBodyCandidates(entries);
+const shapeCandidates = buildShapeCandidates(entries, usedIds);
+
+let recommendedNextAction = 'collect additional saved artifacts or direct captures before diffing';
+if (exactBodyCandidates.length > 0) {
+  recommendedNextAction = 'run exact bundle diff on the recommended exact-body pair first';
+} else if (shapeCandidates.length > 0) {
+  recommendedNextAction = 'use the recommended shape pair to choose the next direct replay or capture target';
+}
+
+const summary = {
+  artifactCount: entries.length,
+  exactBodyCandidateCount: exactBodyCandidates.length,
+  exactBodyCandidates,
+  recommendedNextAction,
+  shapeCandidateCount: shapeCandidates.length,
+  shapeCandidates,
+  sourceFiles: resolvedPaths
+};
+
+fs.writeFileSync(path.join(outDir, 'summary.json'), `${JSON.stringify(summary, null, 2)}\n`);
+fs.writeFileSync(path.join(outDir, 'summary.txt'), buildSummaryText(summary));

--- a/scripts/innies-compat-artifact-candidates.sh
+++ b/scripts/innies-compat-artifact-candidates.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_PATH" ]]; do
+  SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+  SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"
+  [[ "$SCRIPT_PATH" != /* ]] && SCRIPT_PATH="${SCRIPT_DIR}/${SCRIPT_PATH}"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+source "${SCRIPT_DIR}/_common.sh"
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $(basename "$0") <artifact-summary-dir-or-summary.json> [more paths...]" >&2
+  exit 1
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+  echo 'error: node is required' >&2
+  exit 1
+fi
+
+OUT_DIR="${INNIES_COMPAT_ARTIFACT_CANDIDATES_OUT_DIR:-/tmp/innies-compat-artifact-candidates-$(date +%s)}"
+mkdir -p "$OUT_DIR"
+
+TMP_INPUTS="$(mktemp)"
+cleanup() {
+  rm -f "$TMP_INPUTS"
+}
+trap cleanup EXIT
+
+for input in "$@"; do
+  if [[ -d "$input" ]]; then
+    while IFS= read -r summary_path; do
+      printf '%s\n' "$summary_path"
+    done < <(find "$input" -type f -name 'summary.json' | sort)
+    continue
+  fi
+
+  if [[ -f "$input" ]]; then
+    printf '%s\n' "$input"
+    continue
+  fi
+
+  echo "error: input path not found: $input" >&2
+  exit 1
+done | awk '!seen[$0]++' >"$TMP_INPUTS"
+
+if [[ ! -s "$TMP_INPUTS" ]]; then
+  echo 'error: no summary.json files found in input paths' >&2
+  exit 1
+fi
+
+SUMMARY_PATHS=()
+while IFS= read -r summary_path; do
+  SUMMARY_PATHS+=("$summary_path")
+done <"$TMP_INPUTS"
+node "${ROOT_DIR}/scripts/innies-compat-artifact-candidates.mjs" "$OUT_DIR" "${SUMMARY_PATHS[@]}"
+cat "$OUT_DIR/summary.txt"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,6 +17,7 @@ ln -sf "${ROOT_DIR}/scripts/innies-buyer-key-create.sh" "${BIN_DIR}/innies-buyer
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-set.sh" "${BIN_DIR}/innies-buyer-preference-set"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-get.sh" "${BIN_DIR}/innies-buyer-preference-get"
 ln -sf "${ROOT_DIR}/scripts/innies-buyer-preference-check.sh" "${BIN_DIR}/innies-buyer-preference-check"
+ln -sf "${ROOT_DIR}/scripts/innies-compat-artifact-candidates.sh" "${BIN_DIR}/innies-compat-artifact-candidates"
 ln -sf "${ROOT_DIR}/scripts/innies-slo-check.sh" "${BIN_DIR}/innies-slo-check"
 
 rm -f \
@@ -48,6 +49,7 @@ echo "  ${BIN_DIR}/innies-buyer-key-create -> ${ROOT_DIR}/scripts/innies-buyer-k
 echo "  ${BIN_DIR}/innies-buyer-preference-set -> ${ROOT_DIR}/scripts/innies-buyer-preference-set.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-get -> ${ROOT_DIR}/scripts/innies-buyer-preference-get.sh"
 echo "  ${BIN_DIR}/innies-buyer-preference-check -> ${ROOT_DIR}/scripts/innies-buyer-preference-check.sh"
+echo "  ${BIN_DIR}/innies-compat-artifact-candidates -> ${ROOT_DIR}/scripts/innies-compat-artifact-candidates.sh"
 echo "  ${BIN_DIR}/innies-slo-check -> ${ROOT_DIR}/scripts/innies-slo-check.sh"
 echo
 echo 'If command not found, add ~/.local/bin to PATH:'

--- a/scripts/tests/innies-compat-artifact-candidates.test.sh
+++ b/scripts/tests/innies-compat-artifact-candidates.test.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="${ROOT_DIR}/scripts/innies-compat-artifact-candidates.sh"
+
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  if ! grep -Fq "$needle" "$file"; then
+    echo "expected to find '$needle' in $file" >&2
+    exit 1
+  fi
+}
+
+test_builds_exact_and_shape_candidate_shortlists() {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf "$tmpdir"' RETURN
+
+  mkdir -p \
+    "$tmpdir/inputs/fail-exact" \
+    "$tmpdir/inputs/good-exact" \
+    "$tmpdir/inputs/fail-shape" \
+    "$tmpdir/inputs/good-shape" \
+    "$tmpdir/inputs/noise"
+
+  cat >"$tmpdir/inputs/fail-exact/summary.json" <<'JSON'
+{
+  "artifact_path": "/artifacts/fail-exact.html",
+  "request_id": "req_fail_exact",
+  "provider": "anthropic",
+  "upstream_status": 400,
+  "classification": "invalid_request_candidate",
+  "body_sha256": "sha-exact",
+  "body_bytes": 393038,
+  "model": "claude-opus-4-6",
+  "stream": true,
+  "message_count": 425,
+  "tool_count": 21,
+  "tool_result_block_count": 63,
+  "thinking_present": true
+}
+JSON
+
+  cat >"$tmpdir/inputs/good-exact/summary.json" <<'JSON'
+{
+  "artifact_path": "/artifacts/good-exact.html",
+  "request_id": "req_good_exact",
+  "provider": "anthropic",
+  "upstream_status": 200,
+  "classification": "known_good_candidate",
+  "body_sha256": "sha-exact",
+  "body_bytes": 393038,
+  "model": "claude-opus-4-6",
+  "stream": true,
+  "message_count": 425,
+  "tool_count": 21,
+  "tool_result_block_count": 63,
+  "thinking_present": true
+}
+JSON
+
+  cat >"$tmpdir/inputs/fail-shape/summary.json" <<'JSON'
+{
+  "artifact_path": "/artifacts/fail-shape.html",
+  "request_id": "req_fail_shape",
+  "provider": "anthropic",
+  "upstream_status": 400,
+  "classification": "invalid_request_candidate",
+  "model": "claude-opus-4-6",
+  "stream": true,
+  "message_count": 425,
+  "tool_count": 21,
+  "tool_result_block_count": 63,
+  "thinking_present": true
+}
+JSON
+
+  cat >"$tmpdir/inputs/good-shape/summary.json" <<'JSON'
+{
+  "artifact_path": "/artifacts/good-shape.html",
+  "request_id": "req_good_shape",
+  "provider": "anthropic",
+  "upstream_status": 200,
+  "classification": "known_good_candidate",
+  "model": "claude-opus-4-6",
+  "stream": true,
+  "message_count": 425,
+  "tool_count": 21,
+  "tool_result_block_count": 63,
+  "thinking_present": true
+}
+JSON
+
+  cat >"$tmpdir/inputs/noise/summary.json" <<'JSON'
+{
+  "artifact_path": "/artifacts/noise.html",
+  "request_id": "req_noise",
+  "provider": "anthropic",
+  "upstream_status": 200,
+  "classification": "known_good_candidate",
+  "body_sha256": "sha-noise",
+  "body_bytes": 120,
+  "model": "claude-sonnet-4-5",
+  "stream": false,
+  "message_count": 2,
+  "tool_count": 0,
+  "tool_result_block_count": 0,
+  "thinking_present": false
+}
+JSON
+
+  INNIES_COMPAT_ARTIFACT_CANDIDATES_OUT_DIR="$tmpdir/out" \
+    "$SCRIPT" "$tmpdir/inputs" >/tmp/innies-compat-artifact-candidates.out
+
+  assert_contains "$tmpdir/out/summary.txt" 'artifact_count=5'
+  assert_contains "$tmpdir/out/summary.txt" 'exact_body_match_candidates=1'
+  assert_contains "$tmpdir/out/summary.txt" 'shape_match_candidates=1'
+  assert_contains "$tmpdir/out/summary.txt" 'recommended_exact_pair=req_fail_exact -> req_good_exact'
+  assert_contains "$tmpdir/out/summary.txt" 'recommended_shape_pair=req_fail_shape -> req_good_shape'
+  assert_contains "$tmpdir/out/summary.txt" 'recommended_next_action=run exact bundle diff on the recommended exact-body pair first'
+
+  node <<'NODE' "$tmpdir/out/summary.json"
+const fs = require('node:fs');
+const path = process.argv[1];
+const summary = JSON.parse(fs.readFileSync(path, 'utf8'));
+if (summary.artifactCount !== 5) throw new Error(`artifactCount=${summary.artifactCount}`);
+if (summary.exactBodyCandidates.length !== 1) throw new Error(`exact=${summary.exactBodyCandidates.length}`);
+if (summary.shapeCandidates.length !== 1) throw new Error(`shape=${summary.shapeCandidates.length}`);
+if (summary.exactBodyCandidates[0].recommendedPair.failure.requestId !== 'req_fail_exact') {
+  throw new Error('unexpected exact failure request id');
+}
+if (summary.exactBodyCandidates[0].recommendedPair.success.requestId !== 'req_good_exact') {
+  throw new Error('unexpected exact success request id');
+}
+if (summary.shapeCandidates[0].recommendedPair.failure.requestId !== 'req_fail_shape') {
+  throw new Error('unexpected shape failure request id');
+}
+if (summary.shapeCandidates[0].recommendedPair.success.requestId !== 'req_good_shape') {
+  throw new Error('unexpected shape success request id');
+}
+NODE
+}
+
+test_fails_when_no_summary_json_exists() {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf "$tmpdir"' RETURN
+
+  mkdir -p "$tmpdir/empty"
+
+  if INNIES_COMPAT_ARTIFACT_CANDIDATES_OUT_DIR="$tmpdir/out" "$SCRIPT" "$tmpdir/empty" >"$tmpdir/stdout" 2>"$tmpdir/stderr"; then
+    echo 'expected helper to fail when no summary.json files are present' >&2
+    exit 1
+  fi
+
+  assert_contains "$tmpdir/stderr" 'error: no summary.json files found in input paths'
+}
+
+test_builds_exact_and_shape_candidate_shortlists
+test_fails_when_no_summary_json_exists


### PR DESCRIPTION
## Summary
- add \\`scripts/innies-compat-artifact-candidates.{sh,mjs}\\` to scan multiple issue-80 artifact summaries and rank exact-body comparator pairs before any looser shape-only fallback
- write both \\`summary.txt\\` and \\`summary.json\\` so the next operator step can choose the best failing-vs-known-good pair for the existing diff/matrix helpers without manual triage
- wire the helper into \\`scripts/install.sh\\` / \\`scripts/README.md\\` and cover it with a focused shell regression

## Test Plan
- \\`bash scripts/tests/innies-compat-artifact-candidates.test.sh\\`
- \\`node --check scripts/innies-compat-artifact-candidates.mjs\\`
- \\`bash -n scripts/innies-compat-artifact-candidates.sh scripts/tests/innies-compat-artifact-candidates.test.sh scripts/install.sh\\`
- \\`TMP_HOME=\"$(mktemp -d)\" && HOME=\"$TMP_HOME\" bash scripts/install.sh >/tmp/issue80-artifact-candidates-install.out && test -L \"$TMP_HOME/.local/bin/innies-compat-artifact-candidates\"\\`
- \\`git diff --check\\`

## Notes
- this is support tooling only; it does not touch the runtime proxy path or weaken tool/thinking/streaming behavior
- the helper expects one or more compatible \\`summary.json\\` inputs (for example from the open artifact-index lane) and shortlists the strongest exact-body candidate before any shape-only pair

Refs #80