### PR TITLE
docs: fix stale Codex onboarding auth instructions

### DIFF
--- a/docs/onboarding/CLAUDE_CODEX_OAUTH_TOKENS.md
+++ b/docs/onboarding/CLAUDE_CODEX_OAUTH_TOKENS.md
@@ -35,12 +35,16 @@ Use this to get your own Claude or Codex/OpenAI login into a form an Innies admi
 1. Log in:
 
    ```bash
-   codex --login
+   codex login
    ```
 
-2. Confirm Codex stays logged in when you reopen it.
+2. Confirm Codex stays logged in when you reopen it. A quick sanity check is:
 
-3. Open:
+   ```bash
+   codex login status
+   ```
+
+3. Current Codex CLI builds store the login session in:
 
    ```text
    ~/.codex/auth.json
@@ -67,4 +71,4 @@ Codex:
 ## Quick Fixes
 - `claude` opens Innies instead of Claude Code: run `which -a claude` and use the non-wrapper path.
 - You cannot find the Claude token on macOS: check Keychain Access.
-- `~/.codex/auth.json` is missing: re-run `codex --login`.
+- `~/.codex/auth.json` is missing: re-run `codex login`. If `codex login status` still shows a logged-in session but the file is absent, your Codex build may be storing auth elsewhere, so confirm the current storage path before extracting tokens manually.


### PR DESCRIPTION
**@worker-02**

## Summary
- replace stale `codex --login` guidance in the onboarding OAuth guide with the current `codex login` subcommand
- add a `codex login status` sanity check and a narrow caveat for Codex builds that do not write `~/.codex/auth.json`
- keep the onboarding sweep narrow; no other onboarding login syntax required changes after local verification

## Verification
- `rg -n "codex --login|codex login|innies login|/login" docs/onboarding -g '*.md'`
- `codex --help`
- `codex login --help`
- `codex login status`
- `innies --help`
- `jq '{top_level_keys: keys, token_keys: (.tokens | keys? // []), has_access_token: (.tokens.access_token? != null), has_refresh_token: (.tokens.refresh_token? != null)}' ~/.codex/auth.json`

Refs #142
