### PR TITLE
Derive Codex maxed analytics status and align the token table

### DIFF
--- a/api/src/repos/analyticsRepository.ts
+++ b/api/src/repos/analyticsRepository.ts
@@ -170,15 +170,15 @@ function buildSystemSummaryTokenCountsSql(input: {
       provider_usage as (
         select
           pu.token_credential_id,
+          pu.provider,
           pu.five_hour_utilization_ratio,
           pu.seven_day_utilization_ratio
         from ${TABLES.tokenCredentialProviderUsage} pu
-        where pu.provider = 'anthropic'
       ),
       `
     : '';
   const providerUsageJoin = input.options.includeProviderUsage
-    ? 'left join provider_usage pu on pu.token_credential_id = tc.id'
+    ? 'left join provider_usage pu on pu.token_credential_id = tc.id and pu.provider = tc.provider'
     : '';
   const fiveHourReservePercent = input.options.includeReserveColumns
     ? 'coalesce(tc.five_hour_reserve_percent, 0)'
@@ -198,6 +198,17 @@ function buildSystemSummaryTokenCountsSql(input: {
               and (
                 coalesce((pu.five_hour_utilization_ratio * 100) >= (100 - ${fiveHourReservePercent}), false)
                 or coalesce((pu.seven_day_utilization_ratio * 100) >= (100 - ${sevenDayReservePercent}), false)
+              )
+            )
+            when tc.provider = 'openai'
+            then (
+              tc.status = 'maxed'
+              or (
+                pu.token_credential_id is not null
+                and (
+                  coalesce(pu.five_hour_utilization_ratio >= 1, false)
+                  or coalesce(pu.seven_day_utilization_ratio >= 1, false)
+                )
               )
             )
             else tc.status = 'maxed'
@@ -253,18 +264,18 @@ function buildTokenHealthSql(input: {
       provider_usage as (
         select
           pu.token_credential_id,
+          pu.provider,
           pu.five_hour_utilization_ratio,
           pu.five_hour_resets_at,
           pu.seven_day_utilization_ratio,
           pu.seven_day_resets_at,
           pu.fetched_at as provider_usage_fetched_at
         from ${TABLES.tokenCredentialProviderUsage} pu
-        where pu.provider = 'anthropic'
       ),
       `
     : '';
   const providerUsageJoin = input.options.includeProviderUsage
-    ? 'left join provider_usage pu on pu.token_credential_id = cb.id'
+    ? 'left join provider_usage pu on pu.token_credential_id = cb.id and pu.provider = cb.provider'
     : '';
   const providerUsageSelect = input.options.includeProviderUsage
     ? `

--- a/api/src/routes/analytics.ts
+++ b/api/src/routes/analytics.ts
@@ -747,6 +747,16 @@ function appendDashboardWarning(
   warnings.push(warning);
 }
 
+function openAiUsageExhausted(row: {
+  fiveHourUtilizationRatio: number | null;
+  sevenDayUtilizationRatio: number | null;
+}) {
+  return {
+    fiveHour: (row.fiveHourUtilizationRatio ?? 0) >= 1,
+    sevenDay: (row.sevenDayUtilizationRatio ?? 0) >= 1
+  };
+}
+
 function buildProviderUsageWarnings(
   rawTokenHealthRows: unknown,
   now = Date.now()
@@ -758,10 +768,77 @@ function buildProviderUsageWarnings(
   const hardStaleMs = readTokenCredentialProviderUsageHardStaleMs();
 
   for (const row of tokenHealthRows) {
-    if (row.provider !== 'anthropic') continue;
     if (row.status === 'expired' || row.status === 'revoked') continue;
 
     const label = tokenHealthWarningLabel(row);
+    if (row.provider === 'openai') {
+      const fetchedAtRaw = row.providerUsageFetchedAt;
+
+      if (row.lastRefreshError === PROVIDER_USAGE_FETCH_FAILED_REASON) {
+        appendDashboardWarning(
+          warnings,
+          seen,
+          `${label}: provider_usage_fetch_failed - last Codex usage refresh failed; dashboard usage state may lag until a successful refresh.`
+        );
+      } else if (row.lastRefreshError === PROVIDER_USAGE_FETCH_BACKOFF_ACTIVE_REASON) {
+        appendDashboardWarning(
+          warnings,
+          seen,
+          `${label}: provider_usage_fetch_backoff_active - Codex usage refresh is temporarily backing off after recent fetch failures; dashboard usage state may lag until retry.`
+        );
+      }
+
+      if (!fetchedAtRaw) {
+        appendDashboardWarning(
+          warnings,
+          seen,
+          `${label}: provider_usage_snapshot_missing - Codex token has no provider-usage snapshot yet; dashboard usage state may lag until one arrives.`
+        );
+        continue;
+      }
+
+      const fetchedAtMs = Date.parse(fetchedAtRaw);
+      const ageMs = Number.isFinite(fetchedAtMs) ? Math.max(0, now - fetchedAtMs) : null;
+
+      if (ageMs !== null && ageMs > hardStaleMs) {
+        appendDashboardWarning(
+          warnings,
+          seen,
+          `${label}: provider_usage_snapshot_hard_stale - last Codex usage snapshot is ${formatWarningAge(ageMs)} old; dashboard usage state may lag until a fresh snapshot arrives.`
+        );
+        continue;
+      }
+
+      if (ageMs !== null && ageMs > softStaleMs) {
+        appendDashboardWarning(
+          warnings,
+          seen,
+          `${label}: provider_usage_snapshot_soft_stale - last Codex usage snapshot is ${formatWarningAge(ageMs)} old; dashboard is still using the last successful snapshot.`
+        );
+      }
+
+      const exhausted = openAiUsageExhausted(row);
+      if (exhausted.fiveHour) {
+        appendDashboardWarning(
+          warnings,
+          seen,
+          `${label}: usage_exhausted_5h - Codex usage is exhausted for the 5h window${row.fiveHourResetsAt ? ` until ${row.fiveHourResetsAt}` : ''}.`
+        );
+      }
+
+      if (exhausted.sevenDay) {
+        appendDashboardWarning(
+          warnings,
+          seen,
+          `${label}: usage_exhausted_7d - Codex usage is exhausted for the 7d window${row.sevenDayResetsAt ? ` until ${row.sevenDayResetsAt}` : ''}.`
+        );
+      }
+
+      continue;
+    }
+
+    if (row.provider !== 'anthropic') continue;
+
     const availability = evaluateClaudeCredentialAvailability({
       credential: {
         provider: row.provider,

--- a/api/src/services/dashboardTokenStatus.ts
+++ b/api/src/services/dashboardTokenStatus.ts
@@ -10,7 +10,7 @@ export type DashboardCompactStatus =
   | 'expired'
   | 'revoked';
 
-export type DashboardStatusSource = 'backend_maxed' | 'cap_exhausted' | null;
+export type DashboardStatusSource = 'backend_maxed' | 'cap_exhausted' | 'usage_exhausted' | null;
 
 export type DashboardExclusionReason =
   | 'rate_limited'
@@ -94,6 +94,19 @@ function isActiveCooldown(rateLimitedUntil: Date | string | null | undefined, no
   return until !== null && until.getTime() > now.getTime();
 }
 
+function hasOpenAiUsageExhausted(input: Pick<
+  DashboardTokenStatusInput,
+  'provider' | 'fiveHourUtilizationRatio' | 'sevenDayUtilizationRatio'
+>): boolean {
+  const provider = input.provider.trim().toLowerCase();
+  if (provider !== 'openai') {
+    return false;
+  }
+
+  return (input.fiveHourUtilizationRatio ?? 0) >= 1
+    || (input.sevenDayUtilizationRatio ?? 0) >= 1;
+}
+
 export function deriveDashboardTokenStatusRow(
   input: DashboardTokenStatusInput
 ): DashboardTokenStatusOutput {
@@ -137,6 +150,15 @@ export function deriveDashboardTokenStatusRow(
       compactStatus: 'maxed',
       expandedStatus: 'maxed, source: cap_exhausted',
       statusSource: 'cap_exhausted'
+    });
+  }
+
+  if (rawStatus === 'active' && hasOpenAiUsageExhausted(input)) {
+    return buildStatusOutput({
+      rawStatus,
+      compactStatus: 'maxed',
+      expandedStatus: 'maxed, source: usage_exhausted',
+      statusSource: 'usage_exhausted'
     });
   }
 

--- a/api/tests/analytics.route.test.ts
+++ b/api/tests/analytics.route.test.ts
@@ -1264,7 +1264,9 @@ describe('analytics routes', () => {
     });
     expect((res.body as any).window).toBe('5h');
     expect(typeof (res.body as any).snapshotAt).toBe('string');
-    expect((res.body as any).warnings).toEqual([]);
+    expect((res.body as any).warnings).toEqual([
+      'alpha: provider_usage_snapshot_missing - Codex token has no provider-usage snapshot yet; dashboard usage state may lag until one arrives.'
+    ]);
     expect((res.body as any).tokens).toEqual([
       {
         credentialId: '11111111-1111-4111-8111-111111111111',
@@ -1305,6 +1307,102 @@ describe('analytics routes', () => {
         authFailures24h: 1,
         rateLimited24h: 2
       }
+    ]);
+  });
+
+  it('marks Codex dashboard token rows as maxed when provider usage shows an exhausted window', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-12T12:10:00.000Z'));
+
+    const apiKeys = createApiKeysRepo();
+    const analytics = createAnalyticsRepo();
+    analytics.getSystemSummary.mockResolvedValue({
+      total_requests: 10,
+      total_usage_units: 100,
+      active_tokens: 1,
+      maxed_tokens: 0,
+      total_tokens: 1,
+      maxed_events_7d: 0,
+      error_rate: 0,
+      fallback_rate: 0,
+      by_provider: [],
+      by_model: [],
+      by_source: []
+    });
+    analytics.getTokenUsage.mockResolvedValue([
+      {
+        credential_id: '55555555-5555-4555-8555-555555555555',
+        debug_label: 'codex-alpha',
+        provider: 'openai',
+        status: 'active',
+        attempts: 5,
+        requests: 5,
+        usage_units: 100,
+        by_source: []
+      }
+    ]);
+    analytics.getTokenHealth.mockResolvedValue([
+      {
+        credential_id: '55555555-5555-4555-8555-555555555555',
+        debug_label: 'codex-alpha',
+        provider: 'openai',
+        status: 'active',
+        consecutive_rate_limit_count: 0,
+        rate_limited_until: null,
+        monthly_contribution_used_units: 0,
+        monthly_contribution_limit_units: null,
+        maxed_events_7d: 0,
+        utilization_rate_24h: null,
+        five_hour_reserve_percent: null,
+        five_hour_utilization_ratio: 1,
+        five_hour_resets_at: '2026-03-12T14:00:00.000Z',
+        five_hour_contribution_cap_exhausted: null,
+        seven_day_reserve_percent: null,
+        seven_day_utilization_ratio: 0.2,
+        seven_day_resets_at: '2026-03-15T00:00:00.000Z',
+        seven_day_contribution_cap_exhausted: null,
+        provider_usage_fetched_at: '2026-03-12T12:09:00.000Z'
+      }
+    ]);
+    analytics.getTokenRouting.mockResolvedValue([]);
+    analytics.getBuyers.mockResolvedValue([]);
+    analytics.getAnomalies.mockResolvedValue({ checks: {}, ok: true });
+    analytics.getEvents.mockResolvedValue([]);
+
+    const router = createAnalyticsRouter({ apiKeys: apiKeys as any, analytics });
+    const handlers = getRouteHandlers(router as any, '/v1/admin/analytics/dashboard', 'get');
+    const req = createMockReq({
+      method: 'GET',
+      path: '/v1/admin/analytics/dashboard',
+      headers: {
+        authorization: 'Bearer admin_token'
+      }
+    });
+    const res = createMockRes();
+
+    await invokeHandlers(handlers, req, res);
+
+    expect((res.body as any).summary).toEqual(expect.objectContaining({
+      activeTokens: 0,
+      maxedTokens: 1,
+      totalTokens: 1
+    }));
+    expect((res.body as any).tokens).toEqual([
+      expect.objectContaining({
+        credentialId: '55555555-5555-4555-8555-555555555555',
+        provider: 'openai',
+        rawStatus: 'active',
+        status: 'maxed',
+        compactStatus: 'maxed',
+        expandedStatus: 'maxed, source: usage_exhausted',
+        statusSource: 'usage_exhausted',
+        exclusionReason: null,
+        fiveHourUtilizationRatio: 1,
+        providerUsageFetchedAt: '2026-03-12T12:09:00.000Z'
+      })
+    ]);
+    expect((res.body as any).warnings).toEqual([
+      'codex-alpha: usage_exhausted_5h - Codex usage is exhausted for the 5h window until 2026-03-12T14:00:00.000Z.'
     ]);
   });
 

--- a/api/tests/analyticsRepository.test.ts
+++ b/api/tests/analyticsRepository.test.ts
@@ -70,6 +70,22 @@ describe('AnalyticsRepository', () => {
     expect(usageLedgerQueries).toHaveLength(5);
   });
 
+  it('treats active OpenAI tokens with exhausted provider-usage windows as maxed in system summary counts', async () => {
+    const db = new MockSqlClient({ rows: [], rowCount: 0 });
+    const repo = new AnalyticsRepository(db);
+
+    await repo.getSystemSummary({ window: '24h', provider: 'openai' });
+
+    const tokenCountsQuery = db.queries.find((query) => query.sql.includes('token_inventory AS'));
+
+    expect(tokenCountsQuery?.sql).toContain('from in_token_credential_provider_usage pu');
+    expect(tokenCountsQuery?.sql).toContain('left join provider_usage pu on pu.token_credential_id = tc.id and pu.provider = tc.provider');
+    expect(tokenCountsQuery?.sql).toContain("when tc.provider = 'openai'");
+    expect(tokenCountsQuery?.sql).toContain('coalesce(pu.five_hour_utilization_ratio >= 1, false)');
+    expect(tokenCountsQuery?.sql).toContain('coalesce(pu.seven_day_utilization_ratio >= 1, false)');
+    expect(tokenCountsQuery?.sql).toContain("when tc.provider = 'anthropic'");
+  });
+
   it('uses routing metadata request_source in token routing filters, including 24h side counts', async () => {
     const db = new MockSqlClient({ rows: [], rowCount: 0 });
     const repo = new AnalyticsRepository(db);

--- a/api/tests/dashboardTokenStatus.test.ts
+++ b/api/tests/dashboardTokenStatus.test.ts
@@ -55,6 +55,24 @@ describe('deriveDashboardTokenStatusRow', () => {
     });
   });
 
+  it('marks active Codex usage-exhausted tokens as maxed from provider usage exhaustion', () => {
+    expect(deriveDashboardTokenStatusRow({
+      provider: 'openai',
+      rawStatus: 'active',
+      rateLimitedUntil: null,
+      fiveHourUtilizationRatio: 1,
+      fiveHourResetsAt: '2026-03-12T14:00:00.000Z',
+      providerUsageFetchedAt: '2026-03-12T12:00:00.000Z'
+    })).toEqual({
+      rawStatus: 'active',
+      compactStatus: 'maxed',
+      expandedStatus: 'maxed, source: usage_exhausted',
+      statusSource: 'usage_exhausted',
+      exclusionReason: null,
+      hidden: false
+    });
+  });
+
   it('marks cooldowns as active* with rate_limited exclusion', () => {
     expect(deriveDashboardTokenStatusRow({
       provider: 'openai',

--- a/docs/ANALYTICS.md
+++ b/docs/ANALYTICS.md
@@ -59,9 +59,10 @@ The admin analytics read surface now carries these Claude quota fields:
 - `claudeSevenDayAvgUsageUnitsBeforeCapExhaustion`
 
 Current expectation:
-- non-Claude rows keep those fields `null`
+- OpenAI/Codex rows may populate the raw provider-usage snapshot fields (`fiveHourUtilizationRatio`, `fiveHourResetsAt`, `sevenDayUtilizationRatio`, `sevenDayResetsAt`, `providerUsageFetchedAt`) when a stored snapshot exists
+- non-Claude reserve / contribution-cap fields still keep `null`
 - Claude rows may still keep them `null` when the latest usage snapshot is missing or analytics is reading against a pre-migration environment
-- the dashboard shows raw Claude utilization in `5H` / `7D`, tints exhausted cells red when a reserve or provider limit is hit, and renders `n/a` for non-Claude rows
+- the dashboard shows raw provider usage in `5H` / `7D`; Claude rows tint exhausted cells when a reserve or provider limit is hit, while OpenAI/Codex rows use those windows for derived usage-exhausted status without reserve semantics
 - the Claude cap-cycle usage fields are derived from durable `contribution_cap_exhausted` / `contribution_cap_cleared` events plus usage-ledger sums between the prior clear point and each exhaustion point
 
 ## What We Actually Store
@@ -101,7 +102,7 @@ Current expectation:
   - current manual monthly budget usage
   - exact `maxedEvents7d`
   - empirical maxing / recovery / capacity / utilization metrics when enough history exists
-  - live Claude provider-usage / reserve fields for contribution-cap routing
+  - live provider-usage snapshot fields when a stored snapshot exists; reserve / contribution-cap flags remain Claude-only
   - Claude 5h / 7d usage-units-before-cap-exhaustion metrics when those cap cycles have been observed
   - best-effort auth diagnosis fields when Innies can derive them (`authDiagnosis`, `accessTokenExpiresAt`, `refreshTokenState`)
 
@@ -113,7 +114,7 @@ Current expectation:
   - request volume
   - top buyers
   - system-wide latency / error / fallback metrics
-  - current usage-maxed token count in `maxedTokens`
+  - current usage-maxed token count in `maxedTokens`, including active OpenAI/Codex rows whose stored provider-usage window is exhausted
 
 - `/timeseries`
   - request / usage / error / latency over time
@@ -141,11 +142,11 @@ Current expectation:
   - one merged snapshot for summary + tokens + buyers + anomalies + events
   - shared snapshot cache keyed by `window/provider/source`, refreshed at most once every ~2.5s per key
   - keeps the admin dashboard feeling live without recomputing the heaviest buyer/token-health queries for every tab
-  - carries raw Claude provider-usage/reserve fields when available
+  - carries raw provider-usage snapshot fields when available; reserve / contribution-cap flags remain Claude-only
   - derives `5H` / `7D` in the dashboard layer
-  - renders `n/a` CAP placeholders for non-Claude rows while keeping the raw API fields `null`
-  - surfaces provider-usage freshness and contribution-cap warnings in the snapshot `warnings` list
-  - surfaces operator-facing Claude quota warnings for missing snapshots, stale snapshots, and cap exhaustion
+  - renders `n/a` CAP placeholders for non-Claude rows while still allowing OpenAI/Codex rows to carry raw usage-window telemetry
+  - surfaces provider-usage freshness and exhaustion warnings in the snapshot `warnings` list
+  - distinguishes backend auth parking (`backend_maxed`) from derived usage exhaustion (`cap_exhausted` for Claude, `usage_exhausted` for OpenAI/Codex)
 
 - `/anomalies`
   - aggregate staleness / mismatch and attribution checks

--- a/docs/API_CONTRACT.md
+++ b/docs/API_CONTRACT.md
@@ -448,7 +448,8 @@ Notes:
   - `claudeSevenDayCapExhaustionCyclesObserved`
   - `claudeSevenDayUsageUnitsBeforeCapExhaustionLastWindow`
   - `claudeSevenDayAvgUsageUnitsBeforeCapExhaustion`
-- those fields are Claude-only and stay `null` on non-Claude rows
+- reserve / contribution-cap fields stay Claude-only and remain `null` on non-Claude rows
+- OpenAI/Codex rows may populate the raw provider-usage snapshot fields (`fiveHourUtilizationRatio`, `fiveHourResetsAt`, `sevenDayUtilizationRatio`, `sevenDayResetsAt`, `providerUsageFetchedAt`) when a stored snapshot exists
 - Claude rows may also keep them `null` when a fresh provider-usage snapshot has not been fetched yet or analytics is reading against a pre-migration environment
 - analytics should treat rows with `expiresAt <= now` as `expired` for operator-facing status/counting even if the stored DB `status` has not been swept yet
 - rows may also include best-effort auth-diagnosis fields for operator visibility:
@@ -607,7 +608,7 @@ Notes:
 - `topBuyers[*].percentOfTotal` is a `0..1` ratio, not a `0..100` percentage
 - `maxedTokens` counts tokens currently at usage capacity, not broken credentials
 - for Claude, `maxedTokens` uses the latest provider-reported 5h / 7d utilization against each token's configured reserve
-- for non-Claude providers, `maxedTokens` continues to follow the current durable usage-maxed status until provider-usage telemetry exists there
+- for OpenAI/Codex, `maxedTokens` also treats active tokens as maxed when a stored provider-usage `5h` or `7d` window is exhausted
 
 ### `GET /v1/admin/analytics/timeseries`
 Admin-only chart-series endpoint.
@@ -843,14 +844,14 @@ Notes:
 - returns a best-effort merged snapshot for the UI so summary/tables/anomalies/events share one `snapshotAt`
 - `tokens[*]` merges usage, health, and routing metrics by `credentialId`
 - `tokens[*].attempts` is attempt-level volume; `tokens[*].requests` is distinct `request_id` count for the same window
-- `tokens[*]` also carries the same nullable Claude-only contribution-cap/provider-usage fields as `/v1/admin/analytics/tokens/health`
+- `tokens[*]` also carries the same provider-usage snapshot fields as `/v1/admin/analytics/tokens/health`; reserve / contribution-cap flags stay Claude-only
 - `tokens[*]` may also include best-effort auth-diagnosis fields from `/v1/admin/analytics/tokens/health`; the dashboard status text can fold those into backend-`maxed` visibility
-- `summary.maxedTokens` counts tokens currently at usage capacity; for Claude that means provider usage has hit the provider ceiling or the configured reserve threshold
+- `summary.maxedTokens` counts tokens currently at usage capacity; for Claude that means provider usage has hit the provider ceiling or the configured reserve threshold, and for OpenAI/Codex that means a stored provider-usage window is exhausted
 - the dashboard UI shows raw Claude provider utilization in `5H` / `7D`; reserve/exhausted fields only control whether those cells are highlighted as effectively exhausted
-- non-Claude rows keep those raw API fields `null` and the UI renders `--` in the CAP cells
+- OpenAI/Codex rows may carry raw provider-usage utilization/reset fields, but their reserve / contribution-cap fields stay `null` and the UI still renders `--` in the CAP cells
 - `buyers[*]` may include `latencyP50Ms` and `errorRate` when those buyer aggregates are available
 - snapshot `events` is currently capped to the 20 most recent lifecycle events
-- `warnings` is a free-form operator-facing list for Claude operator issues such as auth-failed parked tokens, missing snapshots, stale snapshots, and contribution-cap exhaustion when the backend emits them
+- `warnings` is a free-form operator-facing list for provider-usage freshness/exhaustion issues; Claude rows can emit auth-failed / cap warnings, and OpenAI/Codex rows can emit snapshot freshness or `usage_exhausted_*` warnings when the backend emits them
 
 Response example:
 ```json

--- a/ui/src/lib/analytics/server.ts
+++ b/ui/src/lib/analytics/server.ts
@@ -345,7 +345,9 @@ function deriveFallbackTokenStatus(input: {
   rateLimitedUntil: string | null;
   consecutiveRateLimitCount?: number | null;
   fiveHourReservePercent?: number | null;
+  fiveHourUtilizationRatio?: number | null;
   sevenDayReservePercent?: number | null;
+  sevenDayUtilizationRatio?: number | null;
   providerUsageFetchedAt?: string | null;
   fiveHourContributionCapExhausted?: boolean | null;
   sevenDayContributionCapExhausted?: boolean | null;
@@ -378,6 +380,20 @@ function deriveFallbackTokenStatus(input: {
       compactStatus: 'maxed',
       expandedStatus: 'maxed, source: cap_exhausted',
       statusSource: 'cap_exhausted',
+      exclusionReason: null,
+    };
+  }
+
+  if (
+    rawStatus === 'active'
+    && provider === 'openai'
+    && ((input.fiveHourUtilizationRatio ?? 0) >= 1 || (input.sevenDayUtilizationRatio ?? 0) >= 1)
+  ) {
+    return {
+      rawStatus,
+      compactStatus: 'maxed',
+      expandedStatus: 'maxed, source: usage_exhausted',
+      statusSource: 'usage_exhausted',
       exclusionReason: null,
     };
   }
@@ -812,7 +828,9 @@ function buildTokenRows(
       rateLimitedUntil,
       consecutiveRateLimitCount: toNullableNumber(health?.consecutiveRateLimitCount),
       fiveHourReservePercent,
+      fiveHourUtilizationRatio,
       sevenDayReservePercent,
+      sevenDayUtilizationRatio,
       providerUsageFetchedAt: toStringOrNull(health?.providerUsageFetchedAt),
       fiveHourContributionCapExhausted,
       sevenDayContributionCapExhausted,


### PR DESCRIPTION
**@worker-01**

## Summary
- derive Codex usage-exhausted dashboard status from stored provider-usage windows
- count active Codex usage-exhausted credentials as maxed in analytics summary/dashboard responses
- surface Codex provider-usage freshness and exhaustion warnings, and align the UI fallback/dashboard docs with the new status source

## Verification
- `cd api && npm test -- tests/dashboardTokenStatus.test.ts tests/analyticsRepository.test.ts tests/analytics.route.test.ts`
- `cd api && npm run build`
- temporary `server-only` stub import check for `ui/src/lib/analytics/server.ts` via `tsx` loader (`ui-server-import-ok`)
