### PR TITLE
feat: add openai provider usage refresh

### DIFF
--- a/api/src/repos/tokenCredentialProviderUsageRepository.ts
+++ b/api/src/repos/tokenCredentialProviderUsageRepository.ts
@@ -1,7 +1,7 @@
 import type { SqlClient, SqlQueryResult, SqlValue } from './sqlClient.js';
 import { TABLES } from './tableNames.js';
 
-export type ProviderUsageSource = 'anthropic_oauth_usage';
+export type ProviderUsageSource = 'anthropic_oauth_usage' | 'openai_wham_usage';
 export type ProviderUsagePayload = Record<string, unknown> | unknown[];
 
 type TokenCredentialProviderUsageRow = {

--- a/api/src/services/tokenCredentialProviderUsage.ts
+++ b/api/src/services/tokenCredentialProviderUsage.ts
@@ -1,10 +1,12 @@
 import { type TokenCredential, type TokenCredentialRepository } from '../repos/tokenCredentialRepository.js';
 import type {
   ProviderUsageSource,
+  ProviderUsagePayload,
   TokenCredentialProviderUsageRepository,
   TokenCredentialProviderUsageSnapshot,
   UpsertTokenCredentialProviderUsageInput
 } from '../repos/tokenCredentialProviderUsageRepository.js';
+import { isOpenAiOauthAccessToken, resolveOpenAiOauthAccountId } from '../utils/openaiOauth.js';
 import {
   clearAnthropicUsageRefreshFailure,
   getAnthropicUsageRetryBackoff,
@@ -21,9 +23,11 @@ const DEFAULT_PROVIDER_USAGE_SOFT_STALE_MS = 2 * 60 * 1000;
 const DEFAULT_PROVIDER_USAGE_HARD_STALE_MS = 10 * 60 * 1000;
 const DEFAULT_RATE_LIMIT_LONG_BACKOFF_MINUTES = 15;
 const DEFAULT_ANTHROPIC_OAUTH_USAGE_USER_AGENT = 'claude-code/2.1.34';
+const DEFAULT_OPENAI_OAUTH_USAGE_USER_AGENT = 'CodexBar';
 
 const ANTHROPIC_OAUTH_USAGE_BETA = 'oauth-2025-04-20';
 const ANTHROPIC_OAUTH_USAGE_PATH = '/api/oauth/usage';
+const OPENAI_OAUTH_USAGE_PATH = '/backend-api/wham/usage';
 const inFlightAnthropicUsageRefreshes = new Map<string, Promise<AnthropicOauthUsageRefreshOutcome>>();
 export const PROVIDER_USAGE_FETCH_FAILED_REASON = 'provider_usage_fetch_failed';
 export const PROVIDER_USAGE_FETCH_BACKOFF_ACTIVE_REASON = 'provider_usage_fetch_backoff_active';
@@ -45,6 +49,20 @@ export type AnthropicOauthUsageRefreshOutcome =
       warningReason: typeof PROVIDER_USAGE_FETCH_FAILED_REASON | null;
       rawPayload?: Record<string, unknown>;
       retryAfterMs?: number;
+      errorMessage?: string;
+    };
+export type OpenAiOauthUsageRefreshOutcome =
+  | {
+      ok: true;
+      snapshot: TokenCredentialProviderUsageSnapshot;
+      rawPayload: ProviderUsagePayload;
+    }
+  | {
+      ok: false;
+      reason: string;
+      statusCode: number | null;
+      category: 'fetch_failed' | 'invalid_payload' | 'snapshot_write_failed';
+      rawPayload?: ProviderUsagePayload;
       errorMessage?: string;
     };
 
@@ -199,6 +217,27 @@ function readDateField(record: Record<string, unknown>, keys: string[]): Date | 
   return null;
 }
 
+function readUnixTimestampField(record: Record<string, unknown>, keys: string[]): Date | null {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return new Date(value * 1000);
+    }
+    if (typeof value === 'string' && value.trim().length > 0) {
+      const parsed = Number(value);
+      if (Number.isFinite(parsed)) {
+        return new Date(parsed * 1000);
+      }
+    }
+  }
+  return null;
+}
+
+function readPayloadForStorage(payload: unknown): ProviderUsagePayload | undefined {
+  if (Array.isArray(payload)) return payload;
+  return readObject(payload) ?? undefined;
+}
+
 function normalizeUtilizationRatio(value: number | null): number | null {
   if (value === null) return null;
   if (value < 0) return 0;
@@ -265,6 +304,46 @@ function parseAnthropicOauthUsagePayload(payload: unknown): {
   }
   return {
     usageSource: 'anthropic_oauth_usage',
+    fiveHourUtilizationRatio: fiveHour.utilizationRatio,
+    fiveHourResetsAt: fiveHour.resetsAt,
+    sevenDayUtilizationRatio: sevenDay.utilizationRatio,
+    sevenDayResetsAt: sevenDay.resetsAt,
+    rawPayload: record
+  };
+}
+
+function readOpenAiWhamWindow(window: Record<string, unknown>): {
+  utilizationRatio: number | null;
+  resetsAt: Date | null;
+} {
+  return {
+    utilizationRatio: normalizeUtilizationRatio(readNumberField(window, ['used_percent', 'usedPercent'])),
+    resetsAt: readUnixTimestampField(window, ['reset_at', 'resetAt']) ?? readDateField(window, ['reset_at', 'resetAt'])
+  };
+}
+
+function parseOpenAiOauthUsagePayload(payload: unknown): {
+  usageSource: ProviderUsageSource;
+  fiveHourUtilizationRatio: number;
+  fiveHourResetsAt: Date | null;
+  sevenDayUtilizationRatio: number;
+  sevenDayResetsAt: Date | null;
+  rawPayload: ProviderUsagePayload;
+} {
+  const record = readObject(payload);
+  if (!record) {
+    throw new Error('invalid_payload:not_object');
+  }
+  const rateLimit = readObject(record.rate_limit);
+  const primaryWindow = rateLimit ? readObject(rateLimit.primary_window) : null;
+  const secondaryWindow = rateLimit ? readObject(rateLimit.secondary_window) : null;
+  const fiveHour = primaryWindow ? readOpenAiWhamWindow(primaryWindow) : { utilizationRatio: null, resetsAt: null };
+  const sevenDay = secondaryWindow ? readOpenAiWhamWindow(secondaryWindow) : { utilizationRatio: null, resetsAt: null };
+  if (fiveHour.utilizationRatio === null || sevenDay.utilizationRatio === null) {
+    throw new Error('invalid_payload:missing_utilization');
+  }
+  return {
+    usageSource: 'openai_wham_usage',
     fiveHourUtilizationRatio: fiveHour.utilizationRatio,
     fiveHourResetsAt: fiveHour.resetsAt,
     sevenDayUtilizationRatio: sevenDay.utilizationRatio,
@@ -342,6 +421,104 @@ async function fetchAnthropicOauthUsagePayload(
       statusCode: null,
       category: 'fetch_failed',
       warningReason: PROVIDER_USAGE_FETCH_FAILED_REASON
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function buildOpenAiOauthUsageHeaders(credential: TokenCredential): Record<string, string> {
+  const headers: Record<string, string> = {
+    authorization: `Bearer ${credential.accessToken}`,
+    accept: 'application/json',
+    'user-agent': process.env.OPENAI_OAUTH_USAGE_USER_AGENT?.trim() || DEFAULT_OPENAI_OAUTH_USAGE_USER_AGENT
+  };
+  const accountId = resolveOpenAiOauthAccountId(credential.accessToken);
+  if (accountId) {
+    headers['chatgpt-account-id'] = accountId;
+  }
+  return headers;
+}
+
+async function fetchOpenAiOauthUsagePayload(
+  credential: TokenCredential,
+  timeoutMs: number
+): Promise<OpenAiOauthUsageRefreshOutcome> {
+  if (
+    (credential.provider !== 'openai' && credential.provider !== 'codex')
+    || !isOpenAiOauthAccessToken(credential.accessToken)
+  ) {
+    return {
+      ok: false,
+      reason: 'unsupported_credential',
+      statusCode: null,
+      category: 'fetch_failed'
+    };
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(new URL(OPENAI_OAUTH_USAGE_PATH, 'https://chatgpt.com'), {
+      method: 'GET',
+      headers: buildOpenAiOauthUsageHeaders(credential),
+      signal: controller.signal
+    });
+
+    let payload: unknown = {};
+    try {
+      payload = await response.json();
+    } catch {
+      payload = {};
+    }
+    const rawPayload = readPayloadForStorage(payload);
+
+    if (!response.ok) {
+      return {
+        ok: false,
+        reason: `status_${response.status}`,
+        statusCode: response.status,
+        category: 'fetch_failed',
+        rawPayload
+      };
+    }
+
+    try {
+      const parsed = parseOpenAiOauthUsagePayload(payload);
+      return {
+        ok: true,
+        snapshot: {
+          tokenCredentialId: credential.id,
+          orgId: credential.orgId,
+          provider: 'openai',
+          usageSource: parsed.usageSource,
+          fiveHourUtilizationRatio: parsed.fiveHourUtilizationRatio,
+          fiveHourResetsAt: parsed.fiveHourResetsAt,
+          sevenDayUtilizationRatio: parsed.sevenDayUtilizationRatio,
+          sevenDayResetsAt: parsed.sevenDayResetsAt,
+          rawPayload: parsed.rawPayload,
+          fetchedAt: new Date(),
+          createdAt: new Date(),
+          updatedAt: new Date()
+        },
+        rawPayload: parsed.rawPayload
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        reason: error instanceof Error ? error.message : 'invalid_payload',
+        statusCode: response.status,
+        category: 'invalid_payload',
+        rawPayload
+      };
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'provider_usage_fetch_error';
+    return {
+      ok: false,
+      reason: `network:${message}`,
+      statusCode: null,
+      category: 'fetch_failed'
     };
   } finally {
     clearTimeout(timer);
@@ -430,6 +607,51 @@ export async function refreshAnthropicOauthUsageNow(
     return await refreshPromise;
   } finally {
     inFlightAnthropicUsageRefreshes.delete(credential.id);
+  }
+}
+
+export async function refreshOpenAiOauthUsageNow(
+  repo: TokenCredentialProviderUsageRepository,
+  credential: TokenCredential,
+  options?: {
+    timeoutMs?: number;
+  }
+): Promise<OpenAiOauthUsageRefreshOutcome> {
+  const fetched = await fetchOpenAiOauthUsagePayload(
+    credential,
+    options?.timeoutMs ?? readTokenCredentialProviderUsageTimeoutMs()
+  );
+  if (!fetched.ok) {
+    return fetched;
+  }
+
+  try {
+    const snapshot = await repo.upsertSnapshot({
+      tokenCredentialId: credential.id,
+      orgId: credential.orgId,
+      provider: 'openai',
+      usageSource: fetched.snapshot.usageSource,
+      fiveHourUtilizationRatio: fetched.snapshot.fiveHourUtilizationRatio,
+      fiveHourResetsAt: fetched.snapshot.fiveHourResetsAt,
+      sevenDayUtilizationRatio: fetched.snapshot.sevenDayUtilizationRatio,
+      sevenDayResetsAt: fetched.snapshot.sevenDayResetsAt,
+      rawPayload: fetched.rawPayload,
+      fetchedAt: fetched.snapshot.fetchedAt
+    });
+
+    return {
+      ok: true,
+      snapshot,
+      rawPayload: fetched.rawPayload
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      reason: 'provider_usage_snapshot_write_failed',
+      statusCode: null,
+      category: 'snapshot_write_failed',
+      errorMessage: error instanceof Error ? error.message : 'snapshot_write_failed'
+    };
   }
 }
 

--- a/api/tests/tokenCredentialProviderUsage.test.ts
+++ b/api/tests/tokenCredentialProviderUsage.test.ts
@@ -1,0 +1,266 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { TokenCredential } from '../src/repos/tokenCredentialRepository.js';
+import { refreshOpenAiOauthUsageNow } from '../src/services/tokenCredentialProviderUsage.js';
+
+function createFakeOpenAiOauthToken(input?: {
+  accountId?: string;
+  clientId?: string;
+  exp?: number;
+}): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'RS256', typ: 'JWT' })).toString('base64url');
+  const payload = Buffer.from(JSON.stringify({
+    iss: 'https://auth.openai.com',
+    aud: ['https://api.openai.com/v1'],
+    client_id: input?.clientId ?? 'app_test_codex',
+    exp: input?.exp ?? Math.floor(Date.now() / 1000) + 3600,
+    'https://api.openai.com/auth': {
+      chatgpt_account_id: input?.accountId ?? 'acct_codex_usage'
+    }
+  })).toString('base64url');
+  return `${header}.${payload}.signature`;
+}
+
+function createCredential(overrides?: Partial<TokenCredential>): TokenCredential {
+  return {
+    id: 'cred_openai_1',
+    orgId: '00000000-0000-0000-0000-000000000001',
+    provider: 'openai',
+    authScheme: 'bearer',
+    accessToken: createFakeOpenAiOauthToken(),
+    refreshToken: null,
+    expiresAt: new Date('2026-03-20T00:00:00Z'),
+    status: 'active',
+    rotationVersion: 1,
+    createdAt: new Date('2026-03-01T00:00:00Z'),
+    updatedAt: new Date('2026-03-01T00:00:00Z'),
+    revokedAt: null,
+    monthlyContributionLimitUnits: null,
+    monthlyContributionUsedUnits: 0,
+    monthlyWindowStartAt: new Date('2026-03-01T00:00:00Z'),
+    fiveHourReservePercent: 0,
+    sevenDayReservePercent: 0,
+    debugLabel: 'codex-oauth-main',
+    consecutiveFailureCount: 0,
+    consecutiveRateLimitCount: 0,
+    lastFailedStatus: null,
+    lastFailedAt: null,
+    lastRateLimitedAt: null,
+    maxedAt: null,
+    rateLimitedUntil: null,
+    nextProbeAt: null,
+    lastProbeAt: null,
+    ...overrides
+  };
+}
+
+function createUsageRepo() {
+  return {
+    upsertSnapshot: vi.fn(async (input: any) => ({
+      tokenCredentialId: input.tokenCredentialId,
+      orgId: input.orgId,
+      provider: input.provider,
+      usageSource: input.usageSource,
+      fiveHourUtilizationRatio: input.fiveHourUtilizationRatio,
+      fiveHourResetsAt: input.fiveHourResetsAt,
+      sevenDayUtilizationRatio: input.sevenDayUtilizationRatio,
+      sevenDayResetsAt: input.sevenDayResetsAt,
+      rawPayload: input.rawPayload,
+      fetchedAt: input.fetchedAt,
+      createdAt: input.fetchedAt,
+      updatedAt: input.fetchedAt
+    }))
+  };
+}
+
+describe('refreshOpenAiOauthUsageNow', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetches openai oauth usage with bearer auth and chatgpt-account-id when derivable', async () => {
+    const credential = createCredential({
+      accessToken: createFakeOpenAiOauthToken({ accountId: 'acct_codex_live' })
+    });
+    const usageRepo = createUsageRepo();
+    const payload = {
+      rate_limit: {
+        primary_window: {
+          used_percent: 7,
+          limit_window_seconds: 18_000,
+          reset_at: 1_773_888_569
+        },
+        secondary_window: {
+          used_percent: 12,
+          limit_window_seconds: 604_800,
+          reset_at: 1_774_457_367
+        }
+      }
+    };
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { 'content-type': 'application/json' }
+      })
+    );
+
+    const outcome = await refreshOpenAiOauthUsageNow(usageRepo as any, credential, { timeoutMs: 50 });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [targetUrl, init] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+    const headers = (init.headers as Record<string, string>) ?? {};
+    expect(String(targetUrl)).toBe('https://chatgpt.com/backend-api/wham/usage');
+    expect((init.method ?? '').toUpperCase()).toBe('GET');
+    expect(headers.authorization).toBe(`Bearer ${credential.accessToken}`);
+    expect(headers.accept).toBe('application/json');
+    expect(headers['user-agent']).toBe('CodexBar');
+    expect(headers['chatgpt-account-id']).toBe('acct_codex_live');
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) {
+      throw new Error('expected openai usage refresh to succeed');
+    }
+    expect(outcome.snapshot.usageSource).toBe('openai_wham_usage');
+    expect(outcome.rawPayload).toEqual(payload);
+  });
+
+  it('normalizes primary and secondary wham windows into canonical openai snapshots', async () => {
+    const credential = createCredential({
+      provider: 'codex',
+      accessToken: createFakeOpenAiOauthToken({ accountId: 'acct_codex_usage_live' })
+    });
+    const usageRepo = createUsageRepo();
+    const payload = {
+      user_id: 'user_1',
+      rate_limit: {
+        allowed: true,
+        limit_reached: false,
+        primary_window: {
+          used_percent: 7,
+          limit_window_seconds: 18_000,
+          reset_after_seconds: 14_704,
+          reset_at: 1_773_888_569
+        },
+        secondary_window: {
+          used_percent: 12,
+          limit_window_seconds: 604_800,
+          reset_after_seconds: 583_502,
+          reset_at: 1_774_457_367
+        }
+      },
+      additional_rate_limits: [{
+        limit_name: 'GPT-5.3-Codex-Spark',
+        rate_limit: {
+          primary_window: {
+            used_percent: 0,
+            limit_window_seconds: 18_000,
+            reset_at: 1_773_891_865
+          },
+          secondary_window: {
+            used_percent: 0,
+            limit_window_seconds: 604_800,
+            reset_at: 1_774_478_665
+          }
+        }
+      }]
+    };
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { 'content-type': 'application/json' }
+      })
+    );
+
+    const outcome = await refreshOpenAiOauthUsageNow(usageRepo as any, credential, { timeoutMs: 50 });
+
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) {
+      throw new Error('expected openai usage refresh to succeed');
+    }
+    expect(usageRepo.upsertSnapshot).toHaveBeenCalledWith(expect.objectContaining({
+      provider: 'openai',
+      usageSource: 'openai_wham_usage',
+      fiveHourUtilizationRatio: 0.07,
+      sevenDayUtilizationRatio: 0.12,
+      rawPayload: payload
+    }));
+    expect(outcome.snapshot.provider).toBe('openai');
+    expect(outcome.snapshot.fiveHourResetsAt?.toISOString()).toBe(new Date(1_773_888_569 * 1000).toISOString());
+    expect(outcome.snapshot.sevenDayResetsAt?.toISOString()).toBe(new Date(1_774_457_367 * 1000).toISOString());
+    expect(outcome.snapshot.rawPayload).toEqual(payload);
+  });
+
+  it('returns invalid_payload when the wham usage payload is missing the mapped windows', async () => {
+    const credential = createCredential();
+    const usageRepo = createUsageRepo();
+    const payload = {
+      rate_limit: {
+        primary_window: {
+          limit_window_seconds: 18_000,
+          reset_at: 1_773_888_569
+        },
+        secondary_window: null
+      }
+    };
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { 'content-type': 'application/json' }
+      })
+    );
+
+    const outcome = await refreshOpenAiOauthUsageNow(usageRepo as any, credential, { timeoutMs: 50 });
+
+    expect(outcome).toMatchObject({
+      ok: false,
+      category: 'invalid_payload',
+      reason: 'invalid_payload:missing_utilization',
+      statusCode: 200,
+      rawPayload: payload
+    });
+    expect(usageRepo.upsertSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('surfaces upstream auth failures distinctly enough for callers to act on', async () => {
+    const credential = createCredential();
+    const usageRepo = createUsageRepo();
+    const payload = {
+      detail: 'token expired'
+    };
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(payload), {
+        status: 401,
+        headers: { 'content-type': 'application/json' }
+      })
+    );
+
+    const outcome = await refreshOpenAiOauthUsageNow(usageRepo as any, credential, { timeoutMs: 50 });
+
+    expect(outcome).toMatchObject({
+      ok: false,
+      category: 'fetch_failed',
+      reason: 'status_401',
+      statusCode: 401,
+      rawPayload: payload
+    });
+    expect(usageRepo.upsertSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('rejects unsupported non-session openai credentials without calling chatgpt usage', async () => {
+    const credential = createCredential({
+      provider: 'openai',
+      accessToken: 'openai-api-key'
+    });
+    const usageRepo = createUsageRepo();
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    const outcome = await refreshOpenAiOauthUsageNow(usageRepo as any, credential, { timeoutMs: 50 });
+
+    expect(outcome).toMatchObject({
+      ok: false,
+      category: 'fetch_failed',
+      reason: 'unsupported_credential',
+      statusCode: null
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(usageRepo.upsertSnapshot).not.toHaveBeenCalled();
+  });
+});

--- a/api/tests/tokenCredentialProviderUsageRepository.test.ts
+++ b/api/tests/tokenCredentialProviderUsageRepository.test.ts
@@ -67,6 +67,45 @@ describe('tokenCredentialProviderUsageRepository', () => {
     expect(db.queries[0].sql).toContain('on conflict (token_credential_id)');
   });
 
+  it('persists openai provider-usage snapshots with a distinct usage source', async () => {
+    const db = new SequenceSqlClient([{
+      rows: [{
+        token_credential_id: 'cred_openai_1',
+        org_id: '00000000-0000-0000-0000-000000000001',
+        provider: 'openai',
+        usage_source: 'openai_wham_usage',
+        five_hour_utilization_ratio: '0.07',
+        five_hour_resets_at: '2026-03-18T04:49:29Z',
+        seven_day_utilization_ratio: '0.12',
+        seven_day_resets_at: '2026-03-24T18:49:27Z',
+        raw_payload: { rate_limit: { primary_window: { used_percent: 7 } } },
+        fetched_at: '2026-03-18T00:00:00Z',
+        created_at: '2026-03-18T00:00:00Z',
+        updated_at: '2026-03-18T00:00:00Z'
+      }],
+      rowCount: 1
+    }]);
+    const repo = new TokenCredentialProviderUsageRepository(db);
+
+    const snapshot = await repo.upsertSnapshot({
+      tokenCredentialId: 'cred_openai_1',
+      orgId: '00000000-0000-0000-0000-000000000001',
+      provider: 'openai',
+      usageSource: 'openai_wham_usage',
+      fiveHourUtilizationRatio: 0.07,
+      fiveHourResetsAt: new Date('2026-03-18T04:49:29Z'),
+      sevenDayUtilizationRatio: 0.12,
+      sevenDayResetsAt: new Date('2026-03-24T18:49:27Z'),
+      rawPayload: { rate_limit: { primary_window: { used_percent: 7 } } },
+      fetchedAt: new Date('2026-03-18T00:00:00Z')
+    });
+
+    expect(snapshot.provider).toBe('openai');
+    expect(snapshot.usageSource).toBe('openai_wham_usage');
+    expect(db.queries[0].params?.[2]).toBe('openai');
+    expect(db.queries[0].params?.[3]).toBe('openai_wham_usage');
+  });
+
   it('reads latest provider-usage snapshot by token credential id', async () => {
     const db = new SequenceSqlClient([{
       rows: [{

--- a/docs/onboarding/CLAUDE_CODEX_OAUTH_TOKENS.md
+++ b/docs/onboarding/CLAUDE_CODEX_OAUTH_TOKENS.md
@@ -35,12 +35,16 @@ Use this to get your own Claude or Codex/OpenAI login into a form an Innies admi
 1. Log in:
 
    ```bash
-   codex --login
+   codex login
    ```
 
-2. Confirm Codex stays logged in when you reopen it.
+2. Confirm Codex stays logged in when you reopen it. A quick sanity check is:
 
-3. Open:
+   ```bash
+   codex login status
+   ```
+
+3. Current Codex CLI builds store the login session in:
 
    ```text
    ~/.codex/auth.json
@@ -67,4 +71,4 @@ Codex:
 ## Quick Fixes
 - `claude` opens Innies instead of Claude Code: run `which -a claude` and use the non-wrapper path.
 - You cannot find the Claude token on macOS: check Keychain Access.
-- `~/.codex/auth.json` is missing: re-run `codex --login`.
+- `~/.codex/auth.json` is missing: re-run `codex login`. If `codex login status` still shows a logged-in session but the file is absent, your Codex build may be storing auth elsewhere, so confirm the current storage path before extracting tokens manually.


### PR DESCRIPTION
**@worker-03**

## Summary
- add an OpenAI/Codex provider-usage refresh path against ChatGPT `wham/usage`
- persist canonical `provider="openai"` snapshots with distinct `openai_wham_usage` source and untouched raw payloads
- cover request headers, window mapping, invalid payloads, auth failures, and repository persistence in focused tests

## Testing
- `npx vitest run api/tests/tokenCredentialProviderUsageRepository.test.ts api/tests/tokenCredentialProviderUsage.test.ts`
- `npm --prefix api run build`
