### PR TITLE
Exclude usage-exhausted Codex credentials from pooled routing

### DIFF
--- a/api/src/routes/proxy.ts
+++ b/api/src/routes/proxy.ts
@@ -4,6 +4,7 @@ import { Router, type Response } from 'express';
 import { z } from 'zod';
 import { requireApiKey } from '../middleware/auth.js';
 import type { TokenCredential } from '../repos/tokenCredentialRepository.js';
+import type { TokenCredentialProviderUsageSnapshot } from '../repos/tokenCredentialProviderUsageRepository.js';
 import { runtime } from '../services/runtime.js';
 import type { IdempotencySession } from '../services/idempotencyService.js';
 import { AppError } from '../utils/errors.js';
@@ -38,7 +39,10 @@ import {
   providerUsageWarningReasonFromRefreshOutcome,
   readTokenCredentialRateLimitLongBackoffMinutes
 } from '../services/tokenCredentialProviderUsage.js';
-import { readClaudeContributionCapSnapshotState } from '../services/claudeContributionCapState.js';
+import {
+  readClaudeContributionCapSnapshotState,
+  readClaudeProviderUsageExhaustionHoldState
+} from '../services/claudeContributionCapState.js';
 import {
   attemptTokenCredentialRefresh,
   refreshAnthropicOauthUsageWithCredentialRefresh
@@ -160,6 +164,79 @@ function findUniqueBuyerLabelMatchedCredentialId(
 
 function isProviderUsageWindowExhausted(utilizationRatio: unknown): boolean {
   return typeof utilizationRatio === 'number' && utilizationRatio >= 1;
+}
+
+function evaluateOpenAiProviderUsageEligibility(input: {
+  credential: TokenCredential;
+  snapshot: TokenCredentialProviderUsageSnapshot | null;
+  now?: Date;
+}): {
+  inScope: boolean;
+  eligible: boolean;
+  exclusionReason: 'usage_exhausted_5h' | 'usage_exhausted_7d' | null;
+  routeDecisionMeta: Record<string, unknown>;
+} {
+  const inScope = canonicalizeProvider(input.credential.provider) === 'openai';
+  if (!inScope) {
+    return {
+      inScope,
+      eligible: true,
+      exclusionReason: null,
+      routeDecisionMeta: {
+        openaiProviderUsageInScope: false
+      }
+    };
+  }
+
+  if (!input.snapshot) {
+    return {
+      inScope,
+      eligible: true,
+      exclusionReason: null,
+      routeDecisionMeta: {
+        openaiProviderUsageInScope: true,
+        providerUsageSnapshotState: 'missing',
+        providerUsageFetchedAt: null,
+        fiveHourUtilizationRatio: null,
+        fiveHourResetsAt: null,
+        fiveHourProviderUsageExhausted: false,
+        sevenDayUtilizationRatio: null,
+        sevenDayResetsAt: null,
+        sevenDayProviderUsageExhausted: false,
+        providerUsageExhaustionReason: null,
+        providerUsageExhaustionHoldActive: false,
+        providerUsageExhaustionHoldUntil: null
+      }
+    };
+  }
+
+  const exhaustionHold = readClaudeProviderUsageExhaustionHoldState({
+    fiveHourUtilizationRatio: input.snapshot.fiveHourUtilizationRatio,
+    fiveHourResetsAt: input.snapshot.fiveHourResetsAt,
+    sevenDayUtilizationRatio: input.snapshot.sevenDayUtilizationRatio,
+    sevenDayResetsAt: input.snapshot.sevenDayResetsAt,
+    now: input.now
+  });
+
+  return {
+    inScope,
+    eligible: !exhaustionHold.hasActiveHold,
+    exclusionReason: exhaustionHold.reason,
+    routeDecisionMeta: {
+      openaiProviderUsageInScope: true,
+      providerUsageSnapshotState: 'fresh',
+      providerUsageFetchedAt: input.snapshot.fetchedAt.toISOString(),
+      fiveHourUtilizationRatio: input.snapshot.fiveHourUtilizationRatio,
+      fiveHourResetsAt: input.snapshot.fiveHourResetsAt?.toISOString() ?? null,
+      fiveHourProviderUsageExhausted: exhaustionHold.fiveHourProviderUsageExhausted,
+      sevenDayUtilizationRatio: input.snapshot.sevenDayUtilizationRatio,
+      sevenDayResetsAt: input.snapshot.sevenDayResetsAt?.toISOString() ?? null,
+      sevenDayProviderUsageExhausted: exhaustionHold.sevenDayProviderUsageExhausted,
+      providerUsageExhaustionReason: exhaustionHold.reason,
+      providerUsageExhaustionHoldActive: exhaustionHold.hasActiveHold,
+      providerUsageExhaustionHoldUntil: exhaustionHold.nextRefreshAt?.toISOString() ?? null
+    }
+  };
 }
 
 function buildRequestId(headerValue: string | undefined): string {
@@ -881,22 +958,25 @@ async function resolveEligibleTokenCredentials(input: {
   credentials: TokenCredential[];
   providerUsageRouteMeta: Map<string, Record<string, unknown>>;
   providerUsageExcludedReasonCounts: Record<string, number>;
+  providerUsageExcludedRouteMeta: Record<string, Record<string, unknown>>;
 }> {
+  const canonicalProvider = canonicalizeProvider(input.provider);
   const seededCredentials = orderCredentialsForRequest(
     await runtime.repos.tokenCredentials.listActiveForRouting(input.orgId, input.provider),
     input.requestId
   );
-  const buyerLabelMatchedCredentialId = canonicalizeProvider(input.provider) === 'anthropic'
+  const buyerLabelMatchedCredentialId = canonicalProvider === 'anthropic'
     ? findUniqueBuyerLabelMatchedCredentialId(seededCredentials, input.buyerKeyLabel)
     : null;
   const orderedCredentials = seededCredentials;
 
   const providerUsageRouteMeta = new Map<string, Record<string, unknown>>();
-  if (canonicalizeProvider(input.provider) !== 'anthropic' || orderedCredentials.length === 0) {
+  if ((canonicalProvider !== 'anthropic' && canonicalProvider !== 'openai') || orderedCredentials.length === 0) {
     return {
       credentials: orderedCredentials,
       providerUsageRouteMeta,
-      providerUsageExcludedReasonCounts: {}
+      providerUsageExcludedReasonCounts: {},
+      providerUsageExcludedRouteMeta: {}
     };
   }
 
@@ -906,9 +986,29 @@ async function resolveEligibleTokenCredentials(input: {
   const snapshotsByCredentialId = new Map(snapshots.map((snapshot) => [snapshot.tokenCredentialId, snapshot]));
   const eligibleCredentials: TokenCredential[] = [];
   const providerUsageExcludedReasonCounts: Record<string, number> = {};
+  const providerUsageExcludedRouteMeta: Record<string, Record<string, unknown>> = {};
   const rateLimitEscalationThreshold = tokenCredentialRateLimitThreshold();
 
   for (const credential of orderedCredentials) {
+    if (canonicalProvider === 'openai') {
+      const evaluation = evaluateOpenAiProviderUsageEligibility({
+        credential,
+        snapshot: snapshotsByCredentialId.get(credential.id) ?? null
+      });
+      if (evaluation.inScope) {
+        providerUsageRouteMeta.set(credential.id, evaluation.routeDecisionMeta);
+      }
+      if (!evaluation.eligible) {
+        const reason = evaluation.exclusionReason ?? 'provider_usage_unknown';
+        providerUsageExcludedReasonCounts[reason] = (providerUsageExcludedReasonCounts[reason] ?? 0) + 1;
+        providerUsageExcludedRouteMeta[credential.id] = evaluation.routeDecisionMeta;
+        continue;
+      }
+
+      eligibleCredentials.push(credential);
+      continue;
+    }
+
     const evaluation = evaluateClaudeContributionCap({
       credential,
       snapshot: snapshotsByCredentialId.get(credential.id) ?? null
@@ -941,6 +1041,9 @@ async function resolveEligibleTokenCredentials(input: {
     if (!evaluation.eligible && !buyerLabelAffinityBypassApplied) {
       const reason = evaluation.exclusionReason ?? 'provider_usage_unknown';
       providerUsageExcludedReasonCounts[reason] = (providerUsageExcludedReasonCounts[reason] ?? 0) + 1;
+      if (providerUsageRouteMeta.has(credential.id)) {
+        providerUsageExcludedRouteMeta[credential.id] = providerUsageRouteMeta.get(credential.id) as Record<string, unknown>;
+      }
       continue;
     }
 
@@ -948,6 +1051,9 @@ async function resolveEligibleTokenCredentials(input: {
       providerUsageExcludedReasonCounts[CLAUDE_REPEATED_429_LOCAL_BACKOFF_REASON] = (
         providerUsageExcludedReasonCounts[CLAUDE_REPEATED_429_LOCAL_BACKOFF_REASON] ?? 0
       ) + 1;
+      if (providerUsageRouteMeta.has(credential.id)) {
+        providerUsageExcludedRouteMeta[credential.id] = providerUsageRouteMeta.get(credential.id) as Record<string, unknown>;
+      }
       continue;
     }
 
@@ -957,7 +1063,8 @@ async function resolveEligibleTokenCredentials(input: {
   return {
     credentials: eligibleCredentials,
     providerUsageRouteMeta,
-    providerUsageExcludedReasonCounts
+    providerUsageExcludedReasonCounts,
+    providerUsageExcludedRouteMeta
   };
 }
 
@@ -2017,7 +2124,8 @@ async function executeTokenModeNonStreaming(input: {
   const {
     credentials,
     providerUsageRouteMeta,
-    providerUsageExcludedReasonCounts
+    providerUsageExcludedReasonCounts,
+    providerUsageExcludedRouteMeta
   } = await resolveEligibleTokenCredentials({
     orgId,
     provider,
@@ -2030,6 +2138,9 @@ async function executeTokenModeNonStreaming(input: {
       model,
       providerUsageExcludedReasonCounts: Object.keys(providerUsageExcludedReasonCounts).length > 0
         ? providerUsageExcludedReasonCounts
+        : undefined,
+      providerUsageExcludedRouteMeta: Object.keys(providerUsageExcludedRouteMeta).length > 0
+        ? providerUsageExcludedRouteMeta
         : undefined
     });
   }
@@ -2690,7 +2801,8 @@ async function executeTokenModeStreaming(input: {
   const {
     credentials,
     providerUsageRouteMeta,
-    providerUsageExcludedReasonCounts
+    providerUsageExcludedReasonCounts,
+    providerUsageExcludedRouteMeta
   } = await resolveEligibleTokenCredentials({
     orgId,
     provider,
@@ -2703,6 +2815,9 @@ async function executeTokenModeStreaming(input: {
       model,
       providerUsageExcludedReasonCounts: Object.keys(providerUsageExcludedReasonCounts).length > 0
         ? providerUsageExcludedReasonCounts
+        : undefined,
+      providerUsageExcludedRouteMeta: Object.keys(providerUsageExcludedRouteMeta).length > 0
+        ? providerUsageExcludedRouteMeta
         : undefined
     });
   }

--- a/api/tests/proxy.tokenMode.route.test.ts
+++ b/api/tests/proxy.tokenMode.route.test.ts
@@ -2003,6 +2003,198 @@ describe('proxy token-mode route behavior', () => {
     expect(upstreamSpy).toHaveBeenCalledTimes(2);
   });
 
+  it('skips usage-exhausted Codex credentials and surfaces the reset hold metadata', async () => {
+    process.env.TOKEN_MODE_ENABLED_ORGS = '818d0cc7-7ed2-469f-b690-a977e72a921d';
+    const oauthToken = createFakeOpenAiOauthToken({ accountId: 'acct_codex_exhausted' });
+    const exhaustedUntil = new Date(Date.now() + (60 * 60 * 1000));
+    const sevenDayResetAt = new Date(Date.now() + (72 * 60 * 60 * 1000));
+    const fetchedAt = new Date(Date.now() - (15 * 60 * 1000));
+    vi.spyOn(runtimeModule.runtime.repos.apiKeys, 'findActiveByHash').mockResolvedValue({
+      id: '11111111-1111-4111-8111-111111111111',
+      org_id: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      scope: 'buyer_proxy',
+      is_active: true,
+      expires_at: null,
+      preferred_provider: 'openai'
+    } as any);
+    vi.spyOn(runtimeModule.runtime.repos.modelCompatibility, 'findActive').mockResolvedValue({
+      provider: 'openai',
+      model: 'gpt-5.4',
+      supports_streaming: false
+    } as any);
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'listActiveForRouting').mockResolvedValue([{
+      id: 'dddd2222-0000-4000-8000-000000000000',
+      orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      provider: 'openai',
+      authScheme: 'bearer',
+      accessToken: oauthToken,
+      refreshToken: 'rt_codex_exhausted',
+      expiresAt: new Date('2026-03-20T00:00:00Z'),
+      status: 'active',
+      rotationVersion: 1,
+      createdAt: new Date('2026-03-01T00:00:00Z'),
+      updatedAt: new Date('2026-03-01T00:00:00Z'),
+      revokedAt: null,
+      monthlyContributionLimitUnits: null,
+      monthlyContributionUsedUnits: 0,
+      monthlyWindowStartAt: new Date('2026-03-01T00:00:00Z')
+    } as any]);
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentialProviderUsage, 'listByTokenCredentialIds').mockResolvedValue([{
+      tokenCredentialId: 'dddd2222-0000-4000-8000-000000000000',
+      orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      provider: 'openai',
+      usageSource: 'openai_chatgpt_usage',
+      fiveHourUtilizationRatio: 1,
+      fiveHourResetsAt: exhaustedUntil,
+      sevenDayUtilizationRatio: 0.42,
+      sevenDayResetsAt: sevenDayResetAt,
+      rawPayload: {
+        five_hour: { utilization: 1, resets_at: exhaustedUntil.toISOString() },
+        seven_day: { utilization: 0.42, resets_at: sevenDayResetAt.toISOString() }
+      },
+      fetchedAt,
+      createdAt: fetchedAt,
+      updatedAt: fetchedAt
+    } as any]);
+    const upstreamSpy = vi.spyOn(globalThis, 'fetch');
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/proxy/v1/responses',
+      headers: {
+        authorization: 'Bearer in_test_token',
+        'content-type': 'application/json',
+        'idempotency-key': 'abcdefghijklmnopqrstuvwxyz123456',
+        'x-innies-provider-pin': 'true'
+      },
+      body: {
+        provider: 'codex',
+        model: 'gpt-5.4',
+        streaming: false,
+        payload: { model: 'gpt-5.4', input: 'hello' }
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(handlers[0], req, res);
+    await invoke(handlers[1], req, res);
+
+    expect(res.statusCode).toBe(429);
+    expect((res.body as any).code).toBe('capacity_unavailable');
+    expect((res.body as any).details?.providerUsageExcludedReasonCounts).toEqual({
+      usage_exhausted_5h: 1
+    });
+    expect((res.body as any).details?.providerUsageExcludedRouteMeta?.['dddd2222-0000-4000-8000-000000000000']).toEqual(
+      expect.objectContaining({
+        openaiProviderUsageInScope: true,
+        providerUsageSnapshotState: 'fresh',
+        fiveHourUtilizationRatio: 1,
+        fiveHourResetsAt: exhaustedUntil.toISOString(),
+        fiveHourProviderUsageExhausted: true,
+        providerUsageExhaustionReason: 'usage_exhausted_5h',
+        providerUsageExhaustionHoldActive: true,
+        providerUsageExhaustionHoldUntil: exhaustedUntil.toISOString()
+      })
+    );
+    expect(upstreamSpy).not.toHaveBeenCalled();
+  });
+
+  it('keeps healthy Codex credentials routable and records provider-usage routing metadata', async () => {
+    process.env.TOKEN_MODE_ENABLED_ORGS = '818d0cc7-7ed2-469f-b690-a977e72a921d';
+    const oauthToken = createFakeOpenAiOauthToken({ accountId: 'acct_codex_healthy' });
+    vi.spyOn(runtimeModule.runtime.repos.apiKeys, 'findActiveByHash').mockResolvedValue({
+      id: '11111111-1111-4111-8111-111111111111',
+      org_id: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      scope: 'buyer_proxy',
+      is_active: true,
+      expires_at: null,
+      preferred_provider: 'openai'
+    } as any);
+    vi.spyOn(runtimeModule.runtime.repos.modelCompatibility, 'findActive').mockResolvedValue({
+      provider: 'openai',
+      model: 'gpt-5.4',
+      supports_streaming: false
+    } as any);
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'listActiveForRouting').mockResolvedValue([{
+      id: 'dddd3333-0000-4000-8000-000000000000',
+      orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      provider: 'openai',
+      authScheme: 'bearer',
+      accessToken: oauthToken,
+      refreshToken: 'rt_codex_healthy',
+      expiresAt: new Date('2026-03-20T00:00:00Z'),
+      status: 'active',
+      rotationVersion: 1,
+      createdAt: new Date('2026-03-01T00:00:00Z'),
+      updatedAt: new Date('2026-03-01T00:00:00Z'),
+      revokedAt: null,
+      monthlyContributionLimitUnits: null,
+      monthlyContributionUsedUnits: 0,
+      monthlyWindowStartAt: new Date('2026-03-01T00:00:00Z')
+    } as any]);
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentialProviderUsage, 'listByTokenCredentialIds').mockResolvedValue([{
+      tokenCredentialId: 'dddd3333-0000-4000-8000-000000000000',
+      orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      provider: 'openai',
+      usageSource: 'openai_chatgpt_usage',
+      fiveHourUtilizationRatio: 0.62,
+      fiveHourResetsAt: new Date('2026-03-19T01:00:00.000Z'),
+      sevenDayUtilizationRatio: 0.14,
+      sevenDayResetsAt: new Date('2026-03-22T00:00:00.000Z'),
+      rawPayload: {
+        five_hour: { utilization: 0.62, resets_at: '2026-03-19T01:00:00.000Z' },
+        seven_day: { utilization: 0.14, resets_at: '2026-03-22T00:00:00.000Z' }
+      },
+      fetchedAt: new Date('2026-03-18T22:31:00.000Z'),
+      createdAt: new Date('2026-03-18T22:31:00.000Z'),
+      updatedAt: new Date('2026-03-18T22:31:00.000Z')
+    } as any]);
+    const upstreamSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ id: 'resp_codex_healthy_ok' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' }
+      })
+    );
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/proxy/v1/responses',
+      headers: {
+        authorization: 'Bearer in_test_token',
+        'content-type': 'application/json',
+        'idempotency-key': 'abcdefghijklmnopqrstuvwxyz123456',
+        'x-innies-provider-pin': 'true'
+      },
+      body: {
+        provider: 'codex',
+        model: 'gpt-5.4',
+        streaming: false,
+        payload: { model: 'gpt-5.4', input: 'hello', store: true }
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(handlers[0], req, res);
+    await invoke(handlers[1], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect((res.body as any).id).toBe('resp_codex_healthy_ok');
+    expect(runtimeModule.runtime.repos.routingEvents.insert).toHaveBeenCalledWith(expect.objectContaining({
+      routeDecision: expect.objectContaining({
+        openaiProviderUsageInScope: true,
+        providerUsageSnapshotState: 'fresh',
+        fiveHourUtilizationRatio: 0.62,
+        fiveHourResetsAt: '2026-03-19T01:00:00.000Z',
+        sevenDayUtilizationRatio: 0.14,
+        sevenDayResetsAt: '2026-03-22T00:00:00.000Z',
+        providerUsageExhaustionReason: null,
+        providerUsageExhaustionHoldActive: false,
+        providerUsageExhaustionHoldUntil: null
+      })
+    }));
+    expect(upstreamSpy).toHaveBeenCalledTimes(1);
+  });
+
   it('routes standard openai credentials with bearer auth and openai upstream base URL', async () => {
     process.env.TOKEN_MODE_ENABLED_ORGS = '818d0cc7-7ed2-469f-b690-a977e72a921d';
     process.env.OPENAI_UPSTREAM_BASE_URL = 'https://openai.internal.test';


### PR DESCRIPTION
**@worker-02**

## Summary
- exclude pooled OpenAI/Codex credentials when stored provider-usage windows are still exhausted and on hold
- include excluded-route metadata in capacity_unavailable details so operators can see the reset timing
- add regression tests for exhausted and healthy Codex pooled-routing cases

Closes #139
