### PR TITLE
fix: preserve native terminal upstream 400 after non-stream fallback exhaustion

### DIFF
--- a/api/src/routes/proxy.ts
+++ b/api/src/routes/proxy.ts
@@ -2041,6 +2041,8 @@ async function executeTokenModeNonStreaming(input: {
   let terminalCompatError: ReturnType<typeof mapOpenAiErrorToAnthropic> | null = null;
   let terminalCompatCredentialId: string | null = null;
   let terminalCompatAttemptNo = 0;
+  let terminalNative400Result: ProxyRouteResult | null = null;
+  let sawNonAuthNon400Failure = false;
   for (const initialCredential of credentials) {
     attemptNo += 1;
     let credential = initialCredential;
@@ -2131,7 +2133,10 @@ async function executeTokenModeNonStreaming(input: {
         })
         .finally(() => clearTimeout(timer));
 
-      if (!upstreamResponse) break;
+      if (!upstreamResponse) {
+        sawNonAuthNon400Failure = true;
+        break;
+      }
 
       const status = upstreamResponse.status;
       const upstreamHeadersAt = Date.now();
@@ -2387,6 +2392,7 @@ async function executeTokenModeNonStreaming(input: {
         });
         const backoffMs = 200 * (2 ** (attemptNo - 1)) + Math.floor(Math.random() * 100);
         await sleep(backoffMs);
+        sawNonAuthNon400Failure = true;
         break;
       }
 
@@ -2443,6 +2449,39 @@ async function executeTokenModeNonStreaming(input: {
         }
 
         await logAttemptFailure({ kind: 'server_error', statusCode: status, message: 'upstream server error' }, ttfbMs);
+        sawNonAuthNon400Failure = true;
+        break;
+      }
+
+      if (status === 400) {
+        const contentType = upstreamResponse.headers.get('content-type') ?? 'application/json';
+        const upstreamErrorData = await readUpstreamErrorPayload(upstreamResponse);
+        if (compatTranslation) {
+          terminalCompatError = mapOpenAiErrorToAnthropic(status, upstreamErrorData);
+          terminalCompatCredentialId = credential.id;
+          terminalCompatAttemptNo = attemptNo;
+        } else if (allowCompatTerminalErrorResponse) {
+          terminalNative400Result = {
+            requestId,
+            keyId: credential.id,
+            attemptNo,
+            upstreamStatus: status,
+            usageUnits: 0,
+            contentType,
+            data: upstreamErrorData,
+            routeKind: 'token_credential',
+            alreadyRecorded: true
+          };
+        }
+        await recordTokenCredentialOutcome({
+          credential,
+          requestId,
+          attemptNo,
+          provider,
+          model,
+          upstreamStatus: status
+        });
+        await logAttemptFailure({ statusCode: status, message: 'upstream provider rejected request' }, ttfbMs);
         break;
       }
 
@@ -2508,6 +2547,7 @@ async function executeTokenModeNonStreaming(input: {
           statusCode: effectiveStatus,
           message: 'upstream responses stream reported failure'
         }, ttfbMs);
+        sawNonAuthNon400Failure = true;
         break;
       }
       const downstreamData = compatTranslation && status >= 200 && status < 300 && !extractedFailed
@@ -2654,6 +2694,10 @@ async function executeTokenModeNonStreaming(input: {
         lastAuthStatus,
         ...(compatTerminalResult ? { compatTerminalResult } : {})
       });
+  }
+
+  if (allowCompatTerminalErrorResponse && terminalNative400Result && !sawNonAuthNon400Failure) {
+    return terminalNative400Result;
   }
 
   throw new AppError('capacity_unavailable', 429, 'All token credential attempts exhausted', {

--- a/api/tests/proxy.tokenMode.route.test.ts
+++ b/api/tests/proxy.tokenMode.route.test.ts
@@ -4062,6 +4062,144 @@ describe('proxy token-mode route behavior', () => {
     upstreamSpy.mockRestore();
   });
 
+  it('preserves the final upstream provider 400 after native non-stream fallback exhaustion', async () => {
+    process.env.TOKEN_MODE_ENABLED_ORGS = '818d0cc7-7ed2-469f-b690-a977e72a921d';
+    const openAiToken = createFakeOpenAiOauthToken({
+      accountId: 'acct_provider_400_terminal',
+      clientId: 'app_provider_400_terminal'
+    });
+
+    vi.spyOn(runtimeModule.runtime.repos.apiKeys, 'findActiveByHash').mockResolvedValue({
+      id: '11111111-1111-4111-8111-111111111111',
+      org_id: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      scope: 'buyer_proxy',
+      is_active: true,
+      expires_at: null,
+      preferred_provider: 'openai'
+    } as any);
+    vi.spyOn(runtimeModule.runtime.repos.modelCompatibility, 'findActive').mockImplementation(async (provider: string) => {
+      if (provider === 'openai') {
+        return { provider: 'openai', model: 'gpt-5.4', supports_streaming: false } as any;
+      }
+      if (provider === 'anthropic') {
+        return { provider: 'anthropic', model: 'gpt-5.4', supports_streaming: false } as any;
+      }
+      return null as any;
+    });
+    const listSpy = vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'listActiveForRouting').mockImplementation(async (_orgId: string, provider: string) => {
+      if (provider === 'openai') {
+        return [{
+          id: 'provider-400-openai-terminal',
+          orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+          provider: 'openai',
+          authScheme: 'bearer',
+          accessToken: openAiToken,
+          refreshToken: 'rt_provider_400_terminal',
+          expiresAt: new Date('2026-03-02T00:00:00Z'),
+          status: 'active',
+          rotationVersion: 1,
+          createdAt: new Date('2026-03-01T00:00:00Z'),
+          updatedAt: new Date('2026-03-01T00:00:00Z'),
+          revokedAt: null,
+          monthlyContributionLimitUnits: null,
+          monthlyContributionUsedUnits: 0,
+          monthlyWindowStartAt: new Date('2026-03-01T00:00:00Z')
+        } as any];
+      }
+
+      if (provider === 'anthropic') {
+        return [{
+          id: 'provider-400-anthropic-terminal',
+          orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+          provider: 'anthropic',
+          authScheme: 'x_api_key',
+          accessToken: 'sk-ant-provider-400-terminal',
+          refreshToken: null,
+          expiresAt: new Date('2026-03-02T00:00:00Z'),
+          status: 'active',
+          rotationVersion: 1,
+          createdAt: new Date('2026-03-01T00:00:00Z'),
+          updatedAt: new Date('2026-03-01T00:00:00Z'),
+          revokedAt: null,
+          monthlyContributionLimitUnits: null,
+          monthlyContributionUsedUnits: 0,
+          monthlyWindowStartAt: new Date('2026-03-01T00:00:00Z')
+        } as any];
+      }
+
+      return [];
+    });
+
+    const upstreamSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (_input: URL | RequestInfo, init?: RequestInit) => {
+      const headers = init?.headers as Record<string, string> | undefined;
+      if (headers?.authorization === `Bearer ${openAiToken}`) {
+        return new Response(JSON.stringify({
+          error: {
+            type: 'invalid_request_error',
+            message: 'openai rejected request'
+          }
+        }), {
+          status: 400,
+          headers: { 'content-type': 'application/json' }
+        });
+      }
+
+      if (headers?.['x-api-key'] === 'sk-ant-provider-400-terminal') {
+        return new Response(JSON.stringify({
+          error: {
+            type: 'invalid_request_error',
+            message: 'anthropic rejected request',
+            source: 'anthropic'
+          }
+        }), {
+          status: 400,
+          headers: { 'content-type': 'application/json' }
+        });
+      }
+
+      throw new Error(`unexpected credential headers: ${JSON.stringify(headers ?? {})}`);
+    });
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/proxy/v1/messages',
+      headers: {
+        authorization: 'Bearer in_test_token',
+        'content-type': 'application/json',
+        'idempotency-key': 'abcdefghijklmnopqrstuvwxyz123456',
+        'anthropic-version': '2023-06-01'
+      },
+      body: {
+        provider: 'anthropic',
+        model: 'gpt-5.4',
+        streaming: false,
+        payload: { model: 'gpt-5.4', max_tokens: 8, messages: [{ role: 'user', content: 'hi' }] }
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(handlers[0], req, res);
+    await invoke(handlers[1], req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      error: {
+        type: 'invalid_request_error',
+        message: 'anthropic rejected request',
+        source: 'anthropic'
+      }
+    });
+    expect(listSpy.mock.calls.map((call) => call[1])).toEqual(['openai', 'anthropic']);
+    expect(upstreamSpy).toHaveBeenCalledTimes(2);
+    const routeDecision = (runtimeModule.runtime.repos.routingEvents.insert as any).mock.calls.at(-1)?.[0]?.routeDecision;
+    expect(routeDecision?.reason).toBe('fallback_provider_selected');
+    expect(routeDecision?.provider_preferred).toBe('openai');
+    expect(routeDecision?.provider_effective).toBe('anthropic');
+    expect(routeDecision?.provider_fallback_from).toBe('openai');
+    expect(routeDecision?.provider_fallback_reason).toBe('capacity_unavailable');
+    upstreamSpy.mockRestore();
+  });
+
   it('applies stored buyer-key provider preference ahead of an unpinned request provider', async () => {
     process.env.TOKEN_MODE_ENABLED_ORGS = '818d0cc7-7ed2-469f-b690-a977e72a921d';
     vi.spyOn(runtimeModule.runtime.repos.apiKeys, 'findActiveByHash').mockResolvedValue({


### PR DESCRIPTION
**@worker-01**

## Summary
- classify native non-stream upstream `400` responses as fallback-worthy provider failures instead of returning them immediately on the first provider
- preserve the final upstream provider `400` status/body for last-provider native fallback exhaustion while leaving compat terminal mapping intact
- add regression coverage for the preferred-provider `400` fallback-success case and the exhausted native last-provider `400` case

## Verification
- `cd api && npx vitest run tests/proxy.tokenMode.route.test.ts`
- `cd api && npm run build`

Refs #154
