### PR TITLE
Extend scheduled OpenAI/Codex provider-usage refresh and OAuth retry handling

### DIFF
--- a/api/src/jobs/tokenCredentialProviderUsageJob.ts
+++ b/api/src/jobs/tokenCredentialProviderUsageJob.ts
@@ -5,15 +5,18 @@ import {
 } from '../repos/tokenCredentialProviderUsageRepository.js';
 import type { JobDefinition } from './types.js';
 import {
-  type AnthropicOauthUsageRefreshOutcome,
-  anthropicOauthUsageAuthFailureStatusCode,
   evaluateClaudeContributionCap,
   isAnthropicOauthTokenCredential,
   parkAnthropicOauthCredentialAfterUsageAuthFailure,
-  providerUsageWarningReasonFromRefreshOutcome,
+  PROVIDER_USAGE_FETCH_BACKOFF_ACTIVE_REASON,
+  PROVIDER_USAGE_FETCH_FAILED_REASON,
   readTokenCredentialProviderUsagePollMs,
 } from '../services/tokenCredentialProviderUsage.js';
-import { refreshAnthropicOauthUsageWithCredentialRefresh } from '../services/tokenCredentialOauthRefresh.js';
+import {
+  refreshAnthropicOauthUsageWithCredentialRefresh,
+  refreshTokenCredentialProviderUsageWithCredentialRefresh,
+  type TokenCredentialProviderUsageRefreshOutcome
+} from '../services/tokenCredentialOauthRefresh.js';
 import { evaluateClaudeCredentialAvailability } from '../services/claudeCredentialAvailability.js';
 import {
   readClaudeContributionCapProviderExhaustionHold,
@@ -24,6 +27,7 @@ import {
   readTokenCredentialProbeIntervalMinutes,
   readTokenCredentialProbeTimeoutMs
 } from '../services/tokenCredentialProbe.js';
+import { isOpenAiOauthAccessToken } from '../utils/openaiOauth.js';
 
 const DEFAULT_RATE_LIMIT_ESCALATION_THRESHOLD = 10;
 const DEFAULT_LEGACY_MAXED_RECOVERY_LIMIT = 25;
@@ -41,6 +45,46 @@ function readIntEnv(name: string, fallback: number): number {
   const parsed = Number(value);
   if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
   return Math.floor(parsed);
+}
+
+function isScheduledProviderUsageCredential(
+  credential: Parameters<typeof isAnthropicOauthTokenCredential>[0]
+): boolean {
+  if (isAnthropicOauthTokenCredential(credential)) {
+    return true;
+  }
+
+  return (
+    (credential.provider === 'openai' || credential.provider === 'codex')
+    && isOpenAiOauthAccessToken(credential.accessToken)
+  );
+}
+
+function providerUsageAuthFailureStatusCode(
+  outcome: TokenCredentialProviderUsageRefreshOutcome
+): 401 | 403 | null {
+  if (outcome.ok) return null;
+  if (outcome.statusCode === 401 || outcome.statusCode === 403) {
+    return outcome.statusCode;
+  }
+  return null;
+}
+
+function providerUsageWarningReasonFromOutcome(
+  outcome: TokenCredentialProviderUsageRefreshOutcome
+): typeof PROVIDER_USAGE_FETCH_BACKOFF_ACTIVE_REASON | typeof PROVIDER_USAGE_FETCH_FAILED_REASON | null {
+  if (outcome.ok) return null;
+  if (outcome.category === 'fetch_backoff') return PROVIDER_USAGE_FETCH_BACKOFF_ACTIVE_REASON;
+  if (outcome.category === 'fetch_failed') return PROVIDER_USAGE_FETCH_FAILED_REASON;
+  return null;
+}
+
+function providerUsageLogReasonFromOutcome(outcome: TokenCredentialProviderUsageRefreshOutcome): string | null {
+  if (outcome.ok) return null;
+  if ('warningReason' in outcome) {
+    return outcome.warningReason ?? outcome.reason;
+  }
+  return outcome.reason;
 }
 
 export function createTokenCredentialProviderUsageJob(
@@ -66,9 +110,25 @@ export function createTokenCredentialProviderUsageJob(
       );
       const probeTimeoutMs = readTokenCredentialProbeTimeoutMs();
       const probeIntervalMinutes = readTokenCredentialProbeIntervalMinutes();
-      const credentials = await tokenCredentialsRepo.listActiveOauthByProvider('anthropic', {
-        includeRecoverableExpired: true
-      });
+      const credentialsById = new Map<string, Awaited<ReturnType<typeof tokenCredentialsRepo.listActiveOauthByProvider>>[number]>();
+      for (const credentialList of await Promise.all([
+        tokenCredentialsRepo.listActiveOauthByProvider('anthropic', {
+          includeRecoverableExpired: true
+        }),
+        tokenCredentialsRepo.listActiveOauthByProvider('openai', {
+          includeRecoverableExpired: true
+        }),
+        tokenCredentialsRepo.listActiveOauthByProvider('codex', {
+          includeRecoverableExpired: true
+        })
+      ])) {
+        for (const credential of credentialList) {
+          if (!credentialsById.has(credential.id)) {
+            credentialsById.set(credential.id, credential);
+          }
+        }
+      }
+      const credentials = [...credentialsById.values()];
       const existingSnapshots = typeof (providerUsageRepo as {
         listByTokenCredentialIds?: (ids: string[]) => Promise<TokenCredentialProviderUsageSnapshot[]>;
       }).listByTokenCredentialIds === 'function'
@@ -92,12 +152,12 @@ export function createTokenCredentialProviderUsageJob(
       const syncProviderUsageWarning = async (
         credentialId: string,
         credentialLabel: string | null | undefined,
-        result: AnthropicOauthUsageRefreshOutcome
+        result: TokenCredentialProviderUsageRefreshOutcome
       ): Promise<void> => {
         try {
           await tokenCredentialsRepo.setProviderUsageWarning(
             credentialId,
-            providerUsageWarningReasonFromRefreshOutcome(result)
+            providerUsageWarningReasonFromOutcome(result)
           );
         } catch (error) {
           ctx.logger.error('token credential provider usage warning sync failed', {
@@ -152,51 +212,54 @@ export function createTokenCredentialProviderUsageJob(
       };
 
       for (const credential of credentials) {
-        if (!isAnthropicOauthTokenCredential(credential)) {
+        const isAnthropicCredential = isAnthropicOauthTokenCredential(credential);
+        if (!isScheduledProviderUsageCredential(credential)) {
           skippedNonOauth += 1;
           continue;
         }
 
         const expiredAtRunStart = credential.status === 'expired' || credential.expiresAt.getTime() <= ctx.now.getTime();
         const existingSnapshot = existingSnapshotsByCredentialId.get(credential.id) ?? null;
-        const providerExhaustionHold = readClaudeContributionCapProviderExhaustionHold({
-          credential,
-          snapshot: existingSnapshot,
-          now: ctx.now
-        });
-        const snapshotFetchedAt = existingSnapshot?.fetchedAt ?? null;
-        const snapshotAgeMs = snapshotFetchedAt
-          ? Math.max(0, ctx.now.getTime() - snapshotFetchedAt.getTime())
-          : null;
-        const recentlyVerifiedExhausted = snapshotAgeMs !== null && snapshotAgeMs < providerExhaustionRevalidateMs;
-        if (
-          !expiredAtRunStart
-          &&
-          providerExhaustionHold.hasActiveHold
-          && providerExhaustionHold.nextRefreshAt
-          && recentlyVerifiedExhausted
-        ) {
-          paused += 1;
-          await tokenCredentialsRepo.setProviderUsageWarning(credential.id, null);
-          ctx.logger.info('token credential provider usage refresh paused (provider exhausted)', {
-            credentialId: credential.id,
-            credentialLabel: credential.debugLabel ?? null,
-            provider: credential.provider,
-            reason: providerExhaustionHold.reason,
-            nextRefreshAt: providerExhaustionHold.nextRefreshAt.toISOString(),
-            snapshotAgeMs
+        if (isAnthropicCredential) {
+          const providerExhaustionHold = readClaudeContributionCapProviderExhaustionHold({
+            credential,
+            snapshot: existingSnapshot,
+            now: ctx.now
           });
-          continue;
+          const snapshotFetchedAt = existingSnapshot?.fetchedAt ?? null;
+          const snapshotAgeMs = snapshotFetchedAt
+            ? Math.max(0, ctx.now.getTime() - snapshotFetchedAt.getTime())
+            : null;
+          const recentlyVerifiedExhausted = snapshotAgeMs !== null && snapshotAgeMs < providerExhaustionRevalidateMs;
+          if (
+            !expiredAtRunStart
+            &&
+            providerExhaustionHold.hasActiveHold
+            && providerExhaustionHold.nextRefreshAt
+            && recentlyVerifiedExhausted
+          ) {
+            paused += 1;
+            await tokenCredentialsRepo.setProviderUsageWarning(credential.id, null);
+            ctx.logger.info('token credential provider usage refresh paused (provider exhausted)', {
+              credentialId: credential.id,
+              credentialLabel: credential.debugLabel ?? null,
+              provider: credential.provider,
+              reason: providerExhaustionHold.reason,
+              nextRefreshAt: providerExhaustionHold.nextRefreshAt.toISOString(),
+              snapshotAgeMs
+            });
+            continue;
+          }
         }
 
-        const refreshedUsage = await refreshAnthropicOauthUsageWithCredentialRefresh(
+        const refreshedUsage = await refreshTokenCredentialProviderUsageWithCredentialRefresh(
           providerUsageRepo,
           tokenCredentialsRepo,
           credential
         );
         const credentialForUsage = refreshedUsage.credential;
         const result = refreshedUsage.outcome;
-        const authFailureStatusCode = anthropicOauthUsageAuthFailureStatusCode(result);
+        const authFailureStatusCode = providerUsageAuthFailureStatusCode(result);
         if (authFailureStatusCode !== null) {
           if (expiredAtRunStart) {
             await tokenCredentialsRepo.markExpired(
@@ -233,13 +296,14 @@ export function createTokenCredentialProviderUsageJob(
         }
         await syncProviderUsageWarning(credentialForUsage.id, credentialForUsage.debugLabel, result);
         if (!result.ok) {
+          const logReason = providerUsageLogReasonFromOutcome(result);
           if (result.category === 'fetch_backoff') {
             deferred += 1;
             ctx.logger.info('token credential provider usage refresh deferred', {
               credentialId: credentialForUsage.id,
               credentialLabel: credentialForUsage.debugLabel ?? null,
               provider: credentialForUsage.provider,
-              reason: result.warningReason ?? result.reason,
+              reason: logReason ?? result.reason,
               detailReason: result.reason,
               statusCode: result.statusCode,
               retryAfterMs: result.retryAfterMs ?? null
@@ -250,10 +314,10 @@ export function createTokenCredentialProviderUsageJob(
               credentialId: credentialForUsage.id,
               credentialLabel: credentialForUsage.debugLabel ?? null,
               provider: credentialForUsage.provider,
-              reason: result.warningReason ?? result.reason,
+              reason: logReason ?? result.reason,
               detailReason: result.reason,
               statusCode: result.statusCode,
-              retryAfterMs: result.retryAfterMs ?? null,
+              retryAfterMs: result.category === 'fetch_backoff' ? result.retryAfterMs ?? null : null,
               errorMessage: result.errorMessage ?? null
             });
           }
@@ -261,6 +325,10 @@ export function createTokenCredentialProviderUsageJob(
         }
 
         refreshed += 1;
+        if (!isAnthropicCredential) {
+          continue;
+        }
+
         await syncContributionCapLifecycle(credentialForUsage, result.snapshot);
 
         const evaluation = evaluateClaudeContributionCap({
@@ -343,7 +411,7 @@ export function createTokenCredentialProviderUsageJob(
         );
         const credentialForUsage = refreshedUsage.credential;
         const result = refreshedUsage.outcome;
-        const authFailureStatusCode = anthropicOauthUsageAuthFailureStatusCode(result);
+        const authFailureStatusCode = providerUsageAuthFailureStatusCode(result);
         if (authFailureStatusCode !== null) {
           const nextProbeAt = new Date(ctx.now.getTime() + (probeIntervalMinutes * 60 * 1000));
           await parkAnthropicOauthCredentialAfterUsageAuthFailure(tokenCredentialsRepo, credentialForUsage, {

--- a/api/src/services/tokenCredentialOauthRefresh.ts
+++ b/api/src/services/tokenCredentialOauthRefresh.ts
@@ -1,11 +1,6 @@
 import type { TokenCredential, TokenCredentialRepository } from '../repos/tokenCredentialRepository.js';
 import type { TokenCredentialProviderUsageRepository } from '../repos/tokenCredentialProviderUsageRepository.js';
-import {
-  anthropicOauthUsageAuthFailureStatusCode,
-  type AnthropicOauthUsageRefreshOutcome,
-  isAnthropicOauthTokenCredential,
-  refreshAnthropicOauthUsageNow
-} from './tokenCredentialProviderUsage.js';
+import * as providerUsageService from './tokenCredentialProviderUsage.js';
 import {
   isOpenAiOauthAccessToken,
   resolveOpenAiOauthClientId,
@@ -16,6 +11,10 @@ const DEFAULT_OPENAI_OAUTH_TOKEN_ENDPOINT = 'https://auth.openai.com/oauth/token
 const DEFAULT_ANTHROPIC_OAUTH_TOKEN_ENDPOINT = 'https://platform.claude.com/v1/oauth/token';
 const DEFAULT_ANTHROPIC_OAUTH_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
 const ANTHROPIC_OAUTH_BETA = 'oauth-2025-04-20';
+
+export type TokenCredentialProviderUsageRefreshOutcome =
+  | providerUsageService.AnthropicOauthUsageRefreshOutcome
+  | providerUsageService.OpenAiOauthUsageRefreshOutcome;
 
 function parseRefreshExpiry(
   payload: Record<string, unknown>,
@@ -100,7 +99,7 @@ export async function attemptAnthropicOauthRefresh(
   credential: TokenCredential
 ): Promise<TokenCredential | null> {
   if (!credential.refreshToken) return null;
-  if (!isAnthropicOauthTokenCredential(credential)) return null;
+  if (!providerUsageService.isAnthropicOauthTokenCredential(credential)) return null;
 
   const refreshUrl = process.env.ANTHROPIC_OAUTH_TOKEN_ENDPOINT || DEFAULT_ANTHROPIC_OAUTH_TOKEN_ENDPOINT;
   const form = new URLSearchParams({
@@ -190,11 +189,65 @@ export async function refreshAnthropicOauthUsageWithCredentialRefresh(
   }
 ): Promise<{
   credential: TokenCredential;
-  outcome: AnthropicOauthUsageRefreshOutcome;
+  outcome: providerUsageService.AnthropicOauthUsageRefreshOutcome;
   refreshedCredential: TokenCredential | null;
 }> {
-  const initialOutcome = await refreshAnthropicOauthUsageNow(providerUsageRepo, credential, options);
-  if (anthropicOauthUsageAuthFailureStatusCode(initialOutcome) === null) {
+  const refreshedUsage = await refreshTokenCredentialProviderUsageWithCredentialRefresh(
+    providerUsageRepo,
+    tokenCredentialRepo,
+    credential,
+    options
+  );
+
+  return {
+    credential: refreshedUsage.credential,
+    outcome: refreshedUsage.outcome as providerUsageService.AnthropicOauthUsageRefreshOutcome,
+    refreshedCredential: refreshedUsage.refreshedCredential
+  };
+}
+
+function providerUsageAuthFailureStatusCode(
+  outcome: TokenCredentialProviderUsageRefreshOutcome
+): 401 | 403 | null {
+  if (outcome.ok) return null;
+  if (outcome.statusCode === 401 || outcome.statusCode === 403) {
+    return outcome.statusCode;
+  }
+  return null;
+}
+
+async function refreshProviderUsageNow(
+  providerUsageRepo: TokenCredentialProviderUsageRepository,
+  credential: TokenCredential,
+  options?: {
+    timeoutMs?: number;
+    ignoreRetryBackoff?: boolean;
+  }
+): Promise<TokenCredentialProviderUsageRefreshOutcome> {
+  if (providerUsageService.isAnthropicOauthTokenCredential(credential)) {
+    return providerUsageService.refreshAnthropicOauthUsageNow(providerUsageRepo, credential, options);
+  }
+
+  return providerUsageService.refreshOpenAiOauthUsageNow(providerUsageRepo, credential, {
+    timeoutMs: options?.timeoutMs
+  });
+}
+
+export async function refreshTokenCredentialProviderUsageWithCredentialRefresh(
+  providerUsageRepo: TokenCredentialProviderUsageRepository,
+  tokenCredentialRepo: TokenCredentialRepository,
+  credential: TokenCredential,
+  options?: {
+    timeoutMs?: number;
+    ignoreRetryBackoff?: boolean;
+  }
+): Promise<{
+  credential: TokenCredential;
+  outcome: TokenCredentialProviderUsageRefreshOutcome;
+  refreshedCredential: TokenCredential | null;
+}> {
+  const initialOutcome = await refreshProviderUsageNow(providerUsageRepo, credential, options);
+  if (providerUsageAuthFailureStatusCode(initialOutcome) === null) {
     return {
       credential,
       outcome: initialOutcome,
@@ -211,7 +264,7 @@ export async function refreshAnthropicOauthUsageWithCredentialRefresh(
     };
   }
 
-  const retriedOutcome = await refreshAnthropicOauthUsageNow(providerUsageRepo, refreshedCredential, {
+  const retriedOutcome = await refreshProviderUsageNow(providerUsageRepo, refreshedCredential, {
     timeoutMs: options?.timeoutMs,
     ignoreRetryBackoff: true
   });

--- a/api/tests/tokenCredentialProviderUsageJob.test.ts
+++ b/api/tests/tokenCredentialProviderUsageJob.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createTokenCredentialProviderUsageJob } from '../src/jobs/tokenCredentialProviderUsageJob.js';
+import type { TokenCredential } from '../src/repos/tokenCredentialRepository.js';
 import { resetAnthropicUsageRetryStateForTests } from '../src/services/tokenCredentialProviderUsageRetryState.js';
 
 function createCtx() {
@@ -9,6 +10,57 @@ function createCtx() {
       info: vi.fn(),
       error: vi.fn()
     }
+  };
+}
+
+function createFakeOpenAiOauthToken(input?: {
+  accountId?: string;
+  clientId?: string;
+  exp?: number;
+}): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'RS256', typ: 'JWT' })).toString('base64url');
+  const payload = Buffer.from(JSON.stringify({
+    iss: 'https://auth.openai.com',
+    aud: ['https://api.openai.com/v1'],
+    client_id: input?.clientId ?? 'app_test_codex',
+    exp: input?.exp ?? Math.floor(Date.now() / 1000) + 3600,
+    'https://api.openai.com/auth': {
+      chatgpt_account_id: input?.accountId ?? 'acct_codex_usage'
+    }
+  })).toString('base64url');
+  return `${header}.${payload}.signature`;
+}
+
+function createOpenAiCredential(overrides?: Partial<TokenCredential>): TokenCredential {
+  return {
+    id: 'cred_openai_job',
+    orgId: 'org_1',
+    provider: 'openai',
+    authScheme: 'bearer',
+    accessToken: createFakeOpenAiOauthToken(),
+    refreshToken: null,
+    expiresAt: new Date('2026-03-10T00:00:00Z'),
+    status: 'active',
+    rotationVersion: 1,
+    createdAt: new Date('2026-03-01T00:00:00Z'),
+    updatedAt: new Date('2026-03-01T00:00:00Z'),
+    revokedAt: null,
+    monthlyContributionLimitUnits: null,
+    monthlyContributionUsedUnits: 0,
+    monthlyWindowStartAt: new Date('2026-03-01T00:00:00Z'),
+    fiveHourReservePercent: 0,
+    sevenDayReservePercent: 0,
+    debugLabel: 'codex-oauth-main',
+    consecutiveFailureCount: 0,
+    consecutiveRateLimitCount: 0,
+    lastFailedStatus: null,
+    lastFailedAt: null,
+    lastRateLimitedAt: null,
+    maxedAt: null,
+    rateLimitedUntil: null,
+    nextProbeAt: null,
+    lastProbeAt: null,
+    ...overrides
   };
 }
 
@@ -355,6 +407,264 @@ describe('tokenCredentialProviderUsageJob', () => {
       })
     );
     expect(tokenRepo.setProviderUsageWarning).toHaveBeenCalledWith('cred_2', 'provider_usage_fetch_failed');
+  });
+
+  it('refreshes scheduled OpenAI session credentials alongside Anthropic ones', async () => {
+    const tokenRepo = {
+      listActiveOauthByProvider: vi.fn(async (provider: string) => {
+        if (provider === 'openai') {
+          return [createOpenAiCredential({
+            id: 'cred_openai_success',
+            debugLabel: 'codex-live-session'
+          })];
+        }
+        return [];
+      }),
+      clearRateLimitBackoff: vi.fn(async () => false),
+      setProviderUsageWarning: vi.fn(async () => false),
+      listMaxedForProbe: vi.fn(async () => []),
+      syncClaudeContributionCapLifecycle: vi.fn(async () => ({ fiveHourTransition: null, sevenDayTransition: null })),
+      reactivateFromMaxed: vi.fn(async () => false)
+    };
+    const usageRepo = {
+      upsertSnapshot: vi.fn(async (input: any) => ({
+        tokenCredentialId: input.tokenCredentialId,
+        orgId: input.orgId,
+        provider: input.provider,
+        usageSource: input.usageSource,
+        fiveHourUtilizationRatio: input.fiveHourUtilizationRatio,
+        fiveHourResetsAt: input.fiveHourResetsAt,
+        sevenDayUtilizationRatio: input.sevenDayUtilizationRatio,
+        sevenDayResetsAt: input.sevenDayResetsAt,
+        rawPayload: input.rawPayload,
+        fetchedAt: input.fetchedAt,
+        createdAt: input.fetchedAt,
+        updatedAt: input.fetchedAt
+      }))
+    };
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({
+        rate_limit: {
+          primary_window: {
+            used_percent: 7,
+            reset_at: 1_773_888_569
+          },
+          secondary_window: {
+            used_percent: 12,
+            reset_at: 1_774_457_367
+          }
+        }
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' }
+      })
+    );
+    const job = createTokenCredentialProviderUsageJob(tokenRepo as any, usageRepo as any);
+    const ctx = createCtx();
+
+    await job.run(ctx as any);
+
+    expect(tokenRepo.listActiveOauthByProvider).toHaveBeenCalledWith('anthropic', {
+      includeRecoverableExpired: true
+    });
+    expect(tokenRepo.listActiveOauthByProvider).toHaveBeenCalledWith('openai', {
+      includeRecoverableExpired: true
+    });
+    expect(tokenRepo.listActiveOauthByProvider).toHaveBeenCalledWith('codex', {
+      includeRecoverableExpired: true
+    });
+    expect(usageRepo.upsertSnapshot).toHaveBeenCalledWith(expect.objectContaining({
+      tokenCredentialId: 'cred_openai_success',
+      provider: 'openai',
+      usageSource: 'openai_wham_usage'
+    }));
+    expect(tokenRepo.syncClaudeContributionCapLifecycle).not.toHaveBeenCalled();
+    expect(ctx.logger.info).toHaveBeenCalledWith(
+      'token credential provider usage refresh complete',
+      expect.objectContaining({
+        checked: 1,
+        refreshed: 1,
+        failed: 0
+      })
+    );
+  });
+
+  it('parks active Codex credentials when provider usage refresh returns auth failure', async () => {
+    const tokenRepo = {
+      listActiveOauthByProvider: vi.fn(async (provider: string) => {
+        if (provider === 'codex') {
+          return [createOpenAiCredential({
+            id: 'cred_codex_auth_fail',
+            provider: 'codex',
+            debugLabel: 'codex-auth-fail'
+          })];
+        }
+        return [];
+      }),
+      recordFailureAndMaybeMax: vi.fn(async () => ({
+        status: 'maxed',
+        consecutiveFailures: 1,
+        newlyMaxed: true
+      })),
+      markProbeFailure: vi.fn(async () => false),
+      clearRateLimitBackoff: vi.fn(async () => false),
+      setProviderUsageWarning: vi.fn(async () => false),
+      listMaxedForProbe: vi.fn(async () => []),
+      syncClaudeContributionCapLifecycle: vi.fn(async () => ({ fiveHourTransition: null, sevenDayTransition: null })),
+      reactivateFromMaxed: vi.fn(async () => false)
+    };
+    const usageRepo = {
+      upsertSnapshot: vi.fn()
+    };
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ detail: 'forbidden' }), {
+        status: 403,
+        headers: { 'content-type': 'application/json' }
+      })
+    );
+    const job = createTokenCredentialProviderUsageJob(tokenRepo as any, usageRepo as any);
+    const ctx = createCtx();
+
+    await job.run(ctx as any);
+
+    expect(tokenRepo.recordFailureAndMaybeMax).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'cred_codex_auth_fail',
+      statusCode: 403,
+      threshold: 1,
+      reason: 'upstream_403_provider_usage_refresh'
+    }));
+    expect(tokenRepo.markProbeFailure).not.toHaveBeenCalled();
+    expect(tokenRepo.setProviderUsageWarning).not.toHaveBeenCalled();
+    expect(tokenRepo.syncClaudeContributionCapLifecycle).not.toHaveBeenCalled();
+    expect(ctx.logger.info).toHaveBeenCalledWith(
+      'token credential provider usage auth failure parked',
+      expect.objectContaining({
+        credentialId: 'cred_codex_auth_fail',
+        credentialLabel: 'codex-auth-fail',
+        provider: 'codex',
+        statusCode: 403
+      })
+    );
+  });
+
+  it('refreshes expired Codex credentials before retrying provider usage', async () => {
+    const oldAccessToken = createFakeOpenAiOauthToken({
+      clientId: 'app_codex_old',
+      accountId: 'acct_codex_old',
+      exp: Math.floor(new Date('2026-03-03T23:00:00Z').getTime() / 1000)
+    });
+    const refreshedAccessToken = createFakeOpenAiOauthToken({
+      clientId: 'app_codex_old',
+      accountId: 'acct_codex_new',
+      exp: Math.floor(new Date('2026-03-10T01:00:00Z').getTime() / 1000)
+    });
+    const tokenRepo = {
+      listActiveOauthByProvider: vi.fn(async (provider: string) => {
+        if (provider === 'codex') {
+          return [createOpenAiCredential({
+            id: 'cred_codex_refresh',
+            provider: 'codex',
+            accessToken: oldAccessToken,
+            refreshToken: 'rt_codex_old',
+            expiresAt: new Date('2026-03-03T23:00:00Z'),
+            debugLabel: 'codex-expired-refresh'
+          })];
+        }
+        return [];
+      }),
+      refreshInPlace: vi.fn(async () => createOpenAiCredential({
+        id: 'cred_codex_refresh',
+        provider: 'codex',
+        accessToken: refreshedAccessToken,
+        refreshToken: 'rt_codex_new',
+        expiresAt: new Date('2026-03-10T01:00:00Z'),
+        debugLabel: 'codex-expired-refresh'
+      })),
+      markExpired: vi.fn(async () => true),
+      recordFailureAndMaybeMax: vi.fn(async () => ({
+        status: 'maxed',
+        consecutiveFailures: 1,
+        newlyMaxed: true
+      })),
+      markProbeFailure: vi.fn(async () => false),
+      clearRateLimitBackoff: vi.fn(async () => false),
+      setProviderUsageWarning: vi.fn(async () => false),
+      listMaxedForProbe: vi.fn(async () => []),
+      syncClaudeContributionCapLifecycle: vi.fn(async () => ({ fiveHourTransition: null, sevenDayTransition: null })),
+      reactivateFromMaxed: vi.fn(async () => false)
+    };
+    const usageRepo = {
+      upsertSnapshot: vi.fn(async (input: any) => ({
+        tokenCredentialId: input.tokenCredentialId,
+        orgId: input.orgId,
+        provider: input.provider,
+        usageSource: input.usageSource,
+        fiveHourUtilizationRatio: input.fiveHourUtilizationRatio,
+        fiveHourResetsAt: input.fiveHourResetsAt,
+        sevenDayUtilizationRatio: input.sevenDayUtilizationRatio,
+        sevenDayResetsAt: input.sevenDayResetsAt,
+        rawPayload: input.rawPayload,
+        fetchedAt: input.fetchedAt,
+        createdAt: input.fetchedAt,
+        updatedAt: input.fetchedAt
+      }))
+    };
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: URL | RequestInfo, init?: RequestInit) => {
+      const url = String(input);
+      if (url === 'https://chatgpt.com/backend-api/wham/usage') {
+        const headers = (init?.headers ?? {}) as Record<string, string>;
+        if (headers.authorization === `Bearer ${oldAccessToken}`) {
+          return new Response(JSON.stringify({ detail: 'token expired' }), {
+            status: 401,
+            headers: { 'content-type': 'application/json' }
+          });
+        }
+        expect(headers.authorization).toBe(`Bearer ${refreshedAccessToken}`);
+        return new Response(JSON.stringify({
+          rate_limit: {
+            primary_window: {
+              used_percent: 11,
+              reset_at: 1_773_888_569
+            },
+            secondary_window: {
+              used_percent: 13,
+              reset_at: 1_774_457_367
+            }
+          }
+        }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' }
+        });
+      }
+      if (url === 'https://auth.openai.com/oauth/token') {
+        expect(String(init?.body)).toContain('grant_type=refresh_token');
+        expect(String(init?.body)).toContain('client_id=app_codex_old');
+        expect(String(init?.body)).toContain('refresh_token=rt_codex_old');
+        return new Response(JSON.stringify({
+          access_token: refreshedAccessToken,
+          refresh_token: 'rt_codex_new',
+          expires_in: 3600
+        }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' }
+        });
+      }
+      throw new Error(`unexpected fetch target: ${url}`);
+    });
+    const job = createTokenCredentialProviderUsageJob(tokenRepo as any, usageRepo as any);
+    const ctx = createCtx();
+
+    await job.run(ctx as any);
+
+    expect(tokenRepo.refreshInPlace).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'cred_codex_refresh',
+      accessToken: refreshedAccessToken,
+      refreshToken: 'rt_codex_new'
+    }));
+    expect(tokenRepo.markExpired).not.toHaveBeenCalled();
+    expect(tokenRepo.recordFailureAndMaybeMax).not.toHaveBeenCalled();
+    expect(usageRepo.upsertSnapshot).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
   });
 
   it('parks active Claude credentials when provider usage refresh returns auth failure', async () => {


### PR DESCRIPTION
**@worker-01**

## Summary
- extend the minute provider-usage job to include eligible OpenAI and Codex session/OAuth credentials alongside Anthropic
- add a shared provider-usage refresh-with-credential-refresh seam so OpenAI/Codex usage refreshes can retry after stored token refresh
- park active OpenAI/Codex credentials on provider-usage `401`/`403` and add regression coverage for success, parking, and expired-token recovery

## Testing
- `npm test -- tests/tokenCredentialProviderUsage.test.ts tests/tokenCredentialProviderUsageRepository.test.ts tests/tokenCredentialProviderUsageJob.test.ts`
