### PR TITLE
Add OpenAI/Codex admin provider-usage refresh and operator docs/script support

### DIFF
--- a/api/src/routes/admin.ts
+++ b/api/src/routes/admin.ts
@@ -6,12 +6,14 @@ import { requireApiKey } from '../middleware/auth.js';
 import { runtime } from '../services/runtime.js';
 import { readClaudeContributionCapSnapshotState } from '../services/claudeContributionCapState.js';
 import {
-  anthropicOauthUsageAuthFailureStatusCode,
   isAnthropicOauthTokenCredential,
   parkAnthropicOauthCredentialAfterUsageAuthFailure,
   providerUsageWarningReasonFromRefreshOutcome
 } from '../services/tokenCredentialProviderUsage.js';
-import { refreshAnthropicOauthUsageWithCredentialRefresh } from '../services/tokenCredentialOauthRefresh.js';
+import {
+  refreshAnthropicOauthUsageWithCredentialRefresh,
+  refreshTokenCredentialProviderUsageWithCredentialRefresh
+} from '../services/tokenCredentialOauthRefresh.js';
 import {
   probeAndUpdateTokenCredential,
   readTokenCredentialProbeIntervalMinutes,
@@ -1009,11 +1011,12 @@ router.post('/v1/admin/token-credentials/:id/provider-usage-refresh', requireApi
     if (existing.status === 'revoked') {
       throw new AppError('invalid_request', 409, 'Revoked token credential cannot refresh provider usage');
     }
-    if (!isAnthropicOauthTokenCredential(existing)) {
+    const isAnthropicOauthCredential = isAnthropicOauthTokenCredential(existing);
+    if (!isAnthropicOauthCredential && existing.provider !== 'openai' && existing.provider !== 'codex') {
       throw new AppError(
         'invalid_request',
         409,
-        'Claude provider usage refresh is only supported for Anthropic OAuth credentials',
+        'Provider usage refresh is only supported for Anthropic and OpenAI/Codex OAuth credentials',
         {
           provider: existing.provider,
           status: existing.status
@@ -1029,15 +1032,25 @@ router.post('/v1/admin/token-credentials/:id/provider-usage-refresh', requireApi
       );
     }
 
-    const refreshedUsage = await refreshAnthropicOauthUsageWithCredentialRefresh(
-      runtime.repos.tokenCredentialProviderUsage,
-      runtime.repos.tokenCredentials,
-      existing,
-      { ignoreRetryBackoff: true }
-    );
+    const refreshedUsage = isAnthropicOauthCredential
+      ? await refreshAnthropicOauthUsageWithCredentialRefresh(
+        runtime.repos.tokenCredentialProviderUsage,
+        runtime.repos.tokenCredentials,
+        existing,
+        { ignoreRetryBackoff: true }
+      )
+      : await refreshTokenCredentialProviderUsageWithCredentialRefresh(
+        runtime.repos.tokenCredentialProviderUsage,
+        runtime.repos.tokenCredentials,
+        existing,
+        { ignoreRetryBackoff: true }
+      );
     const effectiveCredential = refreshedUsage.credential;
     const refreshOutcome = refreshedUsage.outcome;
-    const authFailureStatusCode = anthropicOauthUsageAuthFailureStatusCode(refreshOutcome);
+    const authFailureStatusCode = !refreshOutcome.ok
+      && (refreshOutcome.statusCode === 401 || refreshOutcome.statusCode === 403)
+      ? refreshOutcome.statusCode
+      : null;
     const shouldParkAfterAuthFailure = authFailureStatusCode !== null && existing.status !== 'expired';
     const nextProbeAt = shouldParkAfterAuthFailure
       ? new Date(Date.now() + (readTokenCredentialProbeIntervalMinutes() * 60 * 1000))
@@ -1049,30 +1062,32 @@ router.post('/v1/admin/token-credentials/:id/provider-usage-refresh', requireApi
         reason: `upstream_${authFailureStatusCode}_provider_usage_refresh`
       })
       : null;
-    const warningReason = authFailureStatusCode === null
+    const warningReason = isAnthropicOauthCredential && authFailureStatusCode === null
       ? providerUsageWarningReasonFromRefreshOutcome(refreshOutcome)
       : null;
     const stateSyncErrors: string[] = [];
-    let lifecycle = {
-      fiveHourTransition: null as 'exhausted' | 'cleared' | null,
-      sevenDayTransition: null as 'exhausted' | 'cleared' | null
-    };
+    let lifecycle = isAnthropicOauthCredential
+      ? {
+        fiveHourTransition: null as 'exhausted' | 'cleared' | null,
+        sevenDayTransition: null as 'exhausted' | 'cleared' | null
+      }
+      : null;
     let snapshotSummary: {
       usageSource: string;
       fetchedAt: string;
       fiveHourUtilizationRatio: number;
       fiveHourUsedPercent: number;
       fiveHourResetsAt: string | null;
-      fiveHourContributionCapExhausted: boolean;
+      fiveHourContributionCapExhausted: boolean | null;
       fiveHourProviderUsageExhausted: boolean;
       sevenDayUtilizationRatio: number;
       sevenDayUsedPercent: number;
       sevenDayResetsAt: string | null;
-      sevenDayContributionCapExhausted: boolean;
+      sevenDayContributionCapExhausted: boolean | null;
       sevenDayProviderUsageExhausted: boolean;
     } | null = null;
 
-    if (refreshOutcome.ok || warningReason !== null) {
+    if (isAnthropicOauthCredential && (refreshOutcome.ok || warningReason !== null)) {
       try {
         await runtime.repos.tokenCredentials.setProviderUsageWarning(id, refreshOutcome.ok ? null : warningReason);
       } catch (error) {
@@ -1081,53 +1096,70 @@ router.post('/v1/admin/token-credentials/:id/provider-usage-refresh', requireApi
     }
 
     if (refreshOutcome.ok) {
-      const state = readClaudeContributionCapSnapshotState({
-        credential: effectiveCredential,
-        snapshot: refreshOutcome.snapshot
-      });
+      if (isAnthropicOauthCredential) {
+        const state = readClaudeContributionCapSnapshotState({
+          credential: effectiveCredential,
+          snapshot: refreshOutcome.snapshot
+        });
 
-      snapshotSummary = {
-        usageSource: refreshOutcome.snapshot.usageSource,
-        fetchedAt: refreshOutcome.snapshot.fetchedAt.toISOString(),
-        fiveHourUtilizationRatio: refreshOutcome.snapshot.fiveHourUtilizationRatio,
-        fiveHourUsedPercent: refreshOutcome.snapshot.fiveHourUtilizationRatio * 100,
-        fiveHourResetsAt: refreshOutcome.snapshot.fiveHourResetsAt?.toISOString() ?? null,
-        fiveHourContributionCapExhausted: state.fiveHourContributionCapExhausted,
-        fiveHourProviderUsageExhausted: refreshOutcome.snapshot.fiveHourUtilizationRatio >= 1,
-        sevenDayUtilizationRatio: refreshOutcome.snapshot.sevenDayUtilizationRatio,
-        sevenDayUsedPercent: refreshOutcome.snapshot.sevenDayUtilizationRatio * 100,
-        sevenDayResetsAt: refreshOutcome.snapshot.sevenDayResetsAt?.toISOString() ?? null,
-        sevenDayContributionCapExhausted: state.sevenDayContributionCapExhausted,
-        sevenDayProviderUsageExhausted: refreshOutcome.snapshot.sevenDayUtilizationRatio >= 1
-      };
+        snapshotSummary = {
+          usageSource: refreshOutcome.snapshot.usageSource,
+          fetchedAt: refreshOutcome.snapshot.fetchedAt.toISOString(),
+          fiveHourUtilizationRatio: refreshOutcome.snapshot.fiveHourUtilizationRatio,
+          fiveHourUsedPercent: refreshOutcome.snapshot.fiveHourUtilizationRatio * 100,
+          fiveHourResetsAt: refreshOutcome.snapshot.fiveHourResetsAt?.toISOString() ?? null,
+          fiveHourContributionCapExhausted: state.fiveHourContributionCapExhausted,
+          fiveHourProviderUsageExhausted: refreshOutcome.snapshot.fiveHourUtilizationRatio >= 1,
+          sevenDayUtilizationRatio: refreshOutcome.snapshot.sevenDayUtilizationRatio,
+          sevenDayUsedPercent: refreshOutcome.snapshot.sevenDayUtilizationRatio * 100,
+          sevenDayResetsAt: refreshOutcome.snapshot.sevenDayResetsAt?.toISOString() ?? null,
+          sevenDayContributionCapExhausted: state.sevenDayContributionCapExhausted,
+          sevenDayProviderUsageExhausted: refreshOutcome.snapshot.sevenDayUtilizationRatio >= 1
+        };
 
-      if (
-        state.fetchedAt !== null
-        && state.fiveHourUtilizationRatio !== null
-        && state.sevenDayUtilizationRatio !== null
-        && state.fiveHourSharedThresholdPercent !== null
-        && state.sevenDaySharedThresholdPercent !== null
-      ) {
-        try {
-          lifecycle = await runtime.repos.tokenCredentials.syncClaudeContributionCapLifecycle({
-            id: effectiveCredential.id,
-            orgId: effectiveCredential.orgId,
-            provider: effectiveCredential.provider,
-            snapshotFetchedAt: state.fetchedAt,
-            fiveHourReservePercent: state.fiveHourReservePercent,
-            fiveHourUtilizationRatio: state.fiveHourUtilizationRatio,
-            fiveHourResetsAt: state.fiveHourResetsAt,
-            fiveHourSharedThresholdPercent: state.fiveHourSharedThresholdPercent,
-            fiveHourContributionCapExhausted: state.fiveHourContributionCapExhausted,
-            sevenDayReservePercent: state.sevenDayReservePercent,
-            sevenDayUtilizationRatio: state.sevenDayUtilizationRatio,
-            sevenDayResetsAt: state.sevenDayResetsAt,
-            sevenDaySharedThresholdPercent: state.sevenDaySharedThresholdPercent,
-            sevenDayContributionCapExhausted: state.sevenDayContributionCapExhausted
-          });
-        } catch (error) {
-          stateSyncErrors.push(error instanceof Error ? error.message : 'contribution_cap_lifecycle_sync_failed');
+        if (
+          state.fetchedAt !== null
+          && state.fiveHourUtilizationRatio !== null
+          && state.sevenDayUtilizationRatio !== null
+          && state.fiveHourSharedThresholdPercent !== null
+          && state.sevenDaySharedThresholdPercent !== null
+        ) {
+          try {
+            lifecycle = await runtime.repos.tokenCredentials.syncClaudeContributionCapLifecycle({
+              id: effectiveCredential.id,
+              orgId: effectiveCredential.orgId,
+              provider: effectiveCredential.provider,
+              snapshotFetchedAt: state.fetchedAt,
+              fiveHourReservePercent: state.fiveHourReservePercent,
+              fiveHourUtilizationRatio: state.fiveHourUtilizationRatio,
+              fiveHourResetsAt: state.fiveHourResetsAt,
+              fiveHourSharedThresholdPercent: state.fiveHourSharedThresholdPercent,
+              fiveHourContributionCapExhausted: state.fiveHourContributionCapExhausted,
+              sevenDayReservePercent: state.sevenDayReservePercent,
+              sevenDayUtilizationRatio: state.sevenDayUtilizationRatio,
+              sevenDayResetsAt: state.sevenDayResetsAt,
+              sevenDaySharedThresholdPercent: state.sevenDaySharedThresholdPercent,
+              sevenDayContributionCapExhausted: state.sevenDayContributionCapExhausted
+            });
+          } catch (error) {
+            stateSyncErrors.push(error instanceof Error ? error.message : 'contribution_cap_lifecycle_sync_failed');
+          }
         }
+      } else {
+        snapshotSummary = {
+          usageSource: refreshOutcome.snapshot.usageSource,
+          fetchedAt: refreshOutcome.snapshot.fetchedAt.toISOString(),
+          fiveHourUtilizationRatio: refreshOutcome.snapshot.fiveHourUtilizationRatio,
+          fiveHourUsedPercent: refreshOutcome.snapshot.fiveHourUtilizationRatio * 100,
+          fiveHourResetsAt: refreshOutcome.snapshot.fiveHourResetsAt?.toISOString() ?? null,
+          fiveHourContributionCapExhausted: null,
+          fiveHourProviderUsageExhausted: refreshOutcome.snapshot.fiveHourUtilizationRatio >= 1,
+          sevenDayUtilizationRatio: refreshOutcome.snapshot.sevenDayUtilizationRatio,
+          sevenDayUsedPercent: refreshOutcome.snapshot.sevenDayUtilizationRatio * 100,
+          sevenDayResetsAt: refreshOutcome.snapshot.sevenDayResetsAt?.toISOString() ?? null,
+          sevenDayContributionCapExhausted: null,
+          sevenDayProviderUsageExhausted: refreshOutcome.snapshot.sevenDayUtilizationRatio >= 1
+        };
       }
     }
 
@@ -1145,10 +1177,12 @@ router.post('/v1/admin/token-credentials/:id/provider-usage-refresh', requireApi
       nextProbeAt: nextProbeAt?.toISOString() ?? null,
       retryAfterMs: refreshOutcome.ok ? null : (refreshOutcome.retryAfterMs ?? null),
       errorMessage: refreshOutcome.ok ? null : (refreshOutcome.errorMessage ?? null),
-      reserve: {
-        fiveHourReservePercent: effectiveCredential.fiveHourReservePercent,
-        sevenDayReservePercent: effectiveCredential.sevenDayReservePercent
-      },
+      reserve: isAnthropicOauthCredential
+        ? {
+          fiveHourReservePercent: effectiveCredential.fiveHourReservePercent,
+          sevenDayReservePercent: effectiveCredential.sevenDayReservePercent
+        }
+        : null,
       snapshot: snapshotSummary,
       lifecycle,
       rawPayload: refreshOutcome.rawPayload ?? null,

--- a/api/tests/admin.tokenCredentials.route.test.ts
+++ b/api/tests/admin.tokenCredentials.route.test.ts
@@ -1881,7 +1881,7 @@ describe('admin token credential routes idempotent replay', () => {
     expect(refreshSpy).not.toHaveBeenCalled();
   });
 
-  it('rejects manual provider usage refresh for non-Claude OAuth credentials', async () => {
+  it('allows provider usage refresh for active OpenAI/Codex OAuth credentials', async () => {
     vi.spyOn(runtimeModule.runtime.services.idempotency, 'start').mockResolvedValue({
       replay: false,
       input: {
@@ -1896,11 +1896,60 @@ describe('admin token credential routes idempotent replay', () => {
       orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
       provider: 'openai',
       authScheme: 'bearer',
-      accessToken: 'openai-live-token',
+      accessToken: makeOpenAiOauthToken('2026-03-20T15:49:35.000Z'),
+      refreshToken: 'rt_codex_live',
       debugLabel: 'niyant-codex',
       status: 'active',
       expiresAt: new Date('2026-03-20T00:00:00.000Z')
     } as any);
+    const refreshSpy = vi.spyOn(oauthRefreshModule, 'refreshTokenCredentialProviderUsageWithCredentialRefresh').mockResolvedValue({
+      credential: {
+        id: '11111111-1111-4111-8111-111111111111',
+        orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+        provider: 'openai',
+        authScheme: 'bearer',
+        accessToken: makeOpenAiOauthToken('2026-03-20T15:49:35.000Z'),
+        refreshToken: 'rt_codex_live',
+        debugLabel: 'niyant-codex',
+        status: 'active',
+        expiresAt: new Date('2026-03-20T00:00:00.000Z')
+      },
+      refreshedCredential: null,
+      outcome: {
+        ok: true,
+        rawPayload: {
+          rate_limit: {
+            primary_window: { used_percent: 36, reset_at: 1773655200 },
+            secondary_window: { used_percent: 72, reset_at: 1774112400 }
+          }
+        },
+        snapshot: {
+          tokenCredentialId: '11111111-1111-4111-8111-111111111111',
+          orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+          provider: 'openai',
+          usageSource: 'openai_wham_usage',
+          fiveHourUtilizationRatio: 0.36,
+          fiveHourResetsAt: new Date('2026-03-14T10:00:00.000Z'),
+          sevenDayUtilizationRatio: 0.72,
+          sevenDayResetsAt: new Date('2026-03-19T17:00:00.000Z'),
+          rawPayload: {
+            rate_limit: {
+              primary_window: { used_percent: 36, reset_at: 1773655200 },
+              secondary_window: { used_percent: 72, reset_at: 1774112400 }
+            }
+          },
+          fetchedAt: new Date('2026-03-14T09:45:00.000Z'),
+          createdAt: new Date('2026-03-14T09:45:00.000Z'),
+          updatedAt: new Date('2026-03-14T09:45:00.000Z')
+        }
+      }
+    } as any);
+    const setWarningSpy = vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'setProviderUsageWarning').mockResolvedValue(false);
+    const lifecycleSpy = vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'syncClaudeContributionCapLifecycle').mockResolvedValue({
+      fiveHourTransition: null,
+      sevenDayTransition: null
+    } as any);
+    const commitSpy = vi.spyOn(runtimeModule.runtime.services.idempotency, 'commit').mockResolvedValue(undefined);
 
     const req = createMockReq({
       method: 'POST',
@@ -1917,9 +1966,290 @@ describe('admin token credential routes idempotent replay', () => {
     await invoke(providerUsageRefreshHandlers[0], req, res);
     await invoke(providerUsageRefreshHandlers[1], req, res);
 
-    expect(res.statusCode).toBe(409);
-    expect((res.body as any).code).toBe('invalid_request');
-    expect(String((res.body as any).message)).toContain('Anthropic OAuth credentials');
-    expect(providerUsageModule.refreshAnthropicOauthUsageNow).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(200);
+    expect((res.body as any)).toEqual({
+      ok: true,
+      id: '11111111-1111-4111-8111-111111111111',
+      provider: 'openai',
+      debugLabel: 'niyant-codex',
+      status: 'active',
+      refreshOk: true,
+      upstreamStatus: 200,
+      reason: 'ok',
+      category: null,
+      warningReason: null,
+      nextProbeAt: null,
+      retryAfterMs: null,
+      errorMessage: null,
+      reserve: null,
+      snapshot: {
+        usageSource: 'openai_wham_usage',
+        fetchedAt: '2026-03-14T09:45:00.000Z',
+        fiveHourUtilizationRatio: 0.36,
+        fiveHourUsedPercent: 36,
+        fiveHourResetsAt: '2026-03-14T10:00:00.000Z',
+        fiveHourContributionCapExhausted: null,
+        fiveHourProviderUsageExhausted: false,
+        sevenDayUtilizationRatio: 0.72,
+        sevenDayUsedPercent: 72,
+        sevenDayResetsAt: '2026-03-19T17:00:00.000Z',
+        sevenDayContributionCapExhausted: null,
+        sevenDayProviderUsageExhausted: false
+      },
+      lifecycle: null,
+      rawPayload: {
+        rate_limit: {
+          primary_window: { used_percent: 36, reset_at: 1773655200 },
+          secondary_window: { used_percent: 72, reset_at: 1774112400 }
+        }
+      },
+      stateSyncErrors: []
+    });
+    expect(refreshSpy).toHaveBeenCalledWith(
+      runtimeModule.runtime.repos.tokenCredentialProviderUsage,
+      runtimeModule.runtime.repos.tokenCredentials,
+      expect.objectContaining({
+        id: '11111111-1111-4111-8111-111111111111',
+        provider: 'openai',
+        debugLabel: 'niyant-codex'
+      }),
+      { ignoreRetryBackoff: true }
+    );
+    expect(setWarningSpy).not.toHaveBeenCalled();
+    expect(lifecycleSpy).not.toHaveBeenCalled();
+    expect(commitSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('parks active OpenAI/Codex OAuth credentials on provider usage auth failure and returns the next probe time', async () => {
+    vi.spyOn(runtimeModule.runtime.services.idempotency, 'start').mockResolvedValue({
+      replay: false,
+      input: {
+        scope: 'admin_token_credentials_provider_usage_refresh_v1',
+        tenantScope: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+        idempotencyKey: 'abcdefghijklmnopqrstuvwxyz123465',
+        requestHash: 'provider_usage_refresh_h_6'
+      }
+    } as any);
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'getById').mockResolvedValue({
+      id: '11111111-1111-4111-8111-111111111111',
+      orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      provider: 'openai',
+      authScheme: 'bearer',
+      accessToken: makeOpenAiOauthToken('2026-03-20T15:49:35.000Z'),
+      refreshToken: 'rt_codex_live',
+      debugLabel: 'niyant-codex',
+      status: 'active',
+      expiresAt: new Date('2026-03-20T00:00:00.000Z')
+    } as any);
+    vi.spyOn(oauthRefreshModule, 'refreshTokenCredentialProviderUsageWithCredentialRefresh').mockResolvedValue({
+      credential: {
+        id: '11111111-1111-4111-8111-111111111111',
+        orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+        provider: 'openai',
+        authScheme: 'bearer',
+        accessToken: makeOpenAiOauthToken('2026-03-20T15:49:35.000Z'),
+        refreshToken: 'rt_codex_live',
+        debugLabel: 'niyant-codex',
+        status: 'active',
+        expiresAt: new Date('2026-03-20T00:00:00.000Z')
+      },
+      refreshedCredential: null,
+      outcome: {
+        ok: false,
+        reason: 'status_401',
+        statusCode: 401,
+        category: 'fetch_failed',
+        rawPayload: {
+          error: {
+            message: 'OAuth token expired'
+          }
+        }
+      }
+    } as any);
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'recordFailureAndMaybeMax').mockResolvedValue({
+      status: 'maxed',
+      consecutiveFailures: 1,
+      newlyMaxed: true
+    } as any);
+    const setWarningSpy = vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'setProviderUsageWarning').mockResolvedValue(false);
+    const commitSpy = vi.spyOn(runtimeModule.runtime.services.idempotency, 'commit').mockResolvedValue(undefined);
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/admin/token-credentials/11111111-1111-4111-8111-111111111111/provider-usage-refresh',
+      headers: {
+        authorization: 'Bearer in_admin_token',
+        'content-type': 'application/json',
+        'idempotency-key': 'abcdefghijklmnopqrstuvwxyz123465'
+      },
+      params: { id: '11111111-1111-4111-8111-111111111111' }
+    });
+    const res = createMockRes();
+
+    await invoke(providerUsageRefreshHandlers[0], req, res);
+    await invoke(providerUsageRefreshHandlers[1], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect((res.body as any)).toEqual(expect.objectContaining({
+      ok: true,
+      id: '11111111-1111-4111-8111-111111111111',
+      provider: 'openai',
+      debugLabel: 'niyant-codex',
+      status: 'maxed',
+      refreshOk: false,
+      upstreamStatus: 401,
+      reason: 'status_401',
+      category: 'fetch_failed',
+      warningReason: null,
+      nextProbeAt: expect.any(String),
+      retryAfterMs: null,
+      errorMessage: null,
+      reserve: null,
+      snapshot: null,
+      lifecycle: null,
+      rawPayload: {
+        error: {
+          message: 'OAuth token expired'
+        }
+      }
+    }));
+    expect(runtimeModule.runtime.repos.tokenCredentials.recordFailureAndMaybeMax).toHaveBeenCalledWith(expect.objectContaining({
+      id: '11111111-1111-4111-8111-111111111111',
+      statusCode: 401,
+      threshold: 1,
+      reason: 'upstream_401_provider_usage_refresh'
+    }));
+    expect(setWarningSpy).not.toHaveBeenCalled();
+    expect(commitSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows provider usage refresh to recover an expired OpenAI/Codex credential when a refresh token is stored', async () => {
+    vi.spyOn(runtimeModule.runtime.services.idempotency, 'start').mockResolvedValue({
+      replay: false,
+      input: {
+        scope: 'admin_token_credentials_provider_usage_refresh_v1',
+        tenantScope: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+        idempotencyKey: 'abcdefghijklmnopqrstuvwxyz123466',
+        requestHash: 'provider_usage_refresh_h_7'
+      }
+    } as any);
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'getById').mockResolvedValue({
+      id: '11111111-1111-4111-8111-111111111111',
+      orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      provider: 'openai',
+      authScheme: 'bearer',
+      accessToken: makeOpenAiOauthToken('2026-03-14T10:10:41.407Z'),
+      refreshToken: 'rt_codex_old',
+      debugLabel: 'niyant-codex',
+      status: 'active',
+      expiresAt: new Date('2026-03-14T10:10:41.407Z')
+    } as any);
+    const refreshSpy = vi.spyOn(oauthRefreshModule, 'refreshTokenCredentialProviderUsageWithCredentialRefresh').mockResolvedValue({
+      credential: {
+        id: '11111111-1111-4111-8111-111111111111',
+        orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+        provider: 'openai',
+        authScheme: 'bearer',
+        accessToken: makeOpenAiOauthToken('2026-03-14T15:10:41.407Z'),
+        refreshToken: 'rt_codex_new',
+        debugLabel: 'niyant-codex',
+        status: 'active',
+        expiresAt: new Date('2026-03-14T15:10:41.407Z')
+      },
+      refreshedCredential: {
+        id: '11111111-1111-4111-8111-111111111111',
+        orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+        provider: 'openai',
+        authScheme: 'bearer',
+        accessToken: makeOpenAiOauthToken('2026-03-14T15:10:41.407Z'),
+        refreshToken: 'rt_codex_new',
+        debugLabel: 'niyant-codex',
+        status: 'active',
+        expiresAt: new Date('2026-03-14T15:10:41.407Z')
+      },
+      outcome: {
+        ok: true,
+        rawPayload: {
+          rate_limit: {
+            primary_window: { used_percent: 0, reset_at: 1773655200 },
+            secondary_window: { used_percent: 18, reset_at: 1774112400 }
+          }
+        },
+        snapshot: {
+          tokenCredentialId: '11111111-1111-4111-8111-111111111111',
+          orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+          provider: 'openai',
+          usageSource: 'openai_wham_usage',
+          fiveHourUtilizationRatio: 0,
+          fiveHourResetsAt: new Date('2026-03-14T10:00:00.000Z'),
+          sevenDayUtilizationRatio: 0.18,
+          sevenDayResetsAt: new Date('2026-03-19T17:00:00.000Z'),
+          rawPayload: {
+            rate_limit: {
+              primary_window: { used_percent: 0, reset_at: 1773655200 },
+              secondary_window: { used_percent: 18, reset_at: 1774112400 }
+            }
+          },
+          fetchedAt: new Date('2026-03-14T12:50:00.000Z'),
+          createdAt: new Date('2026-03-14T12:50:00.000Z'),
+          updatedAt: new Date('2026-03-14T12:50:00.000Z')
+        }
+      }
+    } as any);
+    const setWarningSpy = vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'setProviderUsageWarning').mockResolvedValue(false);
+    const lifecycleSpy = vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'syncClaudeContributionCapLifecycle').mockResolvedValue({
+      fiveHourTransition: null,
+      sevenDayTransition: null
+    } as any);
+    const commitSpy = vi.spyOn(runtimeModule.runtime.services.idempotency, 'commit').mockResolvedValue(undefined);
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/admin/token-credentials/11111111-1111-4111-8111-111111111111/provider-usage-refresh',
+      headers: {
+        authorization: 'Bearer in_admin_token',
+        'content-type': 'application/json',
+        'idempotency-key': 'abcdefghijklmnopqrstuvwxyz123466'
+      },
+      params: { id: '11111111-1111-4111-8111-111111111111' }
+    });
+    const res = createMockRes();
+
+    await invoke(providerUsageRefreshHandlers[0], req, res);
+    await invoke(providerUsageRefreshHandlers[1], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect((res.body as any)).toEqual(expect.objectContaining({
+      ok: true,
+      id: '11111111-1111-4111-8111-111111111111',
+      provider: 'openai',
+      debugLabel: 'niyant-codex',
+      status: 'active',
+      refreshOk: true,
+      upstreamStatus: 200,
+      reason: 'ok',
+      nextProbeAt: null,
+      reserve: null,
+      snapshot: expect.objectContaining({
+        fiveHourUsedPercent: 0,
+        sevenDayUsedPercent: 18,
+        fiveHourContributionCapExhausted: null,
+        sevenDayContributionCapExhausted: null
+      }),
+      lifecycle: null
+    }));
+    expect(refreshSpy).toHaveBeenCalledWith(
+      runtimeModule.runtime.repos.tokenCredentialProviderUsage,
+      runtimeModule.runtime.repos.tokenCredentials,
+      expect.objectContaining({
+        id: '11111111-1111-4111-8111-111111111111',
+        provider: 'openai',
+        debugLabel: 'niyant-codex'
+      }),
+      { ignoreRetryBackoff: true }
+    );
+    expect(setWarningSpy).not.toHaveBeenCalled();
+    expect(lifecycleSpy).not.toHaveBeenCalled();
+    expect(commitSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/docs/API_CONTRACT.md
+++ b/docs/API_CONTRACT.md
@@ -309,41 +309,41 @@ Notes:
 - auth-diagnosis fields are best-effort operator hints; they are omitted when Innies cannot derive anything more specific than the raw probe result
 
 ### `POST /v1/admin/token-credentials/:id/provider-usage-refresh`
-Refresh Claude provider usage for a token immediately (admin only).
+Refresh provider usage for a token immediately (admin only).
 
 Response shape:
-- `refreshOk`: whether the Anthropic usage refresh succeeded
+- `refreshOk`: whether the provider usage refresh succeeded
 - `status`: current Innies credential status
 - `upstreamStatus`: upstream HTTP status when available
 - `reason`: refresh result reason (`ok|status_<code>|network:<message>|invalid_payload:*|provider_usage_snapshot_write_failed`)
-- `category`: refresh failure category (`fetch_failed|fetch_backoff|snapshot_write_failed`) or `null`
-- `warningReason`: operator warning state synced from the refresh result when applicable
+- `category`: refresh failure category (`fetch_failed|fetch_backoff|invalid_payload|snapshot_write_failed`) or `null`
+- `warningReason`: operator warning state synced from the refresh result when applicable; currently Anthropic-only and `null` for OpenAI/Codex
 - `nextProbeAt`: next scheduled auth-recovery probe time when a usage refresh auth-failure parked the credential
 - `retryAfterMs`: retry backoff duration when the refresh failed and surfaced one
-- `reserve`: stored `fiveHourReservePercent` / `sevenDayReservePercent`
+- `reserve`: stored `fiveHourReservePercent` / `sevenDayReservePercent` for Anthropic credentials, otherwise `null`
 - `snapshot`: parsed snapshot summary when refresh succeeded:
   - `usageSource`
   - `fetchedAt`
   - `fiveHourUtilizationRatio`
   - `fiveHourUsedPercent`
   - `fiveHourResetsAt`
-  - `fiveHourContributionCapExhausted`
+  - `fiveHourContributionCapExhausted` (`null` for OpenAI/Codex)
   - `fiveHourProviderUsageExhausted`
   - `sevenDayUtilizationRatio`
   - `sevenDayUsedPercent`
   - `sevenDayResetsAt`
-  - `sevenDayContributionCapExhausted`
+  - `sevenDayContributionCapExhausted` (`null` for OpenAI/Codex)
   - `sevenDayProviderUsageExhausted`
-- `lifecycle`: contribution-cap lifecycle transitions emitted during sync (`fiveHourTransition`, `sevenDayTransition`)
-- `rawPayload`: raw Anthropic usage payload when one was returned
+- `lifecycle`: Anthropic contribution-cap lifecycle transitions emitted during sync (`fiveHourTransition`, `sevenDayTransition`), otherwise `null`
+- `rawPayload`: raw Anthropic or OpenAI/Codex usage payload when one was returned
 - `stateSyncErrors`: non-fatal warning/lifecycle sync errors encountered after refresh
 
 Notes:
-- intended operator use: compare Anthropic's raw quota payload with Innies' parsed 5h / 7d view for a specific Claude token
-- supported for Anthropic OAuth credentials; expired access tokens can still be refreshed here when Innies has a stored OAuth refresh token
-- route bypasses in-memory usage-fetch backoff so operators can debug a token immediately
-- successful refresh persists the latest snapshot locally and attempts to sync warning + contribution-cap lifecycle state
-- upstream `401` / `403` from the usage endpoint is treated as an auth failure: Innies parks the credential, schedules probe recovery, and stops treating the token like merely stale quota state
+- intended operator use: compare the upstream raw quota payload with Innies' parsed 5h / 7d view for a specific Claude Code or Codex token
+- supported for Anthropic and OpenAI/Codex OAuth credentials; expired access tokens can still be refreshed here when Innies has a stored OAuth refresh token
+- route bypasses Anthropic in-memory usage-fetch backoff so operators can debug a Claude token immediately, and it uses the shared provider-usage-plus-token-refresh helper for both providers
+- successful refresh persists the latest snapshot locally; warning sync and contribution-cap lifecycle sync remain Anthropic-only follow-up state
+- upstream `401` / `403` from the usage endpoint is treated as an auth failure for active credentials: Innies parks the credential, schedules probe recovery, and stops treating the token like merely stale quota state
 
 ### `GET /v1/admin/buyer-keys/:id/provider-preference`
 Read provider preference for a buyer API key (admin only).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -55,7 +55,7 @@ What they do:
 - `innies-token-contribution-cap-set`: set the 5h / 7d reserve percents for a Claude token credential
 - `innies-token-refresh-token-set`: set or clear the stored OAuth refresh token for an existing credential id
 - `innies-token-probe-run`: directly probe an active or maxed token credential now; successful maxed probes immediately reactivate it
-- `innies-token-usage-refresh`: fetch Claude provider usage for a token now and print raw plus parsed 5h / 7d values
+- `innies-token-usage-refresh`: fetch provider usage for a Claude Code or Codex token now and print raw plus parsed 5h / 7d values
 - `innies-buyer-key-create`: create a new buyer key in `in_api_keys` and prompt for provider preference up front
 - `innies-buyer-preference-set`: set a buyer key preference to `Claude Code`, `Codex`, or `null`
 - `innies-buyer-preference-get`: read the current buyer key preference
@@ -95,10 +95,11 @@ Behavior:
 - `innies-token-probe-run` also needs `INNIES_ADMIN_API_KEY` (or prompts for it) because it calls the admin API probe endpoint directly
 - `innies-token-probe-run` now prints a plain-English result summary (`REACTIVATED`, `PROBE OK, NO STATUS CHANGE`, or `PROBE FAILED, NO STATUS CHANGE`) before the raw JSON response
 - `innies-token-probe-run` also prints auth diagnosis details when the backend can derive them, including local OpenAI OAuth expiry and missing-refresh-token state
-- `innies-token-usage-refresh` accepts a credential number, UUID, or exact Claude `debugLabel`; it needs `DATABASE_URL`
-- `innies-token-usage-refresh` lists unexpired Claude credentials in `active|paused|maxed`, plus expired Claude OAuth credentials that still have a stored refresh token (shown as `expired`) so you can recover them manually
+- `innies-token-usage-refresh` accepts a credential number, UUID, or exact `debugLabel`; it needs `DATABASE_URL`
+- `innies-token-usage-refresh` lists unexpired Claude Code and Codex credentials in `active|paused|maxed`, plus expired OAuth credentials from either provider that still have a stored refresh token (shown as `expired`) so you can recover them manually
 - `innies-token-usage-refresh` also needs `INNIES_ADMIN_API_KEY` (or prompts for it) because it calls the admin API provider-usage refresh endpoint directly
-- `innies-token-usage-refresh` bypasses in-memory usage-fetch backoff and prints both parsed 5h / 7d usage plus the raw Anthropic payload
+- `innies-token-usage-refresh` bypasses Anthropic in-memory usage-fetch backoff and prints both parsed 5h / 7d usage plus the raw upstream payload for either provider
+- `innies-token-usage-refresh` only prints contribution-cap exhaustion lines when the backend returns Claude-specific cap state; Codex/OpenAI refreshes leave those fields `null`
 - `label` maps to API field `debugLabel`
 - set/get preference accept either the buyer-key UUID or the live buyer key value; live-key lookup uses `DATABASE_URL`
 - script-side default provider display for `null` preference follows `BUYER_PROVIDER_PREFERENCE_DEFAULT` (legacy alias `INNIES_BUYER_PROVIDER_PREFERENCE_DEFAULT` also works)

--- a/scripts/innies-token-usage-refresh.sh
+++ b/scripts/innies-token-usage-refresh.sh
@@ -14,25 +14,28 @@ ensure_admin_token
 ensure_database_url
 ensure_psql
 
-echo 'Claude Code token credentials:'
+echo 'Token credentials eligible for manual provider-usage refresh:'
 credential_rows="$(
   psql "$DATABASE_URL" -X -A -F $'\x1f' -t -v ON_ERROR_STOP=1 <<'SQL'
 select
   id,
   coalesce(debug_label, ''),
+  provider,
   case
     when expires_at <= now() then 'expired'
     else status
   end as display_status,
   to_char(updated_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as updated_at_utc
 from in_token_credentials
-where provider = 'anthropic'
+where status <> 'revoked'
+  and provider in ('anthropic', 'openai')
   and (
     (status in ('active', 'paused', 'maxed') and expires_at > now())
-    or (expires_at <= now() and encrypted_refresh_token is not null and status <> 'revoked')
+    or (expires_at <= now() and encrypted_refresh_token is not null)
   )
 order by
   case when expires_at <= now() then 1 else 0 end,
+  provider asc,
   updated_at desc;
 SQL
 )"
@@ -41,13 +44,13 @@ credential_rows="$(printf '%s\n' "$credential_rows" | sed '/^[[:space:]]*$/d')"
 credential_ids=()
 if [[ -n "$credential_rows" ]]; then
   selection_index=0
-  while IFS=$'\x1f' read -r listed_id listed_label listed_status listed_updated_at; do
+  while IFS=$'\x1f' read -r listed_id listed_label listed_provider listed_status listed_updated_at; do
     selection_index=$((selection_index + 1))
     credential_ids+=("$listed_id")
     if [[ -n "$listed_label" ]]; then
-      echo "  ${selection_index}) ${listed_label} (${listed_status}) id=${listed_id} updatedAt=${listed_updated_at}"
+      echo "  ${selection_index}) ${listed_label} (${listed_provider}, ${listed_status}) id=${listed_id} updatedAt=${listed_updated_at}"
     else
-      echo "  ${selection_index}) (no label) (${listed_status}) id=${listed_id} updatedAt=${listed_updated_at}"
+      echo "  ${selection_index}) (no label) (${listed_provider}, ${listed_status}) id=${listed_id} updatedAt=${listed_updated_at}"
     fi
   done <<< "$credential_rows"
 else
@@ -65,13 +68,13 @@ if [[ "$credential_input" =~ ^[0-9]+$ ]]; then
   fi
   credential_id="${credential_ids[$((selection_number - 1))]}"
 else
-  credential_id="$(resolve_token_credential_id "$credential_input" "anthropic")"
+  credential_id="$(resolve_token_credential_id "$credential_input")"
 fi
 
 idk="$(prompt 'Idempotency-Key (press Enter to auto-generate)' "$(gen_idempotency_key)")"
 
 echo "tokenCredentialId: $credential_id"
-echo 'Action: direct Claude provider-usage refresh'
+echo 'Action: direct provider-usage refresh'
 
 headers_file="$(mktemp)"
 body_file="$(mktemp)"
@@ -112,10 +115,10 @@ state_sync_errors="$(jq -c '.stateSyncErrors // []' "$body_file")"
 if [[ "$refresh_ok" == "true" ]]; then
   five_hour_used_percent="$(jq -r '.snapshot.fiveHourUsedPercent // "null"' "$body_file")"
   five_hour_resets_at="$(jq -r '.snapshot.fiveHourResetsAt // "null"' "$body_file")"
-  five_hour_cap_exhausted="$(jq -r '.snapshot.fiveHourContributionCapExhausted // false' "$body_file")"
+  five_hour_cap_exhausted="$(jq -r '.snapshot.fiveHourContributionCapExhausted // "null"' "$body_file")"
   seven_day_used_percent="$(jq -r '.snapshot.sevenDayUsedPercent // "null"' "$body_file")"
   seven_day_resets_at="$(jq -r '.snapshot.sevenDayResetsAt // "null"' "$body_file")"
-  seven_day_cap_exhausted="$(jq -r '.snapshot.sevenDayContributionCapExhausted // false' "$body_file")"
+  seven_day_cap_exhausted="$(jq -r '.snapshot.sevenDayContributionCapExhausted // "null"' "$body_file")"
 
   echo
   echo 'Usage refresh result: SUCCESS'
@@ -128,10 +131,14 @@ if [[ "$refresh_ok" == "true" ]]; then
   echo "upstream: ${result_upstream_status} (${result_reason})"
   echo "5h used: ${five_hour_used_percent}%"
   echo "5h reset: ${five_hour_resets_at}"
-  echo "5h cap exhausted: ${five_hour_cap_exhausted}"
+  if [[ "$five_hour_cap_exhausted" != "null" ]]; then
+    echo "5h cap exhausted: ${five_hour_cap_exhausted}"
+  fi
   echo "7d used: ${seven_day_used_percent}%"
   echo "7d reset: ${seven_day_resets_at}"
-  echo "7d cap exhausted: ${seven_day_cap_exhausted}"
+  if [[ "$seven_day_cap_exhausted" != "null" ]]; then
+    echo "7d cap exhausted: ${seven_day_cap_exhausted}"
+  fi
 else
   echo
   echo 'Usage refresh result: FAILED'


### PR DESCRIPTION
**@worker-01**

## Summary
- enable manual admin provider-usage refresh for active or refreshable OpenAI/Codex credentials through the shared helper from #151
- keep Anthropic reserve and lifecycle behavior intact while returning explicit `null` for Claude-only fields on OpenAI/Codex responses
- update the operator script and docs so one refresh command covers both providers

## Testing
- `pnpm --dir api exec vitest run tests/admin.tokenCredentials.route.test.ts`
- `bash -n scripts/innies-token-usage-refresh.sh`
