### PR TITLE
fix: reject unsupported OpenAI/Codex manual refresh requests

### DIFF
--- a/api/src/routes/admin.ts
+++ b/api/src/routes/admin.ts
@@ -6,7 +6,9 @@ import { requireApiKey } from '../middleware/auth.js';
 import { runtime } from '../services/runtime.js';
 import { readClaudeContributionCapSnapshotState } from '../services/claudeContributionCapState.js';
 import {
+  type AnthropicOauthUsageRefreshOutcome,
   isAnthropicOauthTokenCredential,
+  isTokenCredentialProviderUsageRefreshSupported,
   parkAnthropicOauthCredentialAfterUsageAuthFailure,
   providerUsageWarningReasonFromRefreshOutcome
 } from '../services/tokenCredentialProviderUsage.js';
@@ -1012,11 +1014,11 @@ router.post('/v1/admin/token-credentials/:id/provider-usage-refresh', requireApi
       throw new AppError('invalid_request', 409, 'Revoked token credential cannot refresh provider usage');
     }
     const isAnthropicOauthCredential = isAnthropicOauthTokenCredential(existing);
-    if (!isAnthropicOauthCredential && existing.provider !== 'openai' && existing.provider !== 'codex') {
+    if (!isTokenCredentialProviderUsageRefreshSupported(existing)) {
       throw new AppError(
         'invalid_request',
         409,
-        'Provider usage refresh is only supported for Anthropic and OpenAI/Codex OAuth credentials',
+        'Provider usage refresh is only supported for Anthropic OAuth and OpenAI/Codex OAuth or session credentials',
         {
           provider: existing.provider,
           status: existing.status
@@ -1062,8 +1064,11 @@ router.post('/v1/admin/token-credentials/:id/provider-usage-refresh', requireApi
         reason: `upstream_${authFailureStatusCode}_provider_usage_refresh`
       })
       : null;
-    const warningReason = isAnthropicOauthCredential && authFailureStatusCode === null
-      ? providerUsageWarningReasonFromRefreshOutcome(refreshOutcome)
+    const anthropicRefreshOutcome = isAnthropicOauthCredential
+      ? refreshOutcome as AnthropicOauthUsageRefreshOutcome
+      : null;
+    const warningReason = anthropicRefreshOutcome !== null && authFailureStatusCode === null
+      ? providerUsageWarningReasonFromRefreshOutcome(anthropicRefreshOutcome)
       : null;
     const stateSyncErrors: string[] = [];
     let lifecycle = isAnthropicOauthCredential
@@ -1175,7 +1180,9 @@ router.post('/v1/admin/token-credentials/:id/provider-usage-refresh', requireApi
       category: refreshOutcome.ok ? null : refreshOutcome.category,
       warningReason,
       nextProbeAt: nextProbeAt?.toISOString() ?? null,
-      retryAfterMs: refreshOutcome.ok ? null : (refreshOutcome.retryAfterMs ?? null),
+      retryAfterMs: !refreshOutcome.ok && 'retryAfterMs' in refreshOutcome
+        ? (refreshOutcome.retryAfterMs ?? null)
+        : null,
       errorMessage: refreshOutcome.ok ? null : (refreshOutcome.errorMessage ?? null),
       reserve: isAnthropicOauthCredential
         ? {

--- a/api/src/services/tokenCredentialProviderUsage.ts
+++ b/api/src/services/tokenCredentialProviderUsage.ts
@@ -164,6 +164,20 @@ export function isAnthropicOauthTokenCredential(credential: Pick<TokenCredential
   return credential.provider === 'anthropic' && credential.accessToken.includes('sk-ant-oat');
 }
 
+export function isOpenAiProviderUsageRefreshCredential(
+  credential: Pick<TokenCredential, 'provider' | 'accessToken'>
+): boolean {
+  return (credential.provider === 'openai' || credential.provider === 'codex')
+    && isOpenAiOauthAccessToken(credential.accessToken);
+}
+
+export function isTokenCredentialProviderUsageRefreshSupported(
+  credential: Pick<TokenCredential, 'provider' | 'accessToken'>
+): boolean {
+  return isAnthropicOauthTokenCredential(credential)
+    || isOpenAiProviderUsageRefreshCredential(credential);
+}
+
 function readAnthropicOauthUsageUrl(): URL {
   const baseUrl = process.env.ANTHROPIC_OAUTH_USAGE_BASE_URL
     || process.env.ANTHROPIC_UPSTREAM_BASE_URL
@@ -444,10 +458,7 @@ async function fetchOpenAiOauthUsagePayload(
   credential: TokenCredential,
   timeoutMs: number
 ): Promise<OpenAiOauthUsageRefreshOutcome> {
-  if (
-    (credential.provider !== 'openai' && credential.provider !== 'codex')
-    || !isOpenAiOauthAccessToken(credential.accessToken)
-  ) {
+  if (!isOpenAiProviderUsageRefreshCredential(credential)) {
     return {
       ok: false,
       reason: 'unsupported_credential',

--- a/api/tests/admin.tokenCredentials.route.test.ts
+++ b/api/tests/admin.tokenCredentials.route.test.ts
@@ -2020,6 +2020,57 @@ describe('admin token credential routes idempotent replay', () => {
     expect(commitSpy).toHaveBeenCalledTimes(1);
   });
 
+  it('rejects unsupported OpenAI/Codex provider usage refresh credentials before building a success envelope', async () => {
+    vi.spyOn(runtimeModule.runtime.services.idempotency, 'start').mockResolvedValue({
+      replay: false,
+      input: {
+        scope: 'admin_token_credentials_provider_usage_refresh_v1',
+        tenantScope: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+        idempotencyKey: 'abcdefghijklmnopqrstuvwxyz123467',
+        requestHash: 'provider_usage_refresh_h_8'
+      }
+    } as any);
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'getById').mockResolvedValue({
+      id: '11111111-1111-4111-8111-111111111111',
+      orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      provider: 'openai',
+      authScheme: 'bearer',
+      accessToken: 'not-an-openai-oauth-session-token',
+      refreshToken: 'rt_codex_live',
+      debugLabel: 'unsupported-openai',
+      status: 'active',
+      expiresAt: new Date('2026-03-20T00:00:00.000Z')
+    } as any);
+    const refreshSpy = vi.spyOn(oauthRefreshModule, 'refreshTokenCredentialProviderUsageWithCredentialRefresh');
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/admin/token-credentials/11111111-1111-4111-8111-111111111111/provider-usage-refresh',
+      headers: {
+        authorization: 'Bearer in_admin_token',
+        'content-type': 'application/json',
+        'idempotency-key': 'abcdefghijklmnopqrstuvwxyz123467'
+      },
+      params: { id: '11111111-1111-4111-8111-111111111111' }
+    });
+    const res = createMockRes();
+
+    await invoke(providerUsageRefreshHandlers[0], req, res);
+    await invoke(providerUsageRefreshHandlers[1], req, res);
+
+    expect(res.statusCode).toBe(409);
+    expect((res.body as any)).toEqual(expect.objectContaining({
+      code: 'invalid_request',
+      details: expect.objectContaining({
+        provider: 'openai',
+        status: 'active'
+      })
+    }));
+    expect(String((res.body as any).message)).toContain('OpenAI/Codex OAuth or session credentials');
+    expect((res.body as any).ok).toBeUndefined();
+    expect(refreshSpy).not.toHaveBeenCalled();
+  });
+
   it('parks active OpenAI/Codex OAuth credentials on provider usage auth failure and returns the next probe time', async () => {
     vi.spyOn(runtimeModule.runtime.services.idempotency, 'start').mockResolvedValue({
       replay: false,

--- a/docs/API_CONTRACT.md
+++ b/docs/API_CONTRACT.md
@@ -340,7 +340,8 @@ Response shape:
 
 Notes:
 - intended operator use: compare the upstream raw quota payload with Innies' parsed 5h / 7d view for a specific Claude Code or Codex token
-- supported for Anthropic and OpenAI/Codex OAuth credentials; expired access tokens can still be refreshed here when Innies has a stored OAuth refresh token
+- supported for Anthropic OAuth credentials and OpenAI/Codex OAuth or session credentials; expired access tokens can still be refreshed here when Innies has a stored OAuth refresh token
+- unsupported non-OAuth or non-session OpenAI/Codex credentials fail early with `409 invalid_request` before any `ok: true` response envelope is built
 - route bypasses Anthropic in-memory usage-fetch backoff so operators can debug a Claude token immediately, and it uses the shared provider-usage-plus-token-refresh helper for both providers
 - successful refresh persists the latest snapshot locally; warning sync and contribution-cap lifecycle sync remain Anthropic-only follow-up state
 - upstream `401` / `403` from the usage endpoint is treated as an auth failure for active credentials: Innies parks the credential, schedules probe recovery, and stops treating the token like merely stale quota state

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -96,8 +96,9 @@ Behavior:
 - `innies-token-probe-run` now prints a plain-English result summary (`REACTIVATED`, `PROBE OK, NO STATUS CHANGE`, or `PROBE FAILED, NO STATUS CHANGE`) before the raw JSON response
 - `innies-token-probe-run` also prints auth diagnosis details when the backend can derive them, including local OpenAI OAuth expiry and missing-refresh-token state
 - `innies-token-usage-refresh` accepts a credential number, UUID, or exact `debugLabel`; it needs `DATABASE_URL`
-- `innies-token-usage-refresh` lists unexpired Claude Code and Codex credentials in `active|paused|maxed`, plus expired OAuth credentials from either provider that still have a stored refresh token (shown as `expired`) so you can recover them manually
+- `innies-token-usage-refresh` lists only manual-refresh-eligible credentials: unexpired Claude Code and OpenAI/Codex OAuth/session credentials in `active|paused|maxed`, plus expired OAuth credentials from either provider that still have a stored refresh token (shown as `expired`)
 - `innies-token-usage-refresh` also needs `INNIES_ADMIN_API_KEY` (or prompts for it) because it calls the admin API provider-usage refresh endpoint directly
+- `innies-token-usage-refresh` uses local credential decryption to hide unsupported OpenAI/Codex rows from the numbered selector; it reads `SELLER_SECRET_ENC_KEY_B64` from the environment or `api/.env` when needed
 - `innies-token-usage-refresh` bypasses Anthropic in-memory usage-fetch backoff and prints both parsed 5h / 7d usage plus the raw upstream payload for either provider
 - `innies-token-usage-refresh` only prints contribution-cap exhaustion lines when the backend returns Claude-specific cap state; Codex/OpenAI refreshes leave those fields `null`
 - `label` maps to API field `debugLabel`

--- a/scripts/innies-token-usage-refresh.sh
+++ b/scripts/innies-token-usage-refresh.sh
@@ -10,12 +10,20 @@ done
 SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
 source "${SCRIPT_DIR}/_common.sh"
 
+if [[ -z "${SELLER_SECRET_ENC_KEY_B64:-}" && -f "${ROOT_DIR}/api/.env" ]]; then
+  SELLER_SECRET_ENC_KEY_B64="$(sed -n 's/^SELLER_SECRET_ENC_KEY_B64=//p' "${ROOT_DIR}/api/.env" | head -n 1)"
+fi
+export SELLER_SECRET_ENC_KEY_B64
+
 ensure_admin_token
 ensure_database_url
 ensure_psql
+if ! command -v node >/dev/null 2>&1; then
+  echo 'error: node is required for this command' >&2
+  exit 1
+fi
 
-echo 'Token credentials eligible for manual provider-usage refresh:'
-credential_rows="$(
+list_manual_provider_usage_candidates() {
   psql "$DATABASE_URL" -X -A -F $'\x1f' -t -v ON_ERROR_STOP=1 <<'SQL'
 select
   id,
@@ -25,7 +33,9 @@ select
     when expires_at <= now() then 'expired'
     else status
   end as display_status,
-  to_char(updated_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as updated_at_utc
+  to_char(updated_at at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as updated_at_utc,
+  auth_scheme,
+  encode(encrypted_access_token, 'base64') as encrypted_access_token_b64
 from in_token_credentials
 where status <> 'revoked'
   and provider in ('anthropic', 'openai', 'codex')
@@ -38,6 +48,137 @@ order by
   provider asc,
   updated_at desc;
 SQL
+}
+
+filter_manual_provider_usage_candidates() {
+  node --input-type=module -e '
+import { createDecipheriv } from "node:crypto";
+
+const encodedKey = process.env.SELLER_SECRET_ENC_KEY_B64 ?? "";
+const key = encodedKey ? Buffer.from(encodedKey, "base64") : null;
+
+function readStdin() {
+  return new Promise((resolve) => {
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => {
+      data += chunk;
+    });
+    process.stdin.on("end", () => resolve(data));
+  });
+}
+
+function decodeBase64UrlSegment(segment) {
+  const normalized = segment.replace(/-/g, "+").replace(/_/g, "/");
+  const padding = normalized.length % 4;
+  const padded = padding === 0 ? normalized : normalized + "=".repeat(4 - padding);
+  try {
+    return Buffer.from(padded, "base64").toString("utf8");
+  } catch {
+    return null;
+  }
+}
+
+function parseOpenAiOauthAccessToken(accessToken) {
+  const parts = accessToken.trim().split(".");
+  if (parts.length !== 3) return null;
+
+  const payloadJson = decodeBase64UrlSegment(parts[1]);
+  if (!payloadJson) return null;
+
+  let payload;
+  try {
+    payload = JSON.parse(payloadJson);
+  } catch {
+    return null;
+  }
+
+  const issuer = typeof payload.iss === "string" ? payload.iss.trim() : null;
+  if (issuer !== "https://auth.openai.com") return null;
+
+  const authClaim = payload["https://api.openai.com/auth"];
+  const clientId = typeof payload.client_id === "string" && payload.client_id.trim().length > 0
+    ? payload.client_id.trim()
+    : null;
+  const accountId = authClaim && typeof authClaim === "object" && !Array.isArray(authClaim)
+    && typeof authClaim.chatgpt_account_id === "string" && authClaim.chatgpt_account_id.trim().length > 0
+    ? authClaim.chatgpt_account_id.trim()
+    : (typeof payload.chatgpt_account_id === "string" && payload.chatgpt_account_id.trim().length > 0
+      ? payload.chatgpt_account_id.trim()
+      : null);
+  const audience = Array.isArray(payload.aud)
+    ? payload.aud.filter((entry) => typeof entry === "string" && entry.trim().length > 0)
+    : (typeof payload.aud === "string" && payload.aud.trim().length > 0 ? [payload.aud.trim()] : []);
+  const hasOpenAiAudience = audience.some((entry) => entry.includes("api.openai.com"));
+
+  if (!clientId && !accountId && !hasOpenAiAudience) return null;
+  return { issuer, clientId, accountId };
+}
+
+function parseEnvelope(raw) {
+  try {
+    const parsed = JSON.parse(raw);
+    if (
+      parsed
+      && parsed.v === 1
+      && parsed.alg === "aes-256-gcm"
+      && typeof parsed.iv === "string"
+      && typeof parsed.tag === "string"
+      && typeof parsed.ct === "string"
+    ) {
+      return parsed;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function decryptSecret(encodedValue) {
+  const raw = Buffer.from(encodedValue, "base64").toString("utf8");
+  const envelope = parseEnvelope(raw);
+  if (!envelope) {
+    return raw;
+  }
+  if (!key || key.length !== 32) {
+    throw new Error("SELLER_SECRET_ENC_KEY_B64 is required to filter encrypted OpenAI/Codex credentials");
+  }
+  const decipher = createDecipheriv("aes-256-gcm", key, Buffer.from(envelope.iv, "base64"));
+  decipher.setAuthTag(Buffer.from(envelope.tag, "base64"));
+  const plaintext = Buffer.concat([
+    decipher.update(Buffer.from(envelope.ct, "base64")),
+    decipher.final()
+  ]);
+  return plaintext.toString("utf8");
+}
+
+const input = await readStdin();
+const lines = input.split(/\r?\n/).filter((line) => line.trim().length > 0);
+const filtered = [];
+
+for (const line of lines) {
+  const parts = line.split("\x1f");
+  if (parts.length < 7) continue;
+  const [id, label, provider, displayStatus, updatedAtUtc, _authScheme, encryptedAccessTokenB64] = parts;
+
+  if (provider === "anthropic") {
+    filtered.push([id, label, provider, displayStatus, updatedAtUtc].join("\x1f"));
+    continue;
+  }
+
+  const accessToken = decryptSecret(encryptedAccessTokenB64);
+  if (parseOpenAiOauthAccessToken(accessToken)) {
+    filtered.push([id, label, provider, displayStatus, updatedAtUtc].join("\x1f"));
+  }
+}
+
+process.stdout.write(filtered.join("\n"));
+'
+}
+
+echo 'Token credentials eligible for manual provider-usage refresh:'
+credential_rows="$(
+  list_manual_provider_usage_candidates | filter_manual_provider_usage_candidates
 )"
 credential_rows="$(printf '%s\n' "$credential_rows" | sed '/^[[:space:]]*$/d')"
 

--- a/scripts/tests/innies-token-usage-refresh.test.sh
+++ b/scripts/tests/innies-token-usage-refresh.test.sh
@@ -21,25 +21,67 @@ assert_contains() {
   [[ "$haystack" == *"$needle"* ]] || fail "missing expected text: $needle"
 }
 
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  [[ "$haystack" != *"$needle"* ]] || fail "unexpected text present: $needle"
+}
+
+make_openai_oauth_token() {
+  node --input-type=module - "$1" <<'EOF'
+import process from 'node:process';
+
+const expiry = process.argv[2];
+const encode = (value) => Buffer.from(JSON.stringify(value), 'utf8')
+  .toString('base64')
+  .replace(/\+/g, '-')
+  .replace(/\//g, '_')
+  .replace(/=+$/g, '');
+
+const token = [
+  encode({ alg: 'none', typ: 'JWT' }),
+  encode({
+    iss: 'https://auth.openai.com',
+    aud: ['https://api.openai.com/v1'],
+    client_id: 'app_test_client',
+    exp: Math.floor(new Date(expiry).getTime() / 1000),
+    'https://api.openai.com/auth': {
+      chatgpt_account_id: 'acct_test'
+    }
+  }),
+  'sig'
+].join('.');
+
+process.stdout.write(token);
+EOF
+}
+
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
 
-: > "${tmp_dir}/test.env"
+sell_secret="$(node --input-type=module -e "process.stdout.write(Buffer.alloc(32, 7).toString('base64'))")"
+openai_token="$(make_openai_oauth_token '2026-03-20T15:49:35.000Z')"
+codex_token="$(make_openai_oauth_token '2026-03-21T15:49:35.000Z')"
+unsupported_token='sk-proj-not-supported-here'
 
-cat > "${tmp_dir}/psql" <<'EOF'
+anthropic_token_b64="$(printf 'sk-ant-oat01-live' | base64 | tr -d '\n')"
+openai_token_b64="$(printf '%s' "$openai_token" | base64 | tr -d '\n')"
+codex_token_b64="$(printf '%s' "$codex_token" | base64 | tr -d '\n')"
+unsupported_token_b64="$(printf '%s' "$unsupported_token" | base64 | tr -d '\n')"
+
+cat > "${tmp_dir}/test.env" <<EOF
+SELLER_SECRET_ENC_KEY_B64=${sell_secret}
+EOF
+
+cat > "${tmp_dir}/psql" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
 
-sql="$(cat)"
-
-if [[ "$sql" == *"provider in ('anthropic', 'openai', 'codex')"* ]]; then
-  printf 'anthropic-id\x1fclaude-primary\x1fanthropic\x1factive\x1f2026-03-19T12:00:00Z\n'
-  printf 'openai-id\x1fopenai-primary\x1fopenai\x1factive\x1f2026-03-19T11:00:00Z\n'
-  printf 'codex-id\x1fcodex-legacy\x1fcodex\x1factive\x1f2026-03-19T10:00:00Z\n'
-else
-  printf 'anthropic-id\x1fclaude-primary\x1fanthropic\x1factive\x1f2026-03-19T12:00:00Z\n'
-  printf 'openai-id\x1fopenai-primary\x1fopenai\x1factive\x1f2026-03-19T11:00:00Z\n'
-fi
+cat >/dev/null
+printf 'anthropic-id\x1fclaude-primary\x1fanthropic\x1factive\x1f2026-03-19T12:00:00Z\x1fbearer\x1f${anthropic_token_b64}\n'
+printf 'openai-id\x1fopenai-primary\x1fopenai\x1factive\x1f2026-03-19T11:00:00Z\x1fbearer\x1f${openai_token_b64}\n'
+printf 'unsupported-id\x1fopenai-api-key\x1fopenai\x1factive\x1f2026-03-19T10:30:00Z\x1fbearer\x1f${unsupported_token_b64}\n'
+printf 'codex-id\x1fcodex-session\x1fcodex\x1factive\x1f2026-03-19T10:00:00Z\x1fbearer\x1f${codex_token_b64}\n'
 EOF
 chmod +x "${tmp_dir}/psql"
 
@@ -78,7 +120,7 @@ Content-Type: application/json
 
 HEADERS
 cat > "$body_file" <<'JSON'
-{"refreshOk":true,"provider":"codex","debugLabel":"codex-legacy","status":"active","reason":"ok","upstreamStatus":200,"snapshot":{"fiveHourUsedPercent":12,"fiveHourResetsAt":"2026-03-19T12:00:00Z","fiveHourContributionCapExhausted":false,"sevenDayUsedPercent":34,"sevenDayResetsAt":"2026-03-25T12:00:00Z","sevenDayContributionCapExhausted":false},"stateSyncErrors":[]}
+{"refreshOk":true,"provider":"codex","debugLabel":"codex-session","status":"active","reason":"ok","upstreamStatus":200,"snapshot":{"fiveHourUsedPercent":12,"fiveHourResetsAt":"2026-03-19T12:00:00Z","fiveHourContributionCapExhausted":null,"sevenDayUsedPercent":34,"sevenDayResetsAt":"2026-03-25T12:00:00Z","sevenDayContributionCapExhausted":null},"stateSyncErrors":[]}
 JSON
 printf '200'
 EOF
@@ -96,12 +138,16 @@ if ! output="$(
   fail "expected script to accept numbered codex selection, got:\n${output}"
 fi
 
-assert_contains "$output" '3) codex-legacy (codex, active) id=codex-id updatedAt=2026-03-19T10:00:00Z'
+assert_contains "$output" 'Token credentials eligible for manual provider-usage refresh:'
+assert_contains "$output" '1) claude-primary (anthropic, active) id=anthropic-id updatedAt=2026-03-19T12:00:00Z'
+assert_contains "$output" '2) openai-primary (openai, active) id=openai-id updatedAt=2026-03-19T11:00:00Z'
+assert_contains "$output" '3) codex-session (codex, active) id=codex-id updatedAt=2026-03-19T10:00:00Z'
+assert_not_contains "$output" 'openai-api-key'
 assert_contains "$output" 'tokenCredentialId: codex-id'
-assert_contains "$output" 'credential: codex-legacy (codex)'
+assert_contains "$output" 'credential: codex-session (codex)'
 
 curl_url="$(cat "${tmp_dir}/curl-url")"
 [[ "$curl_url" == 'http://localhost:4010/v1/admin/token-credentials/codex-id/provider-usage-refresh' ]] || \
   fail "unexpected provider-usage refresh URL: $curl_url"
 
-echo 'PASS: innies-token-usage-refresh includes legacy codex credentials in numbered selection'
+echo 'PASS: innies-token-usage-refresh only lists manual-refresh-eligible credentials'


### PR DESCRIPTION
**@worker-01**

## Summary
- reject unsupported non-OAuth or non-session OpenAI/Codex manual provider-usage refresh requests at the admin route seam
- narrow `innies-token-usage-refresh` to credentials the shared refresh helper can actually refresh
- add route/script regressions and align the operator/API docs with the updated contract

## Verification
- `cd api && pnpm vitest run tests/admin.tokenCredentials.route.test.ts`
- `bash scripts/tests/innies-token-usage-refresh.test.sh`

## Issue
- #163
