### PR TITLE
fix: restore legacy Codex provider-usage analytics visibility

### DIFF
--- a/api/src/services/tokenCredentialProviderUsage.ts
+++ b/api/src/services/tokenCredentialProviderUsage.ts
@@ -490,7 +490,7 @@ async function fetchOpenAiOauthUsagePayload(
         snapshot: {
           tokenCredentialId: credential.id,
           orgId: credential.orgId,
-          provider: 'openai',
+          provider: credential.provider,
           usageSource: parsed.usageSource,
           fiveHourUtilizationRatio: parsed.fiveHourUtilizationRatio,
           fiveHourResetsAt: parsed.fiveHourResetsAt,
@@ -629,7 +629,7 @@ export async function refreshOpenAiOauthUsageNow(
     const snapshot = await repo.upsertSnapshot({
       tokenCredentialId: credential.id,
       orgId: credential.orgId,
-      provider: 'openai',
+      provider: credential.provider,
       usageSource: fetched.snapshot.usageSource,
       fiveHourUtilizationRatio: fetched.snapshot.fiveHourUtilizationRatio,
       fiveHourResetsAt: fetched.snapshot.fiveHourResetsAt,

--- a/api/tests/tokenCredentialProviderUsage.test.ts
+++ b/api/tests/tokenCredentialProviderUsage.test.ts
@@ -122,7 +122,7 @@ describe('refreshOpenAiOauthUsageNow', () => {
     expect(outcome.rawPayload).toEqual(payload);
   });
 
-  it('normalizes primary and secondary wham windows into canonical openai snapshots', async () => {
+  it('preserves the stored codex provider when persisting wham snapshots for legacy credentials', async () => {
     const credential = createCredential({
       provider: 'codex',
       accessToken: createFakeOpenAiOauthToken({ accountId: 'acct_codex_usage_live' })
@@ -176,13 +176,13 @@ describe('refreshOpenAiOauthUsageNow', () => {
       throw new Error('expected openai usage refresh to succeed');
     }
     expect(usageRepo.upsertSnapshot).toHaveBeenCalledWith(expect.objectContaining({
-      provider: 'openai',
+      provider: 'codex',
       usageSource: 'openai_wham_usage',
       fiveHourUtilizationRatio: 0.07,
       sevenDayUtilizationRatio: 0.12,
       rawPayload: payload
     }));
-    expect(outcome.snapshot.provider).toBe('openai');
+    expect(outcome.snapshot.provider).toBe('codex');
     expect(outcome.snapshot.fiveHourResetsAt?.toISOString()).toBe(new Date(1_773_888_569 * 1000).toISOString());
     expect(outcome.snapshot.sevenDayResetsAt?.toISOString()).toBe(new Date(1_774_457_367 * 1000).toISOString());
     expect(outcome.snapshot.rawPayload).toEqual(payload);


### PR DESCRIPTION
**@worker-02**

Refs #162.

## Summary
- preserve the stored credential provider when persisting OpenAI/Codex WHAM usage snapshots so legacy `provider='codex'` credentials keep matching analytics joins
- update the OpenAI usage refresh regression to assert legacy Codex snapshots stay on the stored provider lane

## Test Plan
- `npm test -- --run tests/tokenCredentialProviderUsage.test.ts`
- `npm test -- --run tests/analyticsRepository.test.ts`
- `npm test -- --run tests/analytics.route.test.ts -t "marks Codex dashboard token rows as maxed when provider usage shows an exhausted window"`
