### PR TITLE
fix: normalize legacy codex analytics filters

### DIFF
--- a/api/src/repos/analyticsRepository.ts
+++ b/api/src/repos/analyticsRepository.ts
@@ -113,6 +113,24 @@ function applyBaseFilters(
   }
 }
 
+function applyCanonicalCredentialProviderFilter(
+  where: string[],
+  params: SqlValue[],
+  provider: string | undefined,
+  column: string
+): void {
+  if (!provider) return;
+
+  if (provider === 'openai') {
+    params.push(['openai', 'codex']);
+    where.push(`${column} = ANY($${params.length}::text[])`);
+    return;
+  }
+
+  params.push(provider);
+  where.push(`${column} = $${params.length}`);
+}
+
 function isMissingReserveColumn(error: unknown): boolean {
   if (!error || typeof error !== 'object') return false;
   const details = error as { code?: string; column?: string; message?: string };
@@ -200,7 +218,7 @@ function buildSystemSummaryTokenCountsSql(input: {
                 or coalesce((pu.seven_day_utilization_ratio * 100) >= (100 - ${sevenDayReservePercent}), false)
               )
             )
-            when tc.provider = 'openai'
+            when tc.provider in ('openai', 'codex')
             then (
               tc.status = 'maxed'
               or (
@@ -807,10 +825,7 @@ export class AnalyticsRepository implements AnalyticsRouteRepository {
     // Provider filter applies to the credential inventory. Source is intentionally ignored
     // for health metrics so derived cycle/utilization fields stay credential-global.
     const credWhere: string[] = [];
-    if (filters.provider) {
-      params.push(filters.provider);
-      credWhere.push(`tc.provider = $${params.length}`);
-    }
+    applyCanonicalCredentialProviderFilter(credWhere, params, filters.provider, 'tc.provider');
     const credFilter = credWhere.length > 0 ? `WHERE ${credWhere.join(' AND ')}` : '';
     const maxedWindowFilter = windowSqlRaw(filters.window, 'cr.maxed_at');
     const recoveryWindowFilter = windowSqlRaw(filters.window, 'cr.reactivated_at');
@@ -967,15 +982,17 @@ export class AnalyticsRepository implements AnalyticsRouteRepository {
     const params: SqlValue[] = [];
     const where: string[] = [];
     applyBaseFilters(where, params, filters);
-    const providerOnlyParams: SqlValue[] = [];
-    const providerOnlyFilter = filters.provider
-      ? (() => {
-        providerOnlyParams.push(filters.provider);
-        return ` where provider = $${providerOnlyParams.length}`;
-      })()
-      : '';
-    const tokenCountProviderFilter = filters.provider
-      ? `where tc.provider = $1`
+    const maxedParams: SqlValue[] = [];
+    const maxedWhere = [
+      `event_type = 'maxed'`,
+      `created_at >= now() - interval '7 days'`
+    ];
+    applyCanonicalCredentialProviderFilter(maxedWhere, maxedParams, filters.provider, 'provider');
+    const tokenCountParams: SqlValue[] = [];
+    const tokenCountWhere: string[] = [];
+    applyCanonicalCredentialProviderFilter(tokenCountWhere, tokenCountParams, filters.provider, 'tc.provider');
+    const tokenCountProviderFilter = tokenCountWhere.length > 0
+      ? `where ${tokenCountWhere.join(' AND ')}`
       : '';
 
     // Main aggregates
@@ -1008,8 +1025,7 @@ export class AnalyticsRepository implements AnalyticsRouteRepository {
     const maxedSql = `
       SELECT count(*) AS maxed_events_7d
       FROM ${TABLES.tokenCredentialEvents}
-      WHERE event_type = 'maxed'
-        AND created_at >= now() - interval '7 days'${filters.provider ? ` AND provider = $${providerOnlyParams.length}` : ''}
+      WHERE ${maxedWhere.join('\n        AND ')}
     `;
 
     // By provider
@@ -1105,7 +1121,7 @@ export class AnalyticsRepository implements AnalyticsRouteRepository {
               providerFilter: tokenCountProviderFilter,
               options
             }),
-            providerOnlyParams
+            tokenCountParams
           );
         } catch (error) {
           const nextOptions: TokenHealthSqlOptions = {
@@ -1129,7 +1145,7 @@ export class AnalyticsRepository implements AnalyticsRouteRepository {
       await Promise.all([
         this.db.query(mainSql, params),
         tokenCountsPromise,
-        this.db.query(maxedSql, providerOnlyParams),
+        this.db.query(maxedSql, maxedParams),
         this.db.query(byProviderSql, byProviderParams),
         this.db.query(byModelSql, byModelParams),
         this.db.query(bySourceSql, bySourceParams),

--- a/api/tests/analyticsRepository.test.ts
+++ b/api/tests/analyticsRepository.test.ts
@@ -60,17 +60,17 @@ describe('AnalyticsRepository', () => {
     expect(mainQuery?.sql).toContain("AND ul.entry_type = 'usage'");
     expect(tokenCountsQuery?.sql).toContain('from in_token_credential_provider_usage pu');
     expect(tokenCountsQuery?.sql).toContain('FROM in_token_credentials tc');
-    expect(tokenCountsQuery?.sql).toContain("where tc.provider = $1");
+    expect(tokenCountsQuery?.sql).toContain('where tc.provider = ANY($1::text[])');
     expect(tokenCountsQuery?.sql).toContain("when tc.expires_at <= now() then 'expired'");
     expect(tokenCountsQuery?.sql).toContain("count(*) FILTER (WHERE status <> 'expired' AND status <> 'revoked' AND NOT usage_maxed) AS active_tokens");
     expect(tokenCountsQuery?.sql).toContain("count(*) FILTER (WHERE status <> 'expired' AND status <> 'revoked' AND usage_maxed) AS maxed_tokens");
-    expect(tokenCountsQuery?.params).toEqual(['openai']);
-    expect(maxedQuery?.sql).toContain('AND provider = $1');
-    expect(maxedQuery?.params).toEqual(['openai']);
+    expect(tokenCountsQuery?.params).toEqual([['openai', 'codex']]);
+    expect(maxedQuery?.sql).toContain('AND provider = ANY($1::text[])');
+    expect(maxedQuery?.params).toEqual([['openai', 'codex']]);
     expect(usageLedgerQueries).toHaveLength(5);
   });
 
-  it('treats active OpenAI tokens with exhausted provider-usage windows as maxed in system summary counts', async () => {
+  it('treats active canonical OpenAI tokens with exhausted provider-usage windows as maxed in system summary counts', async () => {
     const db = new MockSqlClient({ rows: [], rowCount: 0 });
     const repo = new AnalyticsRepository(db);
 
@@ -80,10 +80,20 @@ describe('AnalyticsRepository', () => {
 
     expect(tokenCountsQuery?.sql).toContain('from in_token_credential_provider_usage pu');
     expect(tokenCountsQuery?.sql).toContain('left join provider_usage pu on pu.token_credential_id = tc.id and pu.provider = tc.provider');
-    expect(tokenCountsQuery?.sql).toContain("when tc.provider = 'openai'");
+    expect(tokenCountsQuery?.sql).toContain("when tc.provider in ('openai', 'codex')");
     expect(tokenCountsQuery?.sql).toContain('coalesce(pu.five_hour_utilization_ratio >= 1, false)');
     expect(tokenCountsQuery?.sql).toContain('coalesce(pu.seven_day_utilization_ratio >= 1, false)');
     expect(tokenCountsQuery?.sql).toContain("when tc.provider = 'anthropic'");
+  });
+
+  it('applies canonical OpenAI provider filters to token health credential inventory queries', async () => {
+    const db = new MockSqlClient({ rows: [], rowCount: 0 });
+    const repo = new AnalyticsRepository(db);
+
+    await repo.getTokenHealth({ window: '7d', provider: 'openai' });
+
+    expect(db.queries[0]?.sql).toContain('WHERE tc.provider = ANY($1::text[])');
+    expect(db.queries[0]?.params).toEqual([['openai', 'codex']]);
   });
 
   it('uses routing metadata request_source in token routing filters, including 24h side counts', async () => {


### PR DESCRIPTION
**@worker-01**

## Summary
- normalize canonical OpenAI analytics credential filters so provider-filtered token health and system summary include stored `provider='codex'` rows
- treat stored `codex` credentials the same as `openai` for provider-usage-based `usage_maxed` counts in system summary
- add regression coverage for canonical OpenAI provider filters in system summary and token health repository queries

## Testing
- `pnpm vitest run tests/analyticsRepository.test.ts tests/analytics.route.test.ts tests/dashboardTokenStatus.test.ts`
