### PR TITLE
fix: show Codex usage percentages in analytics

### DIFF
--- a/docs/ANALYTICS.md
+++ b/docs/ANALYTICS.md
@@ -144,7 +144,7 @@ Current expectation:
   - keeps the admin dashboard feeling live without recomputing the heaviest buyer/token-health queries for every tab
   - carries raw provider-usage snapshot fields when available; reserve / contribution-cap flags remain Claude-only
   - derives `5H` / `7D` in the dashboard layer
-  - renders `n/a` CAP placeholders for non-Claude rows while still allowing OpenAI/Codex rows to carry raw usage-window telemetry
+  - renders raw `5H` / `7D` percentages for both Claude and OpenAI/Codex rows when usage-window telemetry exists; only Claude rows get reserve/exhaustion highlighting
   - surfaces provider-usage freshness and exhaustion warnings in the snapshot `warnings` list
   - distinguishes backend auth parking (`backend_maxed`) from derived usage exhaustion (`cap_exhausted` for Claude, `usage_exhausted` for OpenAI/Codex)
 

--- a/docs/API_CONTRACT.md
+++ b/docs/API_CONTRACT.md
@@ -848,8 +848,8 @@ Notes:
 - `tokens[*]` also carries the same provider-usage snapshot fields as `/v1/admin/analytics/tokens/health`; reserve / contribution-cap flags stay Claude-only
 - `tokens[*]` may also include best-effort auth-diagnosis fields from `/v1/admin/analytics/tokens/health`; the dashboard status text can fold those into backend-`maxed` visibility
 - `summary.maxedTokens` counts tokens currently at usage capacity; for Claude that means provider usage has hit the provider ceiling or the configured reserve threshold, and for OpenAI/Codex that means a stored provider-usage window is exhausted
-- the dashboard UI shows raw Claude provider utilization in `5H` / `7D`; reserve/exhausted fields only control whether those cells are highlighted as effectively exhausted
-- OpenAI/Codex rows may carry raw provider-usage utilization/reset fields, but their reserve / contribution-cap fields stay `null` and the UI still renders `--` in the CAP cells
+- the dashboard UI shows raw provider usage in `5H` / `7D`; Claude reserve/exhausted fields only control whether those cells are highlighted as effectively exhausted
+- OpenAI/Codex rows may carry raw provider-usage utilization/reset fields even though their reserve / contribution-cap fields stay `null`
 - `buyers[*]` may include `latencyP50Ms` and `errorRate` when those buyer aggregates are available
 - snapshot `events` is currently capped to the 20 most recent lifecycle events
 - `warnings` is a free-form operator-facing list for provider-usage freshness/exhaustion issues; Claude rows can emit auth-failed / cap warnings, and OpenAI/Codex rows can emit snapshot freshness or `usage_exhausted_*` warnings when the backend emits them

--- a/ui/src/lib/analytics/present.ts
+++ b/ui/src/lib/analytics/present.ts
@@ -115,7 +115,7 @@ export function formatContributionCapPercent(
   value: number | null | undefined,
   provider: string | null | undefined,
 ): string {
-  if (tokenProviderKey(provider) !== 'claude') return '--';
+  if (tokenProviderKey(provider) === null) return '--';
   return formatCapPercent(value);
 }
 

--- a/ui/src/lib/analytics/server.ts
+++ b/ui/src/lib/analytics/server.ts
@@ -306,7 +306,6 @@ function deriveContributionCapUsedRatio(input: {
   provider: string | null;
   utilizationRatio: number | null;
 }): number | null {
-  if ((input.provider ?? '').trim().toLowerCase() !== 'anthropic') return null;
   if (input.utilizationRatio === null) return null;
   return Math.min(1, Math.max(0, input.utilizationRatio));
 }

--- a/ui/src/lib/analytics/sort.ts
+++ b/ui/src/lib/analytics/sort.ts
@@ -70,8 +70,6 @@ function directionValue(direction: SortDirection, comparison: number): number {
 }
 
 function contributionCapSortValue(row: AnalyticsTokenRow, key: 'fiveHourCapUsedRatio' | 'sevenDayCapUsedRatio'): number | null {
-  const provider = row.provider.trim().toLowerCase();
-  if (provider !== 'anthropic') return null;
   return key === 'fiveHourCapUsedRatio' ? row.fiveHourCapUsedRatio : row.sevenDayCapUsedRatio;
 }
 

--- a/ui/tests/analyticsPresent.test.mjs
+++ b/ui/tests/analyticsPresent.test.mjs
@@ -1,10 +1,17 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import test from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 import {
+  formatContributionCapPercent,
   formatCount,
   formatSummaryUnitsCompact,
 } from '../src/lib/analytics/present.ts';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const uiRoot = join(__dirname, '..');
 
 test('formatSummaryUnitsCompact formats millions with 4 decimals and M suffix', () => {
   assert.equal(formatSummaryUnitsCompact(149_917_231), '149.9172M');
@@ -21,4 +28,23 @@ test('formatSummaryUnitsCompact keeps values below one million unscaled', () => 
 test('formatSummaryUnitsCompact preserves nullish placeholder behavior', () => {
   assert.equal(formatSummaryUnitsCompact(null), '--');
   assert.equal(formatSummaryUnitsCompact(undefined), '--');
+});
+
+test('formatContributionCapPercent renders Codex usage ratios when present', () => {
+  assert.equal(formatContributionCapPercent(0.41, 'openai'), '41.0%');
+});
+
+test('analytics token sort keeps non-Claude 5h and 7d ratios sortable', () => {
+  const sortSource = readFileSync(join(uiRoot, 'src/lib/analytics/sort.ts'), 'utf8');
+
+  assert.ok(!sortSource.includes("if (provider !== 'anthropic') return null;"));
+  assert.ok(sortSource.includes("return key === 'fiveHourCapUsedRatio' ? row.fiveHourCapUsedRatio : row.sevenDayCapUsedRatio;"));
+});
+
+test('analytics server preserves non-Claude usage ratios for 5h and 7d cells', () => {
+  const serverSource = readFileSync(join(uiRoot, 'src/lib/analytics/server.ts'), 'utf8');
+
+  assert.ok(serverSource.includes('fiveHourCapUsedRatio: deriveContributionCapUsedRatio({'));
+  assert.ok(serverSource.includes('sevenDayCapUsedRatio: deriveContributionCapUsedRatio({'));
+  assert.ok(!serverSource.includes("if ((input.provider ?? '').trim().toLowerCase() !== 'anthropic') return null;"));
 });


### PR DESCRIPTION
## Summary
- show raw 5h/7d usage percentages for Codex/OpenAI rows in the analytics dashboard when snapshot telemetry exists
- keep Claude-only reserve/exhaustion highlighting while allowing Codex rows to sort by 5h/7d usage ratios
- align analytics docs with the updated dashboard behavior

## Test Plan
- node --test /Users/dylanvu/innies/ui/tests/analyticsPresent.test.mjs
- cd /Users/dylanvu/innies/ui && npm run build