### PR TITLE
Implement Darryn Phase 2 cutover and access

### DIFF
--- a/api/src/middleware/auth.ts
+++ b/api/src/middleware/auth.ts
@@ -41,6 +41,13 @@ export function requireApiKey(repo: ApiKeyRepository, allowedScopes: ApiKeyScope
         res.status(403).json({ code: 'forbidden', message: 'Invalid API key scope' });
         return;
       }
+      if (record.scope === 'buyer_proxy' && record.is_frozen) {
+        res.status(423).json({
+          code: 'cutover_in_progress',
+          message: 'Buyer key is temporarily unavailable during cutover'
+        });
+        return;
+      }
 
       req.auth = {
         apiKeyId: record.id,

--- a/api/src/repos/apiKeyRepository.ts
+++ b/api/src/repos/apiKeyRepository.ts
@@ -11,6 +11,7 @@ export type ApiKeyRecord = {
   is_active: boolean;
   expires_at: string | null;
   preferred_provider: ProviderPreference | null;
+  is_frozen?: boolean;
 };
 
 export type BuyerProviderPreferenceRecord = {
@@ -34,6 +35,13 @@ export function isMissingBuyerProviderPreferenceColumn(error: unknown): boolean 
     || details.message?.includes('provider_preference_updated_at') === true;
 }
 
+function isMissingPilotAdmissionFreezeTable(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const details = error as { code?: string; message?: string };
+  return details.code === '42P01'
+    && details.message?.includes('in_pilot_admission_freezes') === true;
+}
+
 function normalizeActiveApiKeyRecord(row: ApiKeyRecord | LegacyApiKeyRecord | undefined): ApiKeyRecord | null {
   if (!row) return null;
   if (!row.is_active) return null;
@@ -48,29 +56,74 @@ export class ApiKeyRepository {
   constructor(private readonly db: SqlClient) {}
 
   async findActiveByHash(keyHash: string): Promise<ApiKeyRecord | null> {
-    const sql = `
-      select id, org_id, scope, name, is_active, expires_at, preferred_provider
-      from in_api_keys
-      where key_hash = $1
-      limit 1
-    `;
-    try {
-      const result = await this.db.query<ApiKeyRecord>(sql, [keyHash]);
-      if (result.rowCount !== 1) return null;
-      return normalizeActiveApiKeyRecord(result.rows[0]);
-    } catch (error) {
-      if (!isMissingBuyerProviderPreferenceColumn(error)) throw error;
-
-      // Roll app code before migration 009 without breaking API-key auth.
-      const fallbackSql = `
-        select id, org_id, scope, name, is_active, expires_at
+    const runQuery = async (input: {
+      includePreferredProvider: boolean;
+      includeFreezeLookup: boolean;
+    }): Promise<ApiKeyRecord | null> => {
+      const sql = `
+        select
+          id,
+          org_id,
+          scope,
+          name,
+          is_active,
+          expires_at,
+          ${input.includePreferredProvider ? 'preferred_provider' : 'null::text as preferred_provider'},
+          ${input.includeFreezeLookup ? `exists(
+            select 1
+            from in_pilot_admission_freezes paf
+            where paf.resource_type = 'buyer_key'
+              and paf.resource_id = in_api_keys.id
+              and paf.released_at is null
+          )` : 'false'} as is_frozen
         from in_api_keys
         where key_hash = $1
         limit 1
       `;
-      const fallback = await this.db.query<LegacyApiKeyRecord>(fallbackSql, [keyHash]);
-      if (fallback.rowCount !== 1) return null;
-      return normalizeActiveApiKeyRecord(fallback.rows[0]);
+      const result = await this.db.query<ApiKeyRecord>(sql, [keyHash]);
+      if (result.rowCount !== 1) return null;
+      return result.rows[0];
+    };
+
+    try {
+      const record = await runQuery({
+        includePreferredProvider: true,
+        includeFreezeLookup: true
+      });
+      return normalizeActiveApiKeyRecord(record ?? undefined);
+    } catch (error) {
+      if (isMissingBuyerProviderPreferenceColumn(error)) {
+        try {
+          const record = await runQuery({
+            includePreferredProvider: false,
+            includeFreezeLookup: true
+          });
+          return normalizeActiveApiKeyRecord(record ?? undefined);
+        } catch (fallbackError) {
+          if (!isMissingPilotAdmissionFreezeTable(fallbackError)) throw fallbackError;
+          const record = await runQuery({
+            includePreferredProvider: false,
+            includeFreezeLookup: false
+          });
+          return normalizeActiveApiKeyRecord(record ?? undefined);
+        }
+      }
+
+      if (!isMissingPilotAdmissionFreezeTable(error)) throw error;
+      try {
+        const record = await runQuery({
+          includePreferredProvider: true,
+          includeFreezeLookup: false
+        });
+        return normalizeActiveApiKeyRecord(record ?? undefined);
+      } catch (fallbackError) {
+        if (!isMissingBuyerProviderPreferenceColumn(fallbackError)) throw fallbackError;
+        const record = await runQuery({
+          includePreferredProvider: false,
+          includeFreezeLookup: false
+        });
+        return normalizeActiveApiKeyRecord(record ?? undefined);
+      }
     }
   }
 

--- a/api/src/repos/pilotAdmissionFreezeRepository.ts
+++ b/api/src/repos/pilotAdmissionFreezeRepository.ts
@@ -1,4 +1,4 @@
-import type { SqlClient, SqlValue } from './sqlClient.js';
+import type { TransactionContext, SqlValue } from './sqlClient.js';
 import { type IdFactory, uuidV4 } from './idFactory.js';
 import { TABLES } from './tableNames.js';
 
@@ -23,7 +23,7 @@ export type PilotAdmissionFreezeRow = {
 
 export class PilotAdmissionFreezeRepository {
   constructor(
-    private readonly db: SqlClient,
+    private readonly db: TransactionContext,
     private readonly createId: IdFactory = uuidV4
   ) {}
 

--- a/api/src/repos/pilotAdmissionFreezeRepository.ts
+++ b/api/src/repos/pilotAdmissionFreezeRepository.ts
@@ -1,0 +1,148 @@
+import type { SqlClient, SqlValue } from './sqlClient.js';
+import { type IdFactory, uuidV4 } from './idFactory.js';
+import { TABLES } from './tableNames.js';
+
+export type FreezeResourceType = 'buyer_key' | 'token_credential';
+export type FreezeOperationKind = 'cutover' | 'rollback';
+
+export type PilotAdmissionFreezeRow = {
+  id: string;
+  resource_type: FreezeResourceType;
+  resource_id: string;
+  operation_kind: FreezeOperationKind;
+  source_org_id: string | null;
+  target_org_id: string | null;
+  actor_user_id: string | null;
+  released_at: string | null;
+  release_reason: string | null;
+  released_by_user_id: string | null;
+  last_error: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export class PilotAdmissionFreezeRepository {
+  constructor(
+    private readonly db: SqlClient,
+    private readonly createId: IdFactory = uuidV4
+  ) {}
+
+  async activateFreeze(input: {
+    resourceType: FreezeResourceType;
+    resourceId: string;
+    operationKind: FreezeOperationKind;
+    sourceOrgId?: string | null;
+    targetOrgId?: string | null;
+    actorUserId?: string | null;
+  }): Promise<PilotAdmissionFreezeRow> {
+    const sql = `
+      insert into ${TABLES.pilotAdmissionFreezes} (
+        id,
+        resource_type,
+        resource_id,
+        operation_kind,
+        source_org_id,
+        target_org_id,
+        actor_user_id,
+        released_at,
+        release_reason,
+        released_by_user_id,
+        last_error,
+        created_at,
+        updated_at
+      ) values (
+        $1,$2,$3,$4,$5,$6,$7,null,null,null,null,now(),now()
+      )
+      on conflict (resource_type, resource_id) where released_at is null
+      do update set
+        operation_kind = excluded.operation_kind,
+        source_org_id = excluded.source_org_id,
+        target_org_id = excluded.target_org_id,
+        actor_user_id = excluded.actor_user_id,
+        last_error = null,
+        updated_at = now()
+      returning *
+    `;
+
+    return this.expectOne<PilotAdmissionFreezeRow>(sql, [
+      this.createId(),
+      input.resourceType,
+      input.resourceId,
+      input.operationKind,
+      input.sourceOrgId ?? null,
+      input.targetOrgId ?? null,
+      input.actorUserId ?? null
+    ]);
+  }
+
+  async releaseFreeze(input: {
+    resourceType: FreezeResourceType;
+    resourceId: string;
+    releasedByUserId?: string | null;
+    releaseReason: string;
+  }): Promise<boolean> {
+    const sql = `
+      update ${TABLES.pilotAdmissionFreezes}
+      set
+        released_at = now(),
+        release_reason = $3,
+        released_by_user_id = $4,
+        updated_at = now()
+      where resource_type = $1
+        and resource_id = $2
+        and released_at is null
+    `;
+    const result = await this.db.query(sql, [
+      input.resourceType,
+      input.resourceId,
+      input.releaseReason,
+      input.releasedByUserId ?? null
+    ]);
+    return result.rowCount > 0;
+  }
+
+  async findActiveFreeze(
+    resourceType: FreezeResourceType,
+    resourceId: string
+  ): Promise<PilotAdmissionFreezeRow | null> {
+    const sql = `
+      select *
+      from ${TABLES.pilotAdmissionFreezes}
+      where resource_type = $1
+        and resource_id = $2
+        and released_at is null
+      limit 1
+    `;
+    const result = await this.db.query<PilotAdmissionFreezeRow>(sql, [resourceType, resourceId]);
+    return result.rowCount === 1 ? result.rows[0] : null;
+  }
+
+  async recordFailure(input: {
+    resourceType: FreezeResourceType;
+    resourceId: string;
+    errorMessage: string;
+  }): Promise<boolean> {
+    const sql = `
+      update ${TABLES.pilotAdmissionFreezes}
+      set last_error = $3,
+          updated_at = now()
+      where resource_type = $1
+        and resource_id = $2
+        and released_at is null
+    `;
+    const result = await this.db.query(sql, [
+      input.resourceType,
+      input.resourceId,
+      input.errorMessage
+    ]);
+    return result.rowCount > 0;
+  }
+
+  private async expectOne<T>(sql: string, params: SqlValue[]): Promise<T> {
+    const result = await this.db.query<T>(sql, params);
+    if (result.rowCount !== 1) {
+      throw new Error('expected one pilot admission freeze row');
+    }
+    return result.rows[0];
+  }
+}

--- a/api/src/repos/pilotIdentityRepository.ts
+++ b/api/src/repos/pilotIdentityRepository.ts
@@ -1,0 +1,186 @@
+import type { SqlClient, SqlValue } from './sqlClient.js';
+import { type IdFactory, uuidV4 } from './idFactory.js';
+import { TABLES } from './tableNames.js';
+
+export type OrgRow = {
+  id: string;
+  name: string;
+  slug: string;
+  is_active: boolean;
+  spend_cap_minor: number | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type UserRow = {
+  id: string;
+  email: string;
+  display_name: string | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
+export type MembershipRole = 'admin' | 'seller' | 'buyer';
+
+export type MembershipRow = {
+  id: string;
+  org_id: string;
+  user_id: string;
+  role: MembershipRole;
+  created_at: string;
+};
+
+export class PilotIdentityRepository {
+  constructor(
+    private readonly db: SqlClient,
+    private readonly createId: IdFactory = uuidV4
+  ) {}
+
+  async ensureOrg(input: {
+    slug: string;
+    name: string;
+  }): Promise<OrgRow> {
+    const existing = await this.findOrgBySlug(input.slug);
+    if (existing) return existing;
+
+    const sql = `
+      insert into ${TABLES.orgs} (
+        id,
+        name,
+        slug,
+        is_active,
+        created_at,
+        updated_at
+      ) values (
+        $1,$2,$3,true,now(),now()
+      )
+      returning *
+    `;
+
+    return this.expectOne<OrgRow>(sql, [
+      this.createId(),
+      input.name,
+      input.slug
+    ]);
+  }
+
+  async findOrgBySlug(slug: string): Promise<OrgRow | null> {
+    const sql = `
+      select *
+      from ${TABLES.orgs}
+      where slug = $1
+      limit 1
+    `;
+    const result = await this.db.query<OrgRow>(sql, [slug]);
+    return result.rowCount === 1 ? result.rows[0] : null;
+  }
+
+  async ensureUser(input: {
+    email: string;
+    displayName?: string | null;
+  }): Promise<UserRow> {
+    const existing = await this.findUserByEmail(input.email);
+    if (existing) return existing;
+
+    const sql = `
+      insert into in_users (
+        id,
+        email,
+        display_name,
+        is_active,
+        created_at,
+        updated_at
+      ) values (
+        $1,$2,$3,true,now(),now()
+      )
+      returning *
+    `;
+
+    return this.expectOne<UserRow>(sql, [
+      this.createId(),
+      input.email,
+      input.displayName ?? null
+    ]);
+  }
+
+  async findUserByEmail(email: string): Promise<UserRow | null> {
+    const sql = `
+      select *
+      from in_users
+      where lower(email) = lower($1)
+      limit 1
+    `;
+    const result = await this.db.query<UserRow>(sql, [email]);
+    return result.rowCount === 1 ? result.rows[0] : null;
+  }
+
+  async ensureMembership(input: {
+    orgId: string;
+    userId: string;
+    role: MembershipRole;
+  }): Promise<MembershipRow> {
+    const sql = `
+      insert into in_memberships (
+        id,
+        org_id,
+        user_id,
+        role,
+        created_at
+      ) values (
+        $1,$2,$3,$4,now()
+      )
+      on conflict (org_id, user_id)
+      do update set
+        role = excluded.role
+      returning *
+    `;
+
+    return this.expectOne<MembershipRow>(sql, [
+      this.createId(),
+      input.orgId,
+      input.userId,
+      input.role
+    ]);
+  }
+
+  async reassignBuyerKeysToOrg(input: {
+    apiKeyIds: string[];
+    targetOrgId: string;
+  }): Promise<string[]> {
+    if (input.apiKeyIds.length === 0) return [];
+
+    const sql = `
+      update in_api_keys
+      set org_id = $2
+      where id = any($1::uuid[])
+      returning id
+    `;
+    const result = await this.db.query<{ id: string }>(sql, [input.apiKeyIds, input.targetOrgId]);
+    return result.rows.map((row) => row.id);
+  }
+
+  async reassignTokenCredentialsToOrg(input: {
+    tokenCredentialIds: string[];
+    targetOrgId: string;
+  }): Promise<string[]> {
+    if (input.tokenCredentialIds.length === 0) return [];
+
+    const sql = `
+      update ${TABLES.tokenCredentials}
+      set org_id = $2
+      where id = any($1::uuid[])
+      returning id
+    `;
+    const result = await this.db.query<{ id: string }>(sql, [input.tokenCredentialIds, input.targetOrgId]);
+    return result.rows.map((row) => row.id);
+  }
+
+  private async expectOne<T>(sql: string, params: SqlValue[]): Promise<T> {
+    const result = await this.db.query<T>(sql, params);
+    if (result.rowCount !== 1) {
+      throw new Error('expected one pilot identity row');
+    }
+    return result.rows[0];
+  }
+}

--- a/api/src/repos/tableNames.ts
+++ b/api/src/repos/tableNames.ts
@@ -9,6 +9,7 @@ export const TABLES = {
   idempotencyKeys: 'in_idempotency_keys',
   meteringProjectorStates: 'in_metering_projector_states',
   orgs: 'in_orgs',
+  pilotAdmissionFreezes: 'in_pilot_admission_freezes',
   rateCardVersions: 'in_rate_card_versions',
   requestLog: 'in_request_log',
   rollbackRecords: 'in_rollback_records',

--- a/api/src/repos/tokenCredentialRepository.ts
+++ b/api/src/repos/tokenCredentialRepository.ts
@@ -113,6 +113,13 @@ function isMissingTokenCredentialContributionCapColumns(error: unknown): boolean
     || details.message?.includes('seven_day_reserve_percent') === true;
 }
 
+function isMissingPilotAdmissionFreezeTable(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const details = error as { code?: string; message?: string };
+  return details.code === '42P01'
+    && details.message?.includes('in_pilot_admission_freezes') === true;
+}
+
 function tokenCredentialSelectColumns(includeContributionCapColumns: boolean): string {
   const contributionCapColumns = includeContributionCapColumns
     ? `five_hour_reserve_percent,
@@ -150,19 +157,61 @@ function tokenCredentialSelectColumns(includeContributionCapColumns: boolean): s
   `;
 }
 
-async function queryTokenCredentialRowsWithContributionCapFallback(
+async function queryTokenCredentialRowsWithSchemaFallback(
   client: TransactionContext,
-  sqlFor: (includeContributionCapColumns: boolean) => string,
-  params: SqlValue[]
+  sqlFor: (input: {
+    includeContributionCapColumns: boolean;
+    includeFreezeJoin: boolean;
+  }) => string,
+  params: SqlValue[],
+  input?: {
+    includeContributionCapColumns?: boolean;
+    includeFreezeJoin?: boolean;
+  }
 ): Promise<SqlQueryResult<TokenCredentialRow>> {
+  const settings = {
+    includeContributionCapColumns: input?.includeContributionCapColumns ?? true,
+    includeFreezeJoin: input?.includeFreezeJoin ?? false
+  };
+
   try {
-    return await client.query<TokenCredentialRow>(sqlFor(true), params);
+    return await client.query<TokenCredentialRow>(sqlFor(settings), params);
   } catch (error) {
-    if (!isMissingTokenCredentialContributionCapColumns(error)) {
+    if (settings.includeContributionCapColumns && isMissingTokenCredentialContributionCapColumns(error)) {
+      try {
+        return await client.query<TokenCredentialRow>(sqlFor({
+          ...settings,
+          includeContributionCapColumns: false
+        }), params);
+      } catch (fallbackError) {
+        if (!settings.includeFreezeJoin || !isMissingPilotAdmissionFreezeTable(fallbackError)) {
+          throw fallbackError;
+        }
+        return client.query<TokenCredentialRow>(sqlFor({
+          includeContributionCapColumns: false,
+          includeFreezeJoin: false
+        }), params);
+      }
+    }
+
+    if (!settings.includeFreezeJoin || !isMissingPilotAdmissionFreezeTable(error)) {
       throw error;
     }
 
-    return client.query<TokenCredentialRow>(sqlFor(false), params);
+    try {
+      return await client.query<TokenCredentialRow>(sqlFor({
+        ...settings,
+        includeFreezeJoin: false
+      }), params);
+    } catch (fallbackError) {
+      if (!settings.includeContributionCapColumns || !isMissingTokenCredentialContributionCapColumns(fallbackError)) {
+        throw fallbackError;
+      }
+      return client.query<TokenCredentialRow>(sqlFor({
+        includeContributionCapColumns: false,
+        includeFreezeJoin: false
+      }), params);
+    }
   }
 }
 
@@ -297,12 +346,20 @@ export class TokenCredentialRepository {
 
   async listActiveForRouting(orgId: string, provider: string): Promise<TokenCredential[]> {
     const routingProviders = routingProvidersForLookup(provider);
-    const sql = (includeContributionCapColumns: boolean) => `
+    const sql = (input: {
+      includeContributionCapColumns: boolean;
+      includeFreezeJoin: boolean;
+    }) => `
       select
-        ${tokenCredentialSelectColumns(includeContributionCapColumns)}
+        ${tokenCredentialSelectColumns(input.includeContributionCapColumns)}
       from ${TABLES.tokenCredentials}
+      ${input.includeFreezeJoin ? `left join ${TABLES.pilotAdmissionFreezes} paf
+        on paf.resource_type = 'token_credential'
+        and paf.resource_id = ${TABLES.tokenCredentials}.id
+        and paf.released_at is null` : ''}
       where org_id = $1
         and provider = ANY($2::text[])
+        ${input.includeFreezeJoin ? 'and paf.id is null' : ''}
         and status = 'active'
         and expires_at > now()
         and (rate_limited_until is null or rate_limited_until <= now())
@@ -319,19 +376,25 @@ export class TokenCredentialRepository {
       order by rotation_version desc, updated_at desc
     `;
 
-    const result = await queryTokenCredentialRowsWithContributionCapFallback(this.db, sql, [orgId, routingProviders]);
+    const result = await queryTokenCredentialRowsWithSchemaFallback(this.db, sql, [orgId, routingProviders], {
+      includeContributionCapColumns: true,
+      includeFreezeJoin: true
+    });
     return result.rows.map(mapRow);
   }
 
   async getById(id: string): Promise<TokenCredential | null> {
-    const sql = (includeContributionCapColumns: boolean) => `
+    const sql = (input: {
+      includeContributionCapColumns: boolean;
+      includeFreezeJoin: boolean;
+    }) => `
       select
-        ${tokenCredentialSelectColumns(includeContributionCapColumns)}
+        ${tokenCredentialSelectColumns(input.includeContributionCapColumns)}
       from ${TABLES.tokenCredentials}
       where id = $1
       limit 1
     `;
-    const result = await queryTokenCredentialRowsWithContributionCapFallback(this.db, sql, [id]);
+    const result = await queryTokenCredentialRowsWithSchemaFallback(this.db, sql, [id]);
     if (result.rowCount !== 1) return null;
     return mapRow(result.rows[0]);
   }
@@ -355,7 +418,10 @@ export class TokenCredentialRepository {
     expiresAt: Date | null;
     preserveStatus?: boolean;
   }): Promise<TokenCredential | null> {
-    const sql = (includeContributionCapColumns: boolean) => `
+    const sql = (query: {
+      includeContributionCapColumns: boolean;
+      includeFreezeJoin: boolean;
+    }) => `
       update ${TABLES.tokenCredentials}
       set
         encrypted_access_token = $2,
@@ -406,7 +472,7 @@ export class TokenCredentialRepository {
         monthly_contribution_limit_units,
         monthly_contribution_used_units,
         monthly_window_start_at,
-        ${includeContributionCapColumns
+        ${query.includeContributionCapColumns
     ? `five_hour_reserve_percent,
         seven_day_reserve_percent`
     : `0::integer as five_hour_reserve_percent,
@@ -431,7 +497,7 @@ export class TokenCredentialRepository {
       input.preserveStatus === true
     ];
 
-    const result = await queryTokenCredentialRowsWithContributionCapFallback(this.db, sql, params);
+    const result = await queryTokenCredentialRowsWithSchemaFallback(this.db, sql, params);
     if (result.rowCount !== 1) return null;
     return mapRow(result.rows[0]);
   }
@@ -679,9 +745,12 @@ export class TokenCredentialRepository {
       includeRecoverableExpired?: boolean;
     }
   ): Promise<TokenCredential[]> {
-    const sql = (includeContributionCapColumns: boolean) => `
+    const sql = (query: {
+      includeContributionCapColumns: boolean;
+      includeFreezeJoin: boolean;
+    }) => `
       select
-        ${tokenCredentialSelectColumns(includeContributionCapColumns)}
+        ${tokenCredentialSelectColumns(query.includeContributionCapColumns)}
       from ${TABLES.tokenCredentials}
       where provider = $1
         and (
@@ -705,7 +774,7 @@ export class TokenCredentialRepository {
         rotation_version desc
     `;
 
-    const result = await queryTokenCredentialRowsWithContributionCapFallback(this.db, sql, [
+    const result = await queryTokenCredentialRowsWithSchemaFallback(this.db, sql, [
       provider,
       options?.includeRecoverableExpired === true
     ]);
@@ -1311,9 +1380,12 @@ export class TokenCredentialRepository {
   }
 
   async listMaxedForProbe(limit: number): Promise<TokenCredential[]> {
-    const sql = (includeContributionCapColumns: boolean) => `
+    const sql = (query: {
+      includeContributionCapColumns: boolean;
+      includeFreezeJoin: boolean;
+    }) => `
       select
-        ${tokenCredentialSelectColumns(includeContributionCapColumns)}
+        ${tokenCredentialSelectColumns(query.includeContributionCapColumns)}
       from ${TABLES.tokenCredentials}
       where status = 'maxed'
         and expires_at > now()
@@ -1321,7 +1393,7 @@ export class TokenCredentialRepository {
       order by coalesce(next_probe_at, maxed_at, updated_at) asc
       limit $1
     `;
-    const result = await queryTokenCredentialRowsWithContributionCapFallback(this.db, sql, [limit]);
+    const result = await queryTokenCredentialRowsWithSchemaFallback(this.db, sql, [limit]);
     return result.rows.map(mapRow);
   }
 

--- a/api/src/routes/admin.ts
+++ b/api/src/routes/admin.ts
@@ -142,6 +142,44 @@ const buyerProviderPreferenceUpdateSchema = z.object({
   preferredProvider: buyerProviderPreferenceSchema.nullable()
 });
 
+const adminPilotSessionSchema = z.discriminatedUnion('mode', [
+  z.object({
+    mode: z.literal('self'),
+    effectiveOrgId: z.string().min(1).optional(),
+    effectiveOrgSlug: z.string().min(1).optional(),
+    effectiveOrgName: z.string().min(1).optional()
+  }),
+  z.object({
+    mode: z.literal('impersonation'),
+    targetUserId: z.string().min(1),
+    targetOrgId: z.string().min(1),
+    targetOrgSlug: z.string().min(1).optional(),
+    targetOrgName: z.string().min(1).optional(),
+    githubLogin: z.string().min(1).optional(),
+    userEmail: z.string().email().optional()
+  })
+]);
+
+const adminPilotCutoverSchema = z.object({
+  sourceOrgId: z.string().min(1),
+  targetOrgSlug: z.string().min(1),
+  targetOrgName: z.string().min(1),
+  targetUserEmail: z.string().email(),
+  targetUserDisplayName: z.string().min(1).optional(),
+  targetGithubLogin: z.string().min(1),
+  buyerKeyIds: z.array(z.string().min(1)),
+  tokenCredentialIds: z.array(z.string().min(1)),
+  effectiveAt: z.string().datetime({ offset: true }).optional()
+});
+
+const adminPilotRollbackSchema = z.object({
+  sourceCutoverId: z.string().min(1).optional(),
+  targetOrgId: z.string().min(1),
+  buyerKeyIds: z.array(z.string().min(1)),
+  tokenCredentialIds: z.array(z.string().min(1)),
+  effectiveAt: z.string().datetime({ offset: true }).optional()
+});
+
 function isUniqueViolation(error: unknown): boolean {
   if (!error || typeof error !== 'object') return false;
   return (error as { code?: string }).code === '23505';
@@ -187,6 +225,95 @@ router.get('/v1/admin/pool-health', requireApiKey(runtime.repos.apiKeys, ['admin
       byStatus,
       totalQueueDepth: 0,
       orgQueues: {}
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/v1/admin/pilot/session', requireApiKey(runtime.repos.apiKeys, ['admin']), async (req, res, next) => {
+  try {
+    const parsed = adminPilotSessionSchema.parse(req.body);
+    const session = parsed.mode === 'self'
+      ? {
+        sessionKind: 'admin_self' as const,
+        actorUserId: null,
+        actorApiKeyId: req.auth?.apiKeyId ?? null,
+        actorOrgId: req.auth?.orgId ?? null,
+        effectiveOrgId: parsed.effectiveOrgId ?? req.auth?.orgId ?? '',
+        effectiveOrgSlug: parsed.effectiveOrgSlug ?? null,
+        effectiveOrgName: parsed.effectiveOrgName ?? null,
+        githubLogin: null,
+        userEmail: null,
+        impersonatedUserId: null
+      }
+      : {
+        sessionKind: 'admin_impersonation' as const,
+        actorUserId: null,
+        actorApiKeyId: req.auth?.apiKeyId ?? null,
+        actorOrgId: req.auth?.orgId ?? null,
+        effectiveOrgId: parsed.targetOrgId,
+        effectiveOrgSlug: parsed.targetOrgSlug ?? null,
+        effectiveOrgName: parsed.targetOrgName ?? null,
+        githubLogin: parsed.githubLogin ?? null,
+        userEmail: parsed.userEmail ?? null,
+        impersonatedUserId: parsed.targetUserId
+      };
+
+    const sessionToken = runtime.services.pilotSessions.issueSession(session);
+    res.setHeader('set-cookie', `innies_pilot_session=${sessionToken}; Path=/; HttpOnly; SameSite=Lax`);
+    res.status(200).json({
+      ok: true,
+      sessionToken,
+      session
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/v1/admin/pilot/cutover', requireApiKey(runtime.repos.apiKeys, ['admin']), async (req, res, next) => {
+  try {
+    const parsed = adminPilotCutoverSchema.parse(req.body);
+    const result = await runtime.services.pilotCutovers.cutover({
+      sourceOrgId: parsed.sourceOrgId,
+      targetOrgSlug: parsed.targetOrgSlug,
+      targetOrgName: parsed.targetOrgName,
+      targetUserEmail: parsed.targetUserEmail,
+      targetUserDisplayName: parsed.targetUserDisplayName,
+      targetGithubLogin: parsed.targetGithubLogin,
+      buyerKeyIds: parsed.buyerKeyIds,
+      tokenCredentialIds: parsed.tokenCredentialIds,
+      actorUserId: null,
+      effectiveAt: parsed.effectiveAt ? new Date(parsed.effectiveAt) : undefined
+    });
+
+    res.status(200).json({
+      ok: true,
+      cutoverId: result.cutoverRecord.id,
+      targetOrgId: result.targetOrgId,
+      targetUserId: result.targetUserId
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/v1/admin/pilot/rollback', requireApiKey(runtime.repos.apiKeys, ['admin']), async (req, res, next) => {
+  try {
+    const parsed = adminPilotRollbackSchema.parse(req.body);
+    const result = await runtime.services.pilotCutovers.rollback({
+      sourceCutoverId: parsed.sourceCutoverId,
+      targetOrgId: parsed.targetOrgId,
+      buyerKeyIds: parsed.buyerKeyIds,
+      tokenCredentialIds: parsed.tokenCredentialIds,
+      actorUserId: null,
+      effectiveAt: parsed.effectiveAt ? new Date(parsed.effectiveAt) : undefined
+    });
+
+    res.status(200).json({
+      ok: true,
+      rollbackId: result.rollbackRecord.id
     });
   } catch (error) {
     next(error);

--- a/api/src/routes/admin.ts
+++ b/api/src/routes/admin.ts
@@ -166,7 +166,6 @@ const adminPilotCutoverSchema = z.object({
   targetOrgName: z.string().min(1),
   targetUserEmail: z.string().email(),
   targetUserDisplayName: z.string().min(1).optional(),
-  targetGithubLogin: z.string().min(1),
   buyerKeyIds: z.array(z.string().min(1)),
   tokenCredentialIds: z.array(z.string().min(1)),
   effectiveAt: z.string().datetime({ offset: true }).optional()
@@ -281,7 +280,6 @@ router.post('/v1/admin/pilot/cutover', requireApiKey(runtime.repos.apiKeys, ['ad
       targetOrgName: parsed.targetOrgName,
       targetUserEmail: parsed.targetUserEmail,
       targetUserDisplayName: parsed.targetUserDisplayName,
-      targetGithubLogin: parsed.targetGithubLogin,
       buyerKeyIds: parsed.buyerKeyIds,
       tokenCredentialIds: parsed.tokenCredentialIds,
       actorUserId: null,

--- a/api/src/routes/pilot.ts
+++ b/api/src/routes/pilot.ts
@@ -16,6 +16,14 @@ const pilotAuthCallbackQuerySchema = z.object({
   state: z.string().min(1)
 });
 
+function normalizePilotReturnTo(value: string | undefined | null): string | undefined {
+  const normalized = value?.trim();
+  if (!normalized) return undefined;
+  if (!normalized.startsWith('/')) return undefined;
+  if (normalized.startsWith('//')) return undefined;
+  return normalized;
+}
+
 router.get('/v1/pilot/session', async (req, res, next) => {
   try {
     const token = runtime.services.pilotSessions.readTokenFromRequest(req);
@@ -41,7 +49,7 @@ router.get('/v1/pilot/auth/github/start', async (req, res, next) => {
   try {
     const query = pilotAuthStartQuerySchema.parse(req.query ?? {});
     const redirectUrl = runtime.services.pilotGithubAuth.buildAuthorizationUrl({
-      returnTo: query.returnTo
+      returnTo: normalizePilotReturnTo(query.returnTo)
     });
     res.redirect(302, redirectUrl);
   } catch (error) {
@@ -58,7 +66,7 @@ router.get('/v1/pilot/auth/github/callback', async (req, res, next) => {
     });
 
     res.setHeader('set-cookie', buildPilotSessionCookie(result.sessionToken));
-    res.redirect(302, result.returnTo ?? '/pilot');
+    res.redirect(302, normalizePilotReturnTo(result.returnTo) ?? '/pilot');
   } catch (error) {
     next(error);
   }

--- a/api/src/routes/pilot.ts
+++ b/api/src/routes/pilot.ts
@@ -1,0 +1,84 @@
+/// <reference path="../types/express.d.ts" />
+
+import { Router } from 'express';
+import { z } from 'zod';
+import { runtime } from '../services/runtime.js';
+import { AppError } from '../utils/errors.js';
+
+const router = Router();
+
+const pilotAuthStartQuerySchema = z.object({
+  returnTo: z.string().min(1).optional()
+});
+
+const pilotAuthCallbackQuerySchema = z.object({
+  code: z.string().min(1),
+  state: z.string().min(1)
+});
+
+router.get('/v1/pilot/session', async (req, res, next) => {
+  try {
+    const token = runtime.services.pilotSessions.readTokenFromRequest(req);
+    if (!token) {
+      throw new AppError('unauthorized', 401, 'Missing pilot session');
+    }
+
+    const session = runtime.services.pilotSessions.readSession(token);
+    if (!session) {
+      throw new AppError('unauthorized', 401, 'Invalid pilot session');
+    }
+
+    res.status(200).json({
+      ok: true,
+      session
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/v1/pilot/auth/github/start', async (req, res, next) => {
+  try {
+    const query = pilotAuthStartQuerySchema.parse(req.query ?? {});
+    const redirectUrl = runtime.services.pilotGithubAuth.buildAuthorizationUrl({
+      returnTo: query.returnTo
+    });
+    res.redirect(302, redirectUrl);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/v1/pilot/auth/github/callback', async (req, res, next) => {
+  try {
+    const query = pilotAuthCallbackQuerySchema.parse(req.query ?? {});
+    const result = await runtime.services.pilotGithubAuth.finishOauthCallback({
+      code: query.code,
+      state: query.state
+    });
+
+    res.setHeader('set-cookie', buildPilotSessionCookie(result.sessionToken));
+    res.redirect(302, result.returnTo ?? '/pilot');
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/v1/pilot/session/logout', async (_req, res, next) => {
+  try {
+    res.setHeader('set-cookie', buildClearedPilotSessionCookie());
+    res.status(200).json({ ok: true });
+  } catch (error) {
+    next(error);
+  }
+});
+
+export function buildPilotSessionCookie(token: string): string {
+  return `innies_pilot_session=${token}; Path=/; HttpOnly; SameSite=Lax`;
+}
+
+export function buildClearedPilotSessionCookie(): string {
+  return 'innies_pilot_session=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0';
+}
+
+export default router;

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import adminRoutes from './routes/admin.js';
 import analyticsRoutes from './routes/analytics.js';
 import anthropicCompatRoutes from './routes/anthropicCompat.js';
+import pilotRoutes from './routes/pilot.js';
 import proxyRoutes from './routes/proxy.js';
 import sellerKeysRoutes from './routes/sellerKeys.js';
 import usageRoutes from './routes/usage.js';
@@ -135,6 +136,7 @@ export function createApp(): express.Express {
   app.use(adminRoutes);
   app.use(analyticsRoutes);
   app.use(anthropicCompatRoutes);
+  app.use(pilotRoutes);
   app.use(sellerKeysRoutes);
   app.use(usageRoutes);
   app.use(proxyRoutes);

--- a/api/src/services/pilot/pilotCutoverService.ts
+++ b/api/src/services/pilot/pilotCutoverService.ts
@@ -1,0 +1,291 @@
+import type { SqlClient } from '../../repos/sqlClient.js';
+import { FnfOwnershipRepository } from '../../repos/fnfOwnershipRepository.js';
+import { PilotAdmissionFreezeRepository, type FreezeResourceType } from '../../repos/pilotAdmissionFreezeRepository.js';
+import { PilotIdentityRepository } from '../../repos/pilotIdentityRepository.js';
+import { PilotCutoverRepository } from '../../repos/pilotCutoverRepository.js';
+
+type IdentityRepositoryLike = Pick<
+  PilotIdentityRepository,
+  'ensureOrg' | 'ensureUser' | 'ensureMembership' | 'reassignBuyerKeysToOrg' | 'reassignTokenCredentialsToOrg'
+>;
+
+type FnfOwnershipRepositoryLike = Pick<
+  FnfOwnershipRepository,
+  'upsertBuyerKeyOwnership' | 'upsertTokenCredentialOwnership'
+>;
+
+type PilotCutoverRepositoryLike = Pick<
+  PilotCutoverRepository,
+  'createCutoverRecord' | 'createRollbackRecord'
+>;
+
+type PilotAdmissionFreezeRepositoryLike = Pick<
+  PilotAdmissionFreezeRepository,
+  'activateFreeze' | 'releaseFreeze' | 'recordFailure'
+>;
+
+type ReserveFloorMigrationAdapter = {
+  migrateReserveFloors(input: {
+    db: object;
+    fromOrgId: string;
+    toOrgId: string;
+    targetUserId: string;
+    cutoverId: string;
+    actorUserId: string | null;
+  }): Promise<void>;
+};
+
+type FreezeTarget = {
+  resourceType: FreezeResourceType;
+  resourceId: string;
+};
+
+export class PilotCutoverService {
+  private readonly freezeRepository: PilotAdmissionFreezeRepositoryLike;
+  private readonly reserveFloorMigration: ReserveFloorMigrationAdapter;
+  private readonly createIdentityRepository: (db: object) => IdentityRepositoryLike;
+  private readonly createFnfOwnershipRepository: (db: object) => FnfOwnershipRepositoryLike;
+  private readonly createPilotCutoverRepository: (db: object) => PilotCutoverRepositoryLike;
+
+  constructor(input: {
+    sql: SqlClient;
+    freezeRepository?: PilotAdmissionFreezeRepositoryLike;
+    reserveFloorMigration: ReserveFloorMigrationAdapter;
+    createIdentityRepository?: (db: object) => IdentityRepositoryLike;
+    createFnfOwnershipRepository?: (db: object) => FnfOwnershipRepositoryLike;
+    createPilotCutoverRepository?: (db: object) => PilotCutoverRepositoryLike;
+  }) {
+    this.sql = input.sql;
+    this.freezeRepository = input.freezeRepository ?? new PilotAdmissionFreezeRepository(input.sql);
+    this.reserveFloorMigration = input.reserveFloorMigration;
+    this.createIdentityRepository = input.createIdentityRepository
+      ?? ((db) => new PilotIdentityRepository(db as any));
+    this.createFnfOwnershipRepository = input.createFnfOwnershipRepository
+      ?? ((db) => new FnfOwnershipRepository(db as any));
+    this.createPilotCutoverRepository = input.createPilotCutoverRepository
+      ?? ((db) => new PilotCutoverRepository(db as any));
+  }
+
+  private readonly sql: SqlClient;
+
+  async cutover(input: {
+    sourceOrgId: string;
+    targetOrgSlug: string;
+    targetOrgName: string;
+    targetUserEmail: string;
+    targetUserDisplayName?: string | null;
+    targetGithubLogin: string;
+    buyerKeyIds: string[];
+    tokenCredentialIds: string[];
+    actorUserId?: string | null;
+    effectiveAt?: Date;
+  }): Promise<{
+    targetOrgId: string;
+    targetUserId: string;
+    cutoverRecord: Awaited<ReturnType<PilotCutoverRepositoryLike['createCutoverRecord']>>;
+  }> {
+    const freezes = this.freezeTargets(input.buyerKeyIds, input.tokenCredentialIds);
+    await this.activateFreezes({
+      freezes,
+      operationKind: 'cutover',
+      sourceOrgId: input.sourceOrgId,
+      targetOrgId: null,
+      actorUserId: input.actorUserId ?? null
+    });
+
+    try {
+      const result = await this.sql.transaction(async (tx) => {
+        const identityRepository = this.createIdentityRepository(tx);
+        const fnfOwnershipRepository = this.createFnfOwnershipRepository(tx);
+        const pilotCutoverRepository = this.createPilotCutoverRepository(tx);
+
+        const org = await identityRepository.ensureOrg({
+          slug: input.targetOrgSlug,
+          name: input.targetOrgName
+        });
+        const user = await identityRepository.ensureUser({
+          email: input.targetUserEmail,
+          displayName: input.targetUserDisplayName ?? null
+        });
+        await identityRepository.ensureMembership({
+          orgId: org.id,
+          userId: user.id,
+          role: 'buyer'
+        });
+
+        await identityRepository.reassignBuyerKeysToOrg({
+          apiKeyIds: input.buyerKeyIds,
+          targetOrgId: org.id
+        });
+        await identityRepository.reassignTokenCredentialsToOrg({
+          tokenCredentialIds: input.tokenCredentialIds,
+          targetOrgId: org.id
+        });
+
+        await Promise.all(input.buyerKeyIds.map((apiKeyId) => fnfOwnershipRepository.upsertBuyerKeyOwnership({
+          apiKeyId,
+          ownerOrgId: org.id,
+          ownerUserId: user.id
+        })));
+
+        await Promise.all(input.tokenCredentialIds.map((tokenCredentialId) => fnfOwnershipRepository.upsertTokenCredentialOwnership({
+          tokenCredentialId,
+          ownerOrgId: org.id,
+          capacityOwnerUserId: user.id
+        })));
+
+        const cutoverRecord = await pilotCutoverRepository.createCutoverRecord({
+          sourceOrgId: input.sourceOrgId,
+          targetOrgId: org.id,
+          effectiveAt: input.effectiveAt ?? new Date(),
+          buyerKeyOwnershipSwapped: true,
+          providerCredentialOwnershipSwapped: true,
+          reserveFloorMigrationCompleted: true,
+          createdByUserId: input.actorUserId ?? null
+        });
+
+        await this.reserveFloorMigration.migrateReserveFloors({
+          db: tx,
+          fromOrgId: input.sourceOrgId,
+          toOrgId: org.id,
+          targetUserId: user.id,
+          cutoverId: cutoverRecord.id,
+          actorUserId: input.actorUserId ?? null
+        });
+
+        await this.releaseFreezes({
+          freezes,
+          releaseReason: 'cutover_committed',
+          releasedByUserId: input.actorUserId ?? null
+        });
+
+        return {
+          targetOrgId: org.id,
+          targetUserId: user.id,
+          cutoverRecord
+        };
+      });
+
+      return result;
+    } catch (error) {
+      await this.recordFailures(freezes, error);
+      throw error;
+    }
+  }
+
+  async rollback(input: {
+    sourceCutoverId?: string | null;
+    targetOrgId: string;
+    buyerKeyIds: string[];
+    tokenCredentialIds: string[];
+    actorUserId?: string | null;
+    effectiveAt?: Date;
+  }): Promise<{
+    rollbackRecord: Awaited<ReturnType<PilotCutoverRepositoryLike['createRollbackRecord']>>;
+  }> {
+    const freezes = this.freezeTargets(input.buyerKeyIds, input.tokenCredentialIds);
+    await this.activateFreezes({
+      freezes,
+      operationKind: 'rollback',
+      sourceOrgId: null,
+      targetOrgId: input.targetOrgId,
+      actorUserId: input.actorUserId ?? null
+    });
+
+    try {
+      const result = await this.sql.transaction(async (tx) => {
+        const identityRepository = this.createIdentityRepository(tx);
+        const fnfOwnershipRepository = this.createFnfOwnershipRepository(tx);
+        const pilotCutoverRepository = this.createPilotCutoverRepository(tx);
+
+        await identityRepository.reassignBuyerKeysToOrg({
+          apiKeyIds: input.buyerKeyIds,
+          targetOrgId: input.targetOrgId
+        });
+        await identityRepository.reassignTokenCredentialsToOrg({
+          tokenCredentialIds: input.tokenCredentialIds,
+          targetOrgId: input.targetOrgId
+        });
+
+        await Promise.all(input.buyerKeyIds.map((apiKeyId) => fnfOwnershipRepository.upsertBuyerKeyOwnership({
+          apiKeyId,
+          ownerOrgId: input.targetOrgId,
+          ownerUserId: null
+        })));
+
+        await Promise.all(input.tokenCredentialIds.map((tokenCredentialId) => fnfOwnershipRepository.upsertTokenCredentialOwnership({
+          tokenCredentialId,
+          ownerOrgId: input.targetOrgId,
+          capacityOwnerUserId: null
+        })));
+
+        const rollbackRecord = await pilotCutoverRepository.createRollbackRecord({
+          sourceCutoverId: input.sourceCutoverId ?? null,
+          effectiveAt: input.effectiveAt ?? new Date(),
+          revertedBuyerKeyTargetOrgId: input.targetOrgId,
+          revertedProviderCredentialTargetOrgId: input.targetOrgId,
+          createdByUserId: input.actorUserId ?? null
+        });
+
+        await this.releaseFreezes({
+          freezes,
+          releaseReason: 'rollback_committed',
+          releasedByUserId: input.actorUserId ?? null
+        });
+
+        return { rollbackRecord };
+      });
+
+      return result;
+    } catch (error) {
+      await this.recordFailures(freezes, error);
+      throw error;
+    }
+  }
+
+  private freezeTargets(buyerKeyIds: string[], tokenCredentialIds: string[]): FreezeTarget[] {
+    return [
+      ...buyerKeyIds.map((resourceId) => ({ resourceType: 'buyer_key' as const, resourceId })),
+      ...tokenCredentialIds.map((resourceId) => ({ resourceType: 'token_credential' as const, resourceId }))
+    ];
+  }
+
+  private async activateFreezes(input: {
+    freezes: FreezeTarget[];
+    operationKind: 'cutover' | 'rollback';
+    sourceOrgId: string | null;
+    targetOrgId: string | null;
+    actorUserId: string | null;
+  }): Promise<void> {
+    await Promise.all(input.freezes.map((freeze) => this.freezeRepository.activateFreeze({
+      resourceType: freeze.resourceType,
+      resourceId: freeze.resourceId,
+      operationKind: input.operationKind,
+      sourceOrgId: input.sourceOrgId,
+      targetOrgId: input.targetOrgId,
+      actorUserId: input.actorUserId
+    })));
+  }
+
+  private async releaseFreezes(input: {
+    freezes: FreezeTarget[];
+    releaseReason: string;
+    releasedByUserId: string | null;
+  }): Promise<void> {
+    await Promise.all(input.freezes.map((freeze) => this.freezeRepository.releaseFreeze({
+      resourceType: freeze.resourceType,
+      resourceId: freeze.resourceId,
+      releaseReason: input.releaseReason,
+      releasedByUserId: input.releasedByUserId
+    })));
+  }
+
+  private async recordFailures(freezes: FreezeTarget[], error: unknown): Promise<void> {
+    const message = error instanceof Error ? error.message : 'unknown cutover failure';
+    await Promise.all(freezes.map((freeze) => this.freezeRepository.recordFailure({
+      resourceType: freeze.resourceType,
+      resourceId: freeze.resourceId,
+      errorMessage: message
+    })));
+  }
+}

--- a/api/src/services/pilot/pilotCutoverService.ts
+++ b/api/src/services/pilot/pilotCutoverService.ts
@@ -46,6 +46,7 @@ export class PilotCutoverService {
   private readonly createIdentityRepository: (db: object) => IdentityRepositoryLike;
   private readonly createFnfOwnershipRepository: (db: object) => FnfOwnershipRepositoryLike;
   private readonly createPilotCutoverRepository: (db: object) => PilotCutoverRepositoryLike;
+  private readonly createFreezeRepository: (db: object) => PilotAdmissionFreezeRepositoryLike;
 
   constructor(input: {
     sql: SqlClient;
@@ -54,6 +55,7 @@ export class PilotCutoverService {
     createIdentityRepository?: (db: object) => IdentityRepositoryLike;
     createFnfOwnershipRepository?: (db: object) => FnfOwnershipRepositoryLike;
     createPilotCutoverRepository?: (db: object) => PilotCutoverRepositoryLike;
+    createFreezeRepository?: (db: object) => PilotAdmissionFreezeRepositoryLike;
   }) {
     this.sql = input.sql;
     this.freezeRepository = input.freezeRepository ?? new PilotAdmissionFreezeRepository(input.sql);
@@ -64,6 +66,8 @@ export class PilotCutoverService {
       ?? ((db) => new FnfOwnershipRepository(db as any));
     this.createPilotCutoverRepository = input.createPilotCutoverRepository
       ?? ((db) => new PilotCutoverRepository(db as any));
+    this.createFreezeRepository = input.createFreezeRepository
+      ?? ((db) => new PilotAdmissionFreezeRepository(db as any));
   }
 
   private readonly sql: SqlClient;
@@ -74,7 +78,6 @@ export class PilotCutoverService {
     targetOrgName: string;
     targetUserEmail: string;
     targetUserDisplayName?: string | null;
-    targetGithubLogin: string;
     buyerKeyIds: string[];
     tokenCredentialIds: string[];
     actorUserId?: string | null;
@@ -98,6 +101,7 @@ export class PilotCutoverService {
         const identityRepository = this.createIdentityRepository(tx);
         const fnfOwnershipRepository = this.createFnfOwnershipRepository(tx);
         const pilotCutoverRepository = this.createPilotCutoverRepository(tx);
+        const transactionalFreezeRepository = this.createFreezeRepository(tx);
 
         const org = await identityRepository.ensureOrg({
           slug: input.targetOrgSlug,
@@ -154,6 +158,7 @@ export class PilotCutoverService {
         });
 
         await this.releaseFreezes({
+          freezeRepository: transactionalFreezeRepository,
           freezes,
           releaseReason: 'cutover_committed',
           releasedByUserId: input.actorUserId ?? null
@@ -197,6 +202,7 @@ export class PilotCutoverService {
         const identityRepository = this.createIdentityRepository(tx);
         const fnfOwnershipRepository = this.createFnfOwnershipRepository(tx);
         const pilotCutoverRepository = this.createPilotCutoverRepository(tx);
+        const transactionalFreezeRepository = this.createFreezeRepository(tx);
 
         await identityRepository.reassignBuyerKeysToOrg({
           apiKeyIds: input.buyerKeyIds,
@@ -228,6 +234,7 @@ export class PilotCutoverService {
         });
 
         await this.releaseFreezes({
+          freezeRepository: transactionalFreezeRepository,
           freezes,
           releaseReason: 'rollback_committed',
           releasedByUserId: input.actorUserId ?? null
@@ -268,11 +275,12 @@ export class PilotCutoverService {
   }
 
   private async releaseFreezes(input: {
+    freezeRepository: PilotAdmissionFreezeRepositoryLike;
     freezes: FreezeTarget[];
     releaseReason: string;
     releasedByUserId: string | null;
   }): Promise<void> {
-    await Promise.all(input.freezes.map((freeze) => this.freezeRepository.releaseFreeze({
+    await Promise.all(input.freezes.map((freeze) => input.freezeRepository.releaseFreeze({
       resourceType: freeze.resourceType,
       resourceId: freeze.resourceId,
       releaseReason: input.releaseReason,

--- a/api/src/services/pilot/pilotGithubAuthService.ts
+++ b/api/src/services/pilot/pilotGithubAuthService.ts
@@ -100,16 +100,15 @@ export class PilotGithubAuthService {
     const accessToken = await this.exchangeCodeForAccessToken(input.code);
     const githubUser = await this.fetchGithubUser(accessToken);
     const githubEmails = await this.fetchGithubEmails(accessToken);
-    const verifiedPrimaryEmail = selectVerifiedPrimaryEmail(githubUser, githubEmails);
-    const fallbackEmail = normalizeOptionalEmail(githubUser.email);
+    const verifiedEmail = selectVerifiedEmail(githubEmails);
 
-    if (!this.isAllowlisted(githubUser.login, verifiedPrimaryEmail)) {
+    if (!this.isAllowlisted(githubUser.login, verifiedEmail)) {
       throw new AppError('forbidden', 403, 'GitHub user is not allowlisted for the pilot');
     }
-    const sessionEmail = verifiedPrimaryEmail ?? fallbackEmail;
-    if (!sessionEmail) {
+    if (!verifiedEmail) {
       throw new AppError('forbidden', 403, 'GitHub user does not have a verified email for the pilot');
     }
+    const sessionEmail = verifiedEmail;
 
     const org = await this.input.identityRepository.ensureOrg({
       slug: this.input.targetOrgSlug,
@@ -223,12 +222,13 @@ export class PilotGithubAuthService {
   }
 }
 
-function selectVerifiedPrimaryEmail(user: GithubUser, emails: GithubEmail[]): string | null {
+function selectVerifiedEmail(emails: GithubEmail[]): string | null {
   const primaryVerified = emails.find((email) => email.primary && email.verified);
   if (primaryVerified?.email) {
     return primaryVerified.email;
   }
-  return null;
+  const anyVerified = emails.find((email) => email.verified);
+  return anyVerified?.email ?? null;
 }
 
 function normalizeLogin(value: string): string {
@@ -237,10 +237,4 @@ function normalizeLogin(value: string): string {
 
 function normalizeEmail(value: string): string {
   return value.trim().toLowerCase();
-}
-
-function normalizeOptionalEmail(value: string | null): string | null {
-  if (typeof value !== 'string') return null;
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : null;
 }

--- a/api/src/services/pilot/pilotGithubAuthService.ts
+++ b/api/src/services/pilot/pilotGithubAuthService.ts
@@ -1,0 +1,246 @@
+import { AppError } from '../../utils/errors.js';
+import { PilotSessionService, signPayload, verifyPayload } from './pilotSessionService.js';
+
+type IdentityRepositoryLike = {
+  ensureOrg(input: { slug: string; name: string }): Promise<{ id: string; slug: string; name: string }>;
+  ensureUser(input: { email: string; displayName?: string | null }): Promise<{ id: string; email: string }>;
+  ensureMembership(input: { orgId: string; userId: string; role: 'buyer' | 'seller' | 'admin' }): Promise<unknown>;
+};
+
+type SessionServiceLike = Pick<PilotSessionService, 'issueSession'>;
+
+type GithubUser = {
+  login: string;
+  email: string | null;
+  name: string | null;
+};
+
+type GithubEmail = {
+  email: string;
+  primary?: boolean;
+  verified?: boolean;
+};
+
+type SignedOauthState = {
+  returnTo: string | null;
+  issuedAt: string;
+  expiresAt: string;
+};
+
+export class PilotGithubAuthService {
+  private readonly allowlistedLogins: Set<string>;
+  private readonly allowlistedEmails: Set<string>;
+  private readonly now: () => Date;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(private readonly input: {
+    clientId: string;
+    clientSecret: string;
+    callbackUrl: string;
+    allowlistedLogins: string[];
+    allowlistedEmails: string[];
+    identityRepository: IdentityRepositoryLike;
+    sessionService: SessionServiceLike;
+    targetOrgSlug: string;
+    targetOrgName: string;
+    stateSecret: string;
+    now?: () => Date;
+    stateTtlSeconds?: number;
+    fetchImpl?: typeof fetch;
+  }) {
+    this.allowlistedLogins = new Set(input.allowlistedLogins.map(normalizeLogin));
+    this.allowlistedEmails = new Set(input.allowlistedEmails.map(normalizeEmail));
+    this.now = input.now ?? (() => new Date());
+    this.fetchImpl = input.fetchImpl ?? fetch;
+  }
+
+  createOauthState(input: {
+    returnTo?: string | null;
+  }): string {
+    const issuedAt = this.now();
+    const expiresAt = new Date(issuedAt.getTime() + (this.input.stateTtlSeconds ?? 60 * 10) * 1000);
+    return signPayload(this.input.stateSecret, {
+      returnTo: input.returnTo ?? null,
+      issuedAt: issuedAt.toISOString(),
+      expiresAt: expiresAt.toISOString()
+    });
+  }
+
+  buildAuthorizationUrl(input: {
+    returnTo?: string | null;
+  }): string {
+    const state = this.createOauthState(input);
+    const url = new URL('https://github.com/login/oauth/authorize');
+    url.searchParams.set('client_id', this.input.clientId);
+    url.searchParams.set('redirect_uri', this.input.callbackUrl);
+    url.searchParams.set('scope', 'read:user user:email');
+    url.searchParams.set('state', state);
+    return url.toString();
+  }
+
+  async finishOauthCallback(input: {
+    code: string;
+    state: string;
+  }): Promise<{
+    sessionToken: string;
+    session: {
+      sessionKind: 'darryn_self';
+      actorUserId: string;
+      effectiveOrgId: string;
+      githubLogin: string;
+      userEmail: string;
+    };
+    returnTo: string | null;
+  }> {
+    const state = this.readOauthState(input.state);
+    if (!state) {
+      throw new AppError('invalid_request', 400, 'Invalid GitHub OAuth state');
+    }
+
+    const accessToken = await this.exchangeCodeForAccessToken(input.code);
+    const githubUser = await this.fetchGithubUser(accessToken);
+    const githubEmails = await this.fetchGithubEmails(accessToken);
+    const verifiedPrimaryEmail = selectVerifiedPrimaryEmail(githubUser, githubEmails);
+    const fallbackEmail = normalizeOptionalEmail(githubUser.email);
+
+    if (!this.isAllowlisted(githubUser.login, verifiedPrimaryEmail)) {
+      throw new AppError('forbidden', 403, 'GitHub user is not allowlisted for the pilot');
+    }
+    const sessionEmail = verifiedPrimaryEmail ?? fallbackEmail;
+    if (!sessionEmail) {
+      throw new AppError('forbidden', 403, 'GitHub user does not have a verified email for the pilot');
+    }
+
+    const org = await this.input.identityRepository.ensureOrg({
+      slug: this.input.targetOrgSlug,
+      name: this.input.targetOrgName
+    });
+    const user = await this.input.identityRepository.ensureUser({
+      email: sessionEmail,
+      displayName: githubUser.name ?? githubUser.login
+    });
+    await this.input.identityRepository.ensureMembership({
+      orgId: org.id,
+      userId: user.id,
+      role: 'buyer'
+    });
+
+    const session = {
+      sessionKind: 'darryn_self' as const,
+      actorUserId: user.id,
+      actorApiKeyId: null,
+      actorOrgId: org.id,
+      effectiveOrgId: org.id,
+      effectiveOrgSlug: org.slug,
+      effectiveOrgName: org.name,
+      githubLogin: githubUser.login,
+      userEmail: sessionEmail,
+      impersonatedUserId: null
+    };
+    const sessionToken = this.input.sessionService.issueSession(session);
+
+    return {
+      sessionToken,
+      session: {
+        sessionKind: session.sessionKind,
+        actorUserId: user.id,
+        effectiveOrgId: org.id,
+        githubLogin: githubUser.login,
+        userEmail: sessionEmail
+      },
+      returnTo: state.returnTo
+    };
+  }
+
+  private readOauthState(token: string): SignedOauthState | null {
+    const payload = verifyPayload<SignedOauthState>(this.input.stateSecret, token);
+    if (!payload) return null;
+    if (new Date(payload.expiresAt).getTime() <= this.now().getTime()) {
+      return null;
+    }
+    return payload;
+  }
+
+  private async exchangeCodeForAccessToken(code: string): Promise<string> {
+    const response = await this.fetchImpl('https://github.com/login/oauth/access_token', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        client_id: this.input.clientId,
+        client_secret: this.input.clientSecret,
+        code,
+        redirect_uri: this.input.callbackUrl
+      })
+    });
+    if (!response.ok) {
+      throw new AppError('upstream_error', 502, 'GitHub token exchange failed');
+    }
+
+    const payload = await response.json() as { access_token?: string };
+    if (!payload.access_token) {
+      throw new AppError('upstream_error', 502, 'GitHub token exchange returned no access token');
+    }
+    return payload.access_token;
+  }
+
+  private async fetchGithubUser(accessToken: string): Promise<GithubUser> {
+    const response = await this.fetchImpl('https://api.github.com/user', {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${accessToken}`
+      }
+    });
+    if (!response.ok) {
+      throw new AppError('upstream_error', 502, 'GitHub user lookup failed');
+    }
+    return await response.json() as GithubUser;
+  }
+
+  private async fetchGithubEmails(accessToken: string): Promise<GithubEmail[]> {
+    const response = await this.fetchImpl('https://api.github.com/user/emails', {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${accessToken}`
+      }
+    });
+    if (!response.ok) {
+      throw new AppError('upstream_error', 502, 'GitHub email lookup failed');
+    }
+    return await response.json() as GithubEmail[];
+  }
+
+  private isAllowlisted(login: string, email: string | null): boolean {
+    if (this.allowlistedLogins.has(normalizeLogin(login))) {
+      return true;
+    }
+    if (email && this.allowlistedEmails.has(normalizeEmail(email))) {
+      return true;
+    }
+    return false;
+  }
+}
+
+function selectVerifiedPrimaryEmail(user: GithubUser, emails: GithubEmail[]): string | null {
+  const primaryVerified = emails.find((email) => email.primary && email.verified);
+  if (primaryVerified?.email) {
+    return primaryVerified.email;
+  }
+  return null;
+}
+
+function normalizeLogin(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function normalizeEmail(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function normalizeOptionalEmail(value: string | null): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}

--- a/api/src/services/pilot/pilotSessionService.ts
+++ b/api/src/services/pilot/pilotSessionService.ts
@@ -1,0 +1,113 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+export type PilotSessionKind = 'darryn_self' | 'admin_self' | 'admin_impersonation';
+
+export type PilotSession = {
+  sessionKind: PilotSessionKind;
+  actorUserId: string | null;
+  actorApiKeyId: string | null;
+  actorOrgId: string | null;
+  effectiveOrgId: string;
+  effectiveOrgSlug: string | null;
+  effectiveOrgName: string | null;
+  githubLogin: string | null;
+  userEmail: string | null;
+  impersonatedUserId: string | null;
+  issuedAt: string;
+  expiresAt: string;
+};
+
+export class PilotSessionService {
+  private readonly secret: string;
+  private readonly ttlSeconds: number;
+  private readonly now: () => Date;
+
+  constructor(input: {
+    secret: string;
+    ttlSeconds?: number;
+    now?: () => Date;
+  }) {
+    this.secret = input.secret;
+    this.ttlSeconds = input.ttlSeconds ?? 60 * 60 * 12;
+    this.now = input.now ?? (() => new Date());
+  }
+
+  issueSession(input: Omit<PilotSession, 'issuedAt' | 'expiresAt'>): string {
+    const issuedAt = this.now();
+    const expiresAt = new Date(issuedAt.getTime() + this.ttlSeconds * 1000);
+    return signPayload(this.secret, {
+      ...input,
+      issuedAt: issuedAt.toISOString(),
+      expiresAt: expiresAt.toISOString()
+    });
+  }
+
+  readSession(token: string): PilotSession | null {
+    const payload = verifyPayload<PilotSession>(this.secret, token);
+    if (!payload) return null;
+    if (new Date(payload.expiresAt).getTime() <= this.now().getTime()) {
+      return null;
+    }
+    return payload;
+  }
+
+  readTokenFromRequest(req: {
+    header(name: string): string | undefined;
+  }): string | null {
+    const auth = req.header('authorization');
+    if (auth) {
+      const match = auth.match(/^\s*bearer\s+(.+)\s*$/i);
+      if (match?.[1]) {
+        return match[1].trim();
+      }
+    }
+
+    const cookieHeader = req.header('cookie');
+    if (!cookieHeader) return null;
+    for (const entry of cookieHeader.split(';')) {
+      const [rawName, ...rawValue] = entry.trim().split('=');
+      if (rawName === 'innies_pilot_session') {
+        return rawValue.join('=').trim() || null;
+      }
+    }
+    return null;
+  }
+}
+
+export function signPayload(secret: string, payload: Record<string, unknown>): string {
+  const encodedPayload = base64UrlEncode(JSON.stringify(payload));
+  const signature = signMessage(secret, encodedPayload);
+  return `${encodedPayload}.${signature}`;
+}
+
+export function verifyPayload<T>(secret: string, token: string): T | null {
+  const [encodedPayload, signature] = token.split('.');
+  if (!encodedPayload || !signature) return null;
+  const expectedSignature = signMessage(secret, encodedPayload);
+  if (!safeEqual(signature, expectedSignature)) return null;
+
+  try {
+    return JSON.parse(base64UrlDecode(encodedPayload)) as T;
+  } catch {
+    return null;
+  }
+}
+
+function signMessage(secret: string, value: string): string {
+  return createHmac('sha256', secret).update(value).digest('base64url');
+}
+
+function safeEqual(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left);
+  const rightBuffer = Buffer.from(right);
+  if (leftBuffer.length !== rightBuffer.length) return false;
+  return timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+function base64UrlEncode(value: string): string {
+  return Buffer.from(value, 'utf8').toString('base64url');
+}
+
+function base64UrlDecode(value: string): string {
+  return Buffer.from(value, 'base64url').toString('utf8');
+}

--- a/api/src/services/runtime.ts
+++ b/api/src/services/runtime.ts
@@ -13,6 +13,8 @@ import { TokenCredentialProviderUsageRepository } from '../repos/tokenCredential
 import { AnalyticsRepository } from '../repos/analyticsRepository.js';
 import { AnalyticsDashboardSnapshotRepository } from '../repos/analyticsDashboardSnapshotRepository.js';
 import { RequestLogRepository } from '../repos/requestLogRepository.js';
+import { PilotIdentityRepository } from '../repos/pilotIdentityRepository.js';
+import { PilotAdmissionFreezeRepository } from '../repos/pilotAdmissionFreezeRepository.js';
 import { buildDefaultJobs } from '../jobs/registry.js';
 import { JobScheduler } from '../jobs/scheduler.js';
 import { KeyPool } from './keyPool.js';
@@ -21,7 +23,11 @@ import { RoutingService } from './routingService.js';
 import { IdempotencyService } from './idempotencyService.js';
 import { UsageMeteringWriter } from './metering/usageMeteringWriter.js';
 import { TokenCredentialService } from './tokenCredentialService.js';
+import { PilotSessionService } from './pilot/pilotSessionService.js';
+import { PilotGithubAuthService } from './pilot/pilotGithubAuthService.js';
+import { PilotCutoverService } from './pilot/pilotCutoverService.js';
 import { assertRequiredEnv, readRequiredEnv } from '../utils/env.js';
+import { AppError } from '../utils/errors.js';
 
 assertRequiredEnv(['DATABASE_URL', 'SELLER_SECRET_ENC_KEY_B64']);
 const sql = buildPgClient(readRequiredEnv('DATABASE_URL'));
@@ -42,13 +48,18 @@ export const runtime = {
     tokenCredentialProviderUsage: new TokenCredentialProviderUsageRepository(sql),
     analytics: new AnalyticsRepository(sql),
     analyticsDashboardSnapshots: new AnalyticsDashboardSnapshotRepository(sql),
-    requestLog: new RequestLogRepository(sql)
+    requestLog: new RequestLogRepository(sql),
+    pilotIdentity: new PilotIdentityRepository(sql),
+    pilotAdmissionFreezes: new PilotAdmissionFreezeRepository(sql)
   },
   services: {
     idempotency: undefined as unknown as IdempotencyService,
     jobs: undefined as unknown as JobScheduler,
     keyPool: new KeyPool(),
     metering: undefined as unknown as UsageMeteringWriter,
+    pilotCutovers: undefined as unknown as PilotCutoverService,
+    pilotGithubAuth: undefined as unknown as PilotGithubAuthService,
+    pilotSessions: undefined as unknown as PilotSessionService,
     routerEngine: new RouterEngine(),
     routingService: undefined as unknown as RoutingService,
     tokenCredentials: undefined as unknown as TokenCredentialService
@@ -67,6 +78,33 @@ runtime.services.jobs = new JobScheduler({
   }
 });
 runtime.services.metering = new UsageMeteringWriter(runtime.repos.usageLedger);
+runtime.services.pilotSessions = new PilotSessionService({
+  secret: process.env.PILOT_SESSION_SECRET || 'dev-insecure-pilot-session-secret'
+});
+runtime.services.pilotGithubAuth = new PilotGithubAuthService({
+  clientId: process.env.PILOT_GITHUB_CLIENT_ID || '',
+  clientSecret: process.env.PILOT_GITHUB_CLIENT_SECRET || '',
+  callbackUrl: process.env.PILOT_GITHUB_CALLBACK_URL || 'http://localhost:4010/v1/pilot/auth/github/callback',
+  allowlistedLogins: (process.env.PILOT_GITHUB_ALLOWLIST_LOGINS || '').split(',').map((value) => value.trim()).filter(Boolean),
+  allowlistedEmails: (process.env.PILOT_GITHUB_ALLOWLIST_EMAILS || '').split(',').map((value) => value.trim()).filter(Boolean),
+  identityRepository: runtime.repos.pilotIdentity,
+  sessionService: runtime.services.pilotSessions,
+  targetOrgSlug: process.env.PILOT_TARGET_ORG_SLUG || 'fnf',
+  targetOrgName: process.env.PILOT_TARGET_ORG_NAME || 'Friends & Family',
+  stateSecret: process.env.PILOT_GITHUB_STATE_SECRET || 'dev-insecure-pilot-oauth-state-secret'
+});
+runtime.services.pilotCutovers = new PilotCutoverService({
+  sql: runtime.sql,
+  reserveFloorMigration: {
+    async migrateReserveFloors() {
+      throw new AppError(
+        'service_unavailable',
+        503,
+        'Pilot cutover unavailable until reserve-floor migration adapter is configured'
+      );
+    }
+  }
+});
 runtime.services.routingService = new RoutingService(
   runtime.services.keyPool,
   runtime.services.routerEngine

--- a/api/tests/admin.pilot.route.test.ts
+++ b/api/tests/admin.pilot.route.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { AppError } from '../src/utils/errors.js';
+
+type RuntimeModule = typeof import('../src/services/runtime.js');
+type AdminRouteModule = typeof import('../src/routes/admin.js');
+
+type MockReq = {
+  method: string;
+  path: string;
+  originalUrl: string;
+  body: unknown;
+  params: Record<string, string>;
+  auth?: {
+    apiKeyId: string;
+    orgId: string | null;
+    scope: 'buyer_proxy' | 'admin';
+  };
+  header: (name: string) => string | undefined;
+};
+
+type MockRes = {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: unknown;
+  headersSent: boolean;
+  writableEnded: boolean;
+  setHeader: (name: string, value: string) => void;
+  status: (code: number) => MockRes;
+  json: (payload: unknown) => void;
+  send: (payload: unknown) => void;
+};
+
+function createMockReq(input: {
+  method: string;
+  path: string;
+  body?: unknown;
+  headers?: Record<string, string>;
+  params?: Record<string, string>;
+}): MockReq {
+  const lower = Object.fromEntries(
+    Object.entries(input.headers ?? {}).map(([k, v]) => [k.toLowerCase(), v])
+  );
+  return {
+    method: input.method.toUpperCase(),
+    path: input.path,
+    originalUrl: input.path,
+    body: input.body ?? {},
+    params: input.params ?? {},
+    header: (name: string) => lower[name.toLowerCase()]
+  };
+}
+
+function createMockRes(): MockRes {
+  return {
+    statusCode: 200,
+    headers: {},
+    body: undefined,
+    headersSent: false,
+    writableEnded: false,
+    setHeader(name: string, value: string) {
+      this.headers[name.toLowerCase()] = value;
+    },
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      this.headersSent = true;
+      this.writableEnded = true;
+    },
+    send(payload: unknown) {
+      this.body = payload;
+      this.headersSent = true;
+      this.writableEnded = true;
+    }
+  };
+}
+
+function applyError(err: unknown, res: MockRes): void {
+  if (err instanceof z.ZodError) {
+    res.status(400).json({ code: 'invalid_request', message: 'Invalid request', issues: err.issues });
+    return;
+  }
+  if (err instanceof AppError) {
+    res.status(err.status).json({ code: err.code, message: err.message, details: err.details });
+    return;
+  }
+  const message = err instanceof Error ? err.message : 'Unexpected error';
+  res.status(500).json({ code: 'internal_error', message });
+}
+
+async function invoke(handle: (req: any, res: any, next: (error?: unknown) => void) => unknown, req: MockReq, res: MockRes): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    let nextCalled = false;
+    const next = (error?: unknown) => {
+      nextCalled = true;
+      if (error) {
+        applyError(error, res);
+      }
+      resolve();
+    };
+
+    Promise.resolve(handle(req, res, next))
+      .then(() => {
+        if (!nextCalled) resolve();
+      })
+      .catch(reject);
+  });
+}
+
+function getRouteHandlers(router: any, routePath: string, method: 'post'): Array<(req: any, res: any, next: (error?: unknown) => void) => unknown> {
+  const layer = router.stack.find((entry: any) => entry?.route?.path === routePath && entry?.route?.methods?.[method]);
+  if (!layer) throw new Error(`route not found: ${routePath}`);
+  return layer.route.stack.map((s: any) => s.handle);
+}
+
+describe('admin pilot routes', () => {
+  let runtimeModule: RuntimeModule;
+  let sessionHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+  let cutoverHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+  let rollbackHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+
+  beforeAll(async () => {
+    process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgres://postgres:postgres@127.0.0.1:5432/innies_test';
+    process.env.SELLER_SECRET_ENC_KEY_B64 = process.env.SELLER_SECRET_ENC_KEY_B64 || Buffer.alloc(32, 7).toString('base64');
+    runtimeModule = await import('../src/services/runtime.js');
+    const mod = await import('../src/routes/admin.js') as AdminRouteModule;
+    sessionHandlers = getRouteHandlers(mod.default as any, '/v1/admin/pilot/session', 'post');
+    cutoverHandlers = getRouteHandlers(mod.default as any, '/v1/admin/pilot/cutover', 'post');
+    rollbackHandlers = getRouteHandlers(mod.default as any, '/v1/admin/pilot/rollback', 'post');
+  });
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(runtimeModule.runtime.repos.apiKeys, 'findActiveByHash').mockResolvedValue({
+      id: '99999999-9999-4999-8999-999999999999',
+      org_id: 'org_innies',
+      scope: 'admin',
+      is_active: true,
+      expires_at: null,
+      preferred_provider: null,
+      is_frozen: false
+    } as any);
+    vi.spyOn(runtimeModule.runtime.repos.apiKeys, 'touchLastUsed').mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('mints an admin impersonation session token', async () => {
+    vi.spyOn(runtimeModule.runtime.services.pilotSessions, 'issueSession').mockReturnValue('admin-session-token');
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/admin/pilot/session',
+      headers: {
+        authorization: 'Bearer in_admin_token',
+        'content-type': 'application/json'
+      },
+      body: {
+        mode: 'impersonation',
+        targetUserId: 'user_darryn',
+        targetOrgId: 'org_fnf',
+        targetOrgSlug: 'fnf',
+        targetOrgName: 'Friends & Family',
+        githubLogin: 'darryn',
+        userEmail: 'darryn@example.com'
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(sessionHandlers[0], req, res);
+    await invoke(sessionHandlers[1], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(expect.objectContaining({
+      ok: true,
+      sessionToken: 'admin-session-token',
+      session: expect.objectContaining({
+        sessionKind: 'admin_impersonation',
+        effectiveOrgId: 'org_fnf',
+        impersonatedUserId: 'user_darryn'
+      })
+    }));
+    expect(res.headers['set-cookie']).toContain('innies_pilot_session=admin-session-token');
+  });
+
+  it('starts a cutover through the cutover service', async () => {
+    vi.spyOn(runtimeModule.runtime.services.pilotCutovers, 'cutover').mockResolvedValue({
+      targetOrgId: 'org_fnf',
+      targetUserId: 'user_darryn',
+      cutoverRecord: { id: 'cut_1', effective_at: '2026-03-20T00:00:00Z' }
+    } as any);
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/admin/pilot/cutover',
+      headers: {
+        authorization: 'Bearer in_admin_token',
+        'content-type': 'application/json'
+      },
+      body: {
+        sourceOrgId: 'org_innies',
+        targetOrgSlug: 'fnf',
+        targetOrgName: 'Friends & Family',
+        targetUserEmail: 'darryn@example.com',
+        targetUserDisplayName: 'Darryn',
+        targetGithubLogin: 'darryn',
+        buyerKeyIds: ['buyer_1'],
+        tokenCredentialIds: ['cred_1']
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(cutoverHandlers[0], req, res);
+    await invoke(cutoverHandlers[1], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(expect.objectContaining({
+      ok: true,
+      cutoverId: 'cut_1',
+      targetOrgId: 'org_fnf',
+      targetUserId: 'user_darryn'
+    }));
+  });
+
+  it('starts a rollback through the cutover service', async () => {
+    vi.spyOn(runtimeModule.runtime.services.pilotCutovers, 'rollback').mockResolvedValue({
+      rollbackRecord: { id: 'rollback_1', effective_at: '2026-03-20T01:00:00Z' }
+    } as any);
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/admin/pilot/rollback',
+      headers: {
+        authorization: 'Bearer in_admin_token',
+        'content-type': 'application/json'
+      },
+      body: {
+        sourceCutoverId: 'cut_1',
+        targetOrgId: 'org_innies',
+        buyerKeyIds: ['buyer_1'],
+        tokenCredentialIds: ['cred_1']
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(rollbackHandlers[0], req, res);
+    await invoke(rollbackHandlers[1], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(expect.objectContaining({
+      ok: true,
+      rollbackId: 'rollback_1'
+    }));
+  });
+});

--- a/api/tests/admin.pilot.route.test.ts
+++ b/api/tests/admin.pilot.route.test.ts
@@ -189,7 +189,7 @@ describe('admin pilot routes', () => {
   });
 
   it('starts a cutover through the cutover service', async () => {
-    vi.spyOn(runtimeModule.runtime.services.pilotCutovers, 'cutover').mockResolvedValue({
+    const cutover = vi.spyOn(runtimeModule.runtime.services.pilotCutovers, 'cutover').mockResolvedValue({
       targetOrgId: 'org_fnf',
       targetUserId: 'user_darryn',
       cutoverRecord: { id: 'cut_1', effective_at: '2026-03-20T00:00:00Z' }
@@ -208,7 +208,6 @@ describe('admin pilot routes', () => {
         targetOrgName: 'Friends & Family',
         targetUserEmail: 'darryn@example.com',
         targetUserDisplayName: 'Darryn',
-        targetGithubLogin: 'darryn',
         buyerKeyIds: ['buyer_1'],
         tokenCredentialIds: ['cred_1']
       }
@@ -225,6 +224,17 @@ describe('admin pilot routes', () => {
       targetOrgId: 'org_fnf',
       targetUserId: 'user_darryn'
     }));
+    expect(cutover).toHaveBeenCalledWith({
+      sourceOrgId: 'org_innies',
+      targetOrgSlug: 'fnf',
+      targetOrgName: 'Friends & Family',
+      targetUserEmail: 'darryn@example.com',
+      targetUserDisplayName: 'Darryn',
+      buyerKeyIds: ['buyer_1'],
+      tokenCredentialIds: ['cred_1'],
+      actorUserId: null,
+      effectiveAt: undefined
+    });
   });
 
   it('starts a rollback through the cutover service', async () => {

--- a/api/tests/admin.tokenCredentials.route.test.ts
+++ b/api/tests/admin.tokenCredentials.route.test.ts
@@ -278,7 +278,7 @@ describe('admin token credential routes idempotent replay', () => {
       sevenDayReservePercent: 0,
       debugLabel: 'oauth-main-1',
       status: 'maxed',
-      expiresAt: new Date('2026-03-20T00:00:00.000Z')
+      expiresAt: new Date('2026-04-20T00:00:00.000Z')
     } as any);
     vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'setProviderUsageWarning').mockResolvedValue(false);
     vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'syncClaudeContributionCapLifecycle').mockResolvedValue({
@@ -1281,7 +1281,7 @@ describe('admin token credential routes idempotent replay', () => {
       refreshToken: null,
       debugLabel: 'niyant-codex',
       status: 'maxed',
-      expiresAt: new Date('2026-03-20T00:00:00.000Z')
+      expiresAt: new Date('2026-04-20T00:00:00.000Z')
     } as any);
     const probeSpy = vi.spyOn(probeModule, 'probeAndUpdateTokenCredential').mockResolvedValue({
       ok: true,
@@ -1341,7 +1341,7 @@ describe('admin token credential routes idempotent replay', () => {
       provider: 'openai',
       debugLabel: 'niyant-codex',
       status: 'active',
-      expiresAt: new Date('2026-03-20T00:00:00.000Z')
+      expiresAt: new Date('2026-04-20T00:00:00.000Z')
     } as any);
     const probeSpy = vi.spyOn(probeModule, 'probeAndUpdateTokenCredential').mockResolvedValue({
       ok: true,
@@ -1403,7 +1403,7 @@ describe('admin token credential routes idempotent replay', () => {
       refreshToken: null,
       debugLabel: 'niyant-codex',
       status: 'maxed',
-      expiresAt: new Date('2026-03-20T00:00:00.000Z')
+      expiresAt: new Date('2026-04-20T00:00:00.000Z')
     } as any);
     const probeSpy = vi.spyOn(probeModule, 'probeAndUpdateTokenCredential').mockResolvedValue({
       ok: false,
@@ -1548,7 +1548,7 @@ describe('admin token credential routes idempotent replay', () => {
       provider: 'openai',
       debugLabel: 'niyant-codex',
       status: 'paused',
-      expiresAt: new Date('2026-03-20T00:00:00.000Z')
+      expiresAt: new Date('2026-04-20T00:00:00.000Z')
     } as any);
 
     const req = createMockReq({
@@ -1592,7 +1592,7 @@ describe('admin token credential routes idempotent replay', () => {
       sevenDayReservePercent: 0,
       debugLabel: 'shirtless',
       status: 'active',
-      expiresAt: new Date('2026-03-20T00:00:00.000Z')
+      expiresAt: new Date('2026-04-20T00:00:00.000Z')
     } as any);
     const refreshSpy = vi.spyOn(providerUsageModule, 'refreshAnthropicOauthUsageNow').mockResolvedValue({
       ok: true,
@@ -1726,7 +1726,7 @@ describe('admin token credential routes idempotent replay', () => {
       sevenDayReservePercent: 15,
       debugLabel: 'shirtless',
       status: 'active',
-      expiresAt: new Date('2026-03-20T00:00:00.000Z')
+      expiresAt: new Date('2026-04-20T00:00:00.000Z')
     } as any);
     vi.spyOn(providerUsageModule, 'refreshAnthropicOauthUsageNow').mockResolvedValue({
       ok: false,
@@ -1988,7 +1988,7 @@ describe('admin token credential routes idempotent replay', () => {
       refreshToken: 'rt_codex_live',
       debugLabel: 'niyant-codex',
       status: 'active',
-      expiresAt: new Date('2026-03-20T00:00:00.000Z')
+      expiresAt: new Date('2026-04-20T00:00:00.000Z')
     } as any);
     const refreshSpy = vi.spyOn(oauthRefreshModule, 'refreshTokenCredentialProviderUsageWithCredentialRefresh').mockResolvedValue({
       credential: {
@@ -2000,7 +2000,7 @@ describe('admin token credential routes idempotent replay', () => {
         refreshToken: 'rt_codex_live',
         debugLabel: 'niyant-codex',
         status: 'active',
-        expiresAt: new Date('2026-03-20T00:00:00.000Z')
+        expiresAt: new Date('2026-04-20T00:00:00.000Z')
       },
       refreshedCredential: null,
       outcome: {
@@ -2133,7 +2133,7 @@ describe('admin token credential routes idempotent replay', () => {
       refreshToken: 'rt_codex_live',
       debugLabel: 'unsupported-openai',
       status: 'active',
-      expiresAt: new Date('2026-03-20T00:00:00.000Z')
+      expiresAt: new Date('2026-04-20T00:00:00.000Z')
     } as any);
     const refreshSpy = vi.spyOn(oauthRefreshModule, 'refreshTokenCredentialProviderUsageWithCredentialRefresh');
 
@@ -2184,7 +2184,7 @@ describe('admin token credential routes idempotent replay', () => {
       refreshToken: 'rt_codex_live',
       debugLabel: 'niyant-codex',
       status: 'active',
-      expiresAt: new Date('2026-03-20T00:00:00.000Z')
+      expiresAt: new Date('2026-04-20T00:00:00.000Z')
     } as any);
     vi.spyOn(oauthRefreshModule, 'refreshTokenCredentialProviderUsageWithCredentialRefresh').mockResolvedValue({
       credential: {
@@ -2196,7 +2196,7 @@ describe('admin token credential routes idempotent replay', () => {
         refreshToken: 'rt_codex_live',
         debugLabel: 'niyant-codex',
         status: 'active',
-        expiresAt: new Date('2026-03-20T00:00:00.000Z')
+        expiresAt: new Date('2026-04-20T00:00:00.000Z')
       },
       refreshedCredential: null,
       outcome: {

--- a/api/tests/apiKeyRepository.test.ts
+++ b/api/tests/apiKeyRepository.test.ts
@@ -21,6 +21,13 @@ class SequenceSqlClient implements SqlClient {
   }
 }
 
+function createMissingFreezeTableError(): Record<string, string> {
+  return {
+    code: '42P01',
+    message: 'relation "in_pilot_admission_freezes" does not exist'
+  };
+}
+
 describe('apiKeyRepository', () => {
   it('loads preferred provider when migration is present', async () => {
     const db = new SequenceSqlClient([{
@@ -82,7 +89,43 @@ describe('apiKeyRepository', () => {
     expect(db.queries).toHaveLength(2);
     expect(db.queries[1]?.sql).toContain('name');
     expect(db.queries[0]?.sql).toContain('preferred_provider');
-    expect(db.queries[1]?.sql).not.toContain('preferred_provider');
+    expect(db.queries[1]?.sql).toContain('null::text as preferred_provider');
+  });
+
+  it('falls back cleanly before migration 018 creates the freeze table', async () => {
+    const db = new SequenceSqlClient([
+      { error: createMissingFreezeTableError() },
+      {
+        rows: [{
+          id: 'key_1',
+          org_id: '00000000-0000-0000-0000-000000000001',
+          scope: 'buyer_proxy',
+          name: 'shirtless',
+          is_active: true,
+          expires_at: null,
+          preferred_provider: 'openai',
+          is_frozen: false
+        }],
+        rowCount: 1
+      }
+    ]);
+    const repo = new ApiKeyRepository(db);
+
+    const record = await repo.findActiveByHash('hash_live');
+
+    expect(record).toEqual({
+      id: 'key_1',
+      org_id: '00000000-0000-0000-0000-000000000001',
+      scope: 'buyer_proxy',
+      name: 'shirtless',
+      is_active: true,
+      expires_at: null,
+      preferred_provider: 'openai',
+      is_frozen: false
+    });
+    expect(db.queries).toHaveLength(2);
+    expect(db.queries[0]?.sql).toContain('in_pilot_admission_freezes');
+    expect(db.queries[1]?.sql).not.toContain('in_pilot_admission_freezes');
   });
 
   it('loads buyer provider preference via legacy read path before migration 009 is applied', async () => {

--- a/api/tests/auth.middleware.test.ts
+++ b/api/tests/auth.middleware.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest';
+import { requireApiKey } from '../src/middleware/auth.js';
+import { sha256Hex } from '../src/utils/hash.js';
+
+function createMockReq(headers: Record<string, string>) {
+  const lower = Object.fromEntries(Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value]));
+  return {
+    auth: undefined,
+    header(name: string) {
+      return lower[name.toLowerCase()];
+    }
+  } as any;
+}
+
+function createMockRes() {
+  return {
+    statusCode: 200,
+    body: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+    }
+  } as any;
+}
+
+describe('requireApiKey', () => {
+  it('fails closed for frozen buyer keys', async () => {
+    const repo = {
+      findActiveByHash: vi.fn().mockResolvedValue({
+        id: 'buyer_1',
+        org_id: 'org_fnf',
+        scope: 'buyer_proxy',
+        is_active: true,
+        expires_at: null,
+        preferred_provider: null,
+        is_frozen: true
+      }),
+      touchLastUsed: vi.fn().mockResolvedValue(undefined)
+    } as any;
+
+    const middleware = requireApiKey(repo, ['buyer_proxy']);
+    const req = createMockReq({ 'x-api-key': 'buyer-token' });
+    const res = createMockRes();
+    const next = vi.fn();
+
+    await middleware(req, res, next);
+
+    expect(repo.findActiveByHash).toHaveBeenCalledWith(sha256Hex('buyer-token'));
+    expect(res.statusCode).toBe(423);
+    expect(res.body).toEqual({
+      code: 'cutover_in_progress',
+      message: 'Buyer key is temporarily unavailable during cutover'
+    });
+    expect(repo.touchLastUsed).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('populates request auth for active unfrozen buyer keys', async () => {
+    const repo = {
+      findActiveByHash: vi.fn().mockResolvedValue({
+        id: 'buyer_1',
+        org_id: 'org_fnf',
+        scope: 'buyer_proxy',
+        name: 'darryn',
+        is_active: true,
+        expires_at: null,
+        preferred_provider: null,
+        is_frozen: false
+      }),
+      touchLastUsed: vi.fn().mockResolvedValue(undefined)
+    } as any;
+
+    const middleware = requireApiKey(repo, ['buyer_proxy']);
+    const req = createMockReq({ authorization: 'Bearer buyer-token' });
+    const res = createMockRes();
+    const next = vi.fn();
+
+    await middleware(req, res, next);
+
+    expect(res.statusCode).toBe(200);
+    expect(req.auth).toEqual(expect.objectContaining({
+      apiKeyId: 'buyer_1',
+      orgId: 'org_fnf',
+      scope: 'buyer_proxy',
+      buyerKeyLabel: 'darryn'
+    }));
+    expect(repo.touchLastUsed).toHaveBeenCalledWith('buyer_1');
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+});

--- a/api/tests/darrynCutoverAccessMigrations.test.ts
+++ b/api/tests/darrynCutoverAccessMigrations.test.ts
@@ -1,0 +1,101 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const initMigrationPath = resolve(process.cwd(), '../docs/migrations/001_checkpoint1_init.sql');
+const hardCutoverMigrationPath = resolve(process.cwd(), '../docs/migrations/005_hard_cutover_in_prefix.sql');
+const foundationMigrationPath = resolve(process.cwd(), '../docs/migrations/017_darryn_foundation_contracts.sql');
+const migrationPath = resolve(process.cwd(), '../docs/migrations/018_darryn_cutover_access.sql');
+
+const initNoExtensionsMigrationPath = resolve(process.cwd(), '../docs/migrations/001_checkpoint1_init_no_extensions.sql');
+const hardCutoverNoExtensionsMigrationPath = resolve(process.cwd(), '../docs/migrations/005_hard_cutover_in_prefix_no_extensions.sql');
+const foundationNoExtensionsMigrationPath = resolve(process.cwd(), '../docs/migrations/017_darryn_foundation_contracts_no_extensions.sql');
+const noExtensionsMigrationPath = resolve(process.cwd(), '../docs/migrations/018_darryn_cutover_access_no_extensions.sql');
+
+describe('darryn cutover access migrations', () => {
+  it('creates the pilot admission freeze table in the primary migration', () => {
+    const sql = readFileSync(migrationPath, 'utf8');
+
+    expect(sql).toContain('CREATE TABLE IF NOT EXISTS in_pilot_admission_freezes');
+    expect(sql).toContain("resource_type text NOT NULL CHECK (resource_type IN ('buyer_key', 'token_credential'))");
+    expect(sql).toContain('resource_id uuid NOT NULL');
+    expect(sql).toContain("operation_kind text NOT NULL CHECK (operation_kind IN ('cutover', 'rollback'))");
+    expect(sql).toContain('released_at timestamptz');
+    expect(sql).toContain('last_error text');
+    expect(sql).toContain('CREATE UNIQUE INDEX IF NOT EXISTS uq_in_pilot_admission_freezes_active_resource');
+    expect(sql).toContain('WHERE released_at IS NULL');
+  });
+
+  it('keeps the no-extensions migration aligned with the primary cutover-access table', () => {
+    const sql = readFileSync(noExtensionsMigrationPath, 'utf8');
+
+    expect(sql).toContain('CREATE TABLE IF NOT EXISTS in_pilot_admission_freezes');
+    expect(sql).toContain("resource_type text NOT NULL CHECK (resource_type IN ('buyer_key', 'token_credential'))");
+    expect(sql).toContain("operation_kind text NOT NULL CHECK (operation_kind IN ('cutover', 'rollback'))");
+    expect(sql).toContain('CREATE UNIQUE INDEX IF NOT EXISTS uq_in_pilot_admission_freezes_active_resource');
+    expect(sql).toContain('WHERE released_at IS NULL');
+  });
+
+  it('references only tables that already exist in schema history or are created in the migration', () => {
+    const priorSql = [
+      readFileSync(initMigrationPath, 'utf8'),
+      readFileSync(hardCutoverMigrationPath, 'utf8'),
+      readFileSync(foundationMigrationPath, 'utf8')
+    ].join('\n');
+    const sql = readFileSync(migrationPath, 'utf8');
+
+    expect(findUnresolvedTableDependencies(priorSql, sql)).toEqual([]);
+  });
+
+  it('keeps the no-extensions migration on the same dependency graph', () => {
+    const priorSql = [
+      readFileSync(initNoExtensionsMigrationPath, 'utf8'),
+      readFileSync(hardCutoverNoExtensionsMigrationPath, 'utf8'),
+      readFileSync(foundationNoExtensionsMigrationPath, 'utf8')
+    ].join('\n');
+    const sql = readFileSync(noExtensionsMigrationPath, 'utf8');
+
+    expect(findUnresolvedTableDependencies(priorSql, sql)).toEqual([]);
+  });
+});
+
+function findUnresolvedTableDependencies(priorSql: string, currentSql: string): string[] {
+  const availableTables = new Set<string>([
+    ...extractCreatedTables(priorSql),
+    ...extractRenamedTables(priorSql),
+    ...extractCreatedTables(currentSql)
+  ]);
+
+  const requiredTables = new Set<string>([
+    ...extractReferencedTables(currentSql),
+    ...extractAlteredTables(currentSql)
+  ]);
+
+  return Array.from(requiredTables)
+    .filter((table) => !availableTables.has(table))
+    .sort();
+}
+
+function extractCreatedTables(sql: string): string[] {
+  return extractMatches(sql, /CREATE TABLE IF NOT EXISTS ([a-z0-9_]+)/gi);
+}
+
+function extractRenamedTables(sql: string): string[] {
+  return extractMatches(sql, /ALTER TABLE IF EXISTS [a-z0-9_]+ RENAME TO ([a-z0-9_]+)/gi);
+}
+
+function extractReferencedTables(sql: string): string[] {
+  return extractMatches(sql, /REFERENCES ([a-z0-9_]+)\s*\(/gi);
+}
+
+function extractAlteredTables(sql: string): string[] {
+  return extractMatches(sql, /ALTER TABLE ([a-z0-9_]+)/gi);
+}
+
+function extractMatches(sql: string, pattern: RegExp): string[] {
+  const matches: string[] = [];
+  for (const match of sql.matchAll(pattern)) {
+    matches.push(match[1]);
+  }
+  return matches;
+}

--- a/api/tests/pilot.route.test.ts
+++ b/api/tests/pilot.route.test.ts
@@ -191,7 +191,7 @@ describe('pilot routes', () => {
   });
 
   it('redirects to GitHub auth with a signed state token', async () => {
-    vi.spyOn(runtimeModule.runtime.services.pilotGithubAuth, 'buildAuthorizationUrl')
+    const buildAuthorizationUrl = vi.spyOn(runtimeModule.runtime.services.pilotGithubAuth, 'buildAuthorizationUrl')
       .mockReturnValue('https://github.com/login/oauth/authorize?state=signed');
 
     const req = createMockReq({
@@ -205,6 +205,24 @@ describe('pilot routes', () => {
 
     expect(res.statusCode).toBe(302);
     expect(res.headers.location).toBe('https://github.com/login/oauth/authorize?state=signed');
+    expect(buildAuthorizationUrl).toHaveBeenCalledWith({ returnTo: '/pilot' });
+  });
+
+  it('drops unsafe external returnTo values before starting GitHub auth', async () => {
+    const buildAuthorizationUrl = vi.spyOn(runtimeModule.runtime.services.pilotGithubAuth, 'buildAuthorizationUrl')
+      .mockReturnValue('https://github.com/login/oauth/authorize?state=signed');
+
+    const req = createMockReq({
+      method: 'GET',
+      path: '/v1/pilot/auth/github/start',
+      query: { returnTo: 'https://evil.example.com/phish' }
+    });
+    const res = createMockRes();
+
+    await invoke(authStartHandlers[0], req, res);
+
+    expect(res.statusCode).toBe(302);
+    expect(buildAuthorizationUrl).toHaveBeenCalledWith({ returnTo: undefined });
   });
 
   it('handles the GitHub callback by setting the pilot session cookie and redirecting', async () => {
@@ -233,6 +251,32 @@ describe('pilot routes', () => {
     expect(res.headers.location).toBe('/pilot');
     expect(res.headers['set-cookie']).toContain('innies_pilot_session=signed-session-token');
     expect(res.headers['set-cookie']).toContain('HttpOnly');
+  });
+
+  it('falls back to /pilot when the callback returnTo is unsafe', async () => {
+    vi.spyOn(runtimeModule.runtime.services.pilotGithubAuth, 'finishOauthCallback').mockResolvedValue({
+      sessionToken: 'signed-session-token',
+      returnTo: 'https://evil.example.com/phish',
+      session: {
+        sessionKind: 'darryn_self',
+        actorUserId: 'user_darryn',
+        effectiveOrgId: 'org_fnf',
+        githubLogin: 'darryn',
+        userEmail: 'darryn@example.com'
+      }
+    } as any);
+
+    const req = createMockReq({
+      method: 'GET',
+      path: '/v1/pilot/auth/github/callback',
+      query: { code: 'oauth-code', state: 'oauth-state' }
+    });
+    const res = createMockRes();
+
+    await invoke(authCallbackHandlers[0], req, res);
+
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toBe('/pilot');
   });
 
   it('clears the pilot session cookie on logout', async () => {

--- a/api/tests/pilot.route.test.ts
+++ b/api/tests/pilot.route.test.ts
@@ -1,0 +1,251 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { AppError } from '../src/utils/errors.js';
+
+type RuntimeModule = typeof import('../src/services/runtime.js');
+type PilotRouteModule = typeof import('../src/routes/pilot.js');
+
+type MockReq = {
+  method: string;
+  path: string;
+  originalUrl: string;
+  body: unknown;
+  params: Record<string, string>;
+  query: Record<string, string>;
+  auth?: {
+    apiKeyId: string;
+    orgId: string | null;
+    scope: 'buyer_proxy' | 'admin';
+  };
+  header: (name: string) => string | undefined;
+};
+
+type MockRes = {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: unknown;
+  headersSent: boolean;
+  writableEnded: boolean;
+  setHeader: (name: string, value: string) => void;
+  status: (code: number) => MockRes;
+  json: (payload: unknown) => void;
+  send: (payload: unknown) => void;
+  redirect: (code: number, location: string) => void;
+};
+
+function createMockReq(input: {
+  method: string;
+  path: string;
+  headers?: Record<string, string>;
+  query?: Record<string, string>;
+  params?: Record<string, string>;
+}): MockReq {
+  const lower = Object.fromEntries(
+    Object.entries(input.headers ?? {}).map(([k, v]) => [k.toLowerCase(), v])
+  );
+  return {
+    method: input.method.toUpperCase(),
+    path: input.path,
+    originalUrl: input.path,
+    body: {},
+    params: input.params ?? {},
+    query: input.query ?? {},
+    header: (name: string) => lower[name.toLowerCase()]
+  };
+}
+
+function createMockRes(): MockRes {
+  return {
+    statusCode: 200,
+    headers: {},
+    body: undefined,
+    headersSent: false,
+    writableEnded: false,
+    setHeader(name: string, value: string) {
+      this.headers[name.toLowerCase()] = value;
+    },
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      this.headersSent = true;
+      this.writableEnded = true;
+    },
+    send(payload: unknown) {
+      this.body = payload;
+      this.headersSent = true;
+      this.writableEnded = true;
+    },
+    redirect(code: number, location: string) {
+      this.statusCode = code;
+      this.headers.location = location;
+      this.headersSent = true;
+      this.writableEnded = true;
+    }
+  };
+}
+
+function applyError(err: unknown, res: MockRes): void {
+  if (err instanceof z.ZodError) {
+    res.status(400).json({ code: 'invalid_request', message: 'Invalid request', issues: err.issues });
+    return;
+  }
+  if (err instanceof AppError) {
+    res.status(err.status).json({ code: err.code, message: err.message, details: err.details });
+    return;
+  }
+  const message = err instanceof Error ? err.message : 'Unexpected error';
+  res.status(500).json({ code: 'internal_error', message });
+}
+
+async function invoke(handle: (req: any, res: any, next: (error?: unknown) => void) => unknown, req: MockReq, res: MockRes): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    let nextCalled = false;
+    const next = (error?: unknown) => {
+      nextCalled = true;
+      if (error) {
+        applyError(error, res);
+      }
+      resolve();
+    };
+
+    Promise.resolve(handle(req, res, next))
+      .then(() => {
+        if (!nextCalled) resolve();
+      })
+      .catch(reject);
+  });
+}
+
+function getRouteHandlers(router: any, routePath: string, method: 'get' | 'post'): Array<(req: any, res: any, next: (error?: unknown) => void) => unknown> {
+  const layer = router.stack.find((entry: any) => entry?.route?.path === routePath && entry?.route?.methods?.[method]);
+  if (!layer) throw new Error(`route not found: ${routePath}`);
+  return layer.route.stack.map((s: any) => s.handle);
+}
+
+describe('pilot routes', () => {
+  let runtimeModule: RuntimeModule;
+  let sessionHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+  let authStartHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+  let authCallbackHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+  let logoutHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+
+  beforeAll(async () => {
+    process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgres://postgres:postgres@127.0.0.1:5432/innies_test';
+    process.env.SELLER_SECRET_ENC_KEY_B64 = process.env.SELLER_SECRET_ENC_KEY_B64 || Buffer.alloc(32, 7).toString('base64');
+    runtimeModule = await import('../src/services/runtime.js');
+    const mod = await import('../src/routes/pilot.js') as PilotRouteModule;
+    sessionHandlers = getRouteHandlers(mod.default as any, '/v1/pilot/session', 'get');
+    authStartHandlers = getRouteHandlers(mod.default as any, '/v1/pilot/auth/github/start', 'get');
+    authCallbackHandlers = getRouteHandlers(mod.default as any, '/v1/pilot/auth/github/callback', 'get');
+    logoutHandlers = getRouteHandlers(mod.default as any, '/v1/pilot/session/logout', 'post');
+  });
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns the current pilot session from a bearer token', async () => {
+    vi.spyOn(runtimeModule.runtime.services.pilotSessions, 'readTokenFromRequest').mockReturnValue('pilot-token');
+    vi.spyOn(runtimeModule.runtime.services.pilotSessions, 'readSession').mockReturnValue({
+      sessionKind: 'darryn_self',
+      actorUserId: 'user_darryn',
+      actorApiKeyId: null,
+      actorOrgId: 'org_fnf',
+      effectiveOrgId: 'org_fnf',
+      effectiveOrgSlug: 'fnf',
+      effectiveOrgName: 'Friends & Family',
+      githubLogin: 'darryn',
+      userEmail: 'darryn@example.com',
+      impersonatedUserId: null,
+      issuedAt: '2026-03-20T00:00:00Z',
+      expiresAt: '2026-03-20T01:00:00Z'
+    } as any);
+
+    const req = createMockReq({
+      method: 'GET',
+      path: '/v1/pilot/session',
+      headers: {
+        authorization: 'Bearer pilot-token'
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(sessionHandlers[0], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(expect.objectContaining({
+      ok: true,
+      session: expect.objectContaining({
+        sessionKind: 'darryn_self',
+        effectiveOrgId: 'org_fnf',
+        githubLogin: 'darryn'
+      })
+    }));
+  });
+
+  it('redirects to GitHub auth with a signed state token', async () => {
+    vi.spyOn(runtimeModule.runtime.services.pilotGithubAuth, 'buildAuthorizationUrl')
+      .mockReturnValue('https://github.com/login/oauth/authorize?state=signed');
+
+    const req = createMockReq({
+      method: 'GET',
+      path: '/v1/pilot/auth/github/start',
+      query: { returnTo: '/pilot' }
+    });
+    const res = createMockRes();
+
+    await invoke(authStartHandlers[0], req, res);
+
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toBe('https://github.com/login/oauth/authorize?state=signed');
+  });
+
+  it('handles the GitHub callback by setting the pilot session cookie and redirecting', async () => {
+    vi.spyOn(runtimeModule.runtime.services.pilotGithubAuth, 'finishOauthCallback').mockResolvedValue({
+      sessionToken: 'signed-session-token',
+      returnTo: '/pilot',
+      session: {
+        sessionKind: 'darryn_self',
+        actorUserId: 'user_darryn',
+        effectiveOrgId: 'org_fnf',
+        githubLogin: 'darryn',
+        userEmail: 'darryn@example.com'
+      }
+    } as any);
+
+    const req = createMockReq({
+      method: 'GET',
+      path: '/v1/pilot/auth/github/callback',
+      query: { code: 'oauth-code', state: 'oauth-state' }
+    });
+    const res = createMockRes();
+
+    await invoke(authCallbackHandlers[0], req, res);
+
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toBe('/pilot');
+    expect(res.headers['set-cookie']).toContain('innies_pilot_session=signed-session-token');
+    expect(res.headers['set-cookie']).toContain('HttpOnly');
+  });
+
+  it('clears the pilot session cookie on logout', async () => {
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/pilot/session/logout'
+    });
+    const res = createMockRes();
+
+    await invoke(logoutHandlers[0], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['set-cookie']).toContain('innies_pilot_session=');
+    expect(res.headers['set-cookie']).toContain('Max-Age=0');
+  });
+});

--- a/api/tests/pilotAdmissionFreezeRepository.test.ts
+++ b/api/tests/pilotAdmissionFreezeRepository.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { PilotAdmissionFreezeRepository } from '../src/repos/pilotAdmissionFreezeRepository.js';
+import { MockSqlClient, SequenceSqlClient } from './testHelpers.js';
+
+describe('PilotAdmissionFreezeRepository', () => {
+  it('upserts active buyer-key freezes', async () => {
+    const db = new MockSqlClient({
+      rows: [{ resource_type: 'buyer_key', resource_id: 'buyer_1', released_at: null }],
+      rowCount: 1
+    });
+    const repo = new PilotAdmissionFreezeRepository(db, () => 'freeze_1');
+
+    await repo.activateFreeze({
+      resourceType: 'buyer_key',
+      resourceId: 'buyer_1',
+      operationKind: 'cutover',
+      sourceOrgId: 'org_innies',
+      targetOrgId: 'org_fnf',
+      actorUserId: 'user_admin'
+    });
+
+    expect(db.queries[0].sql).toContain('insert into in_pilot_admission_freezes');
+    expect(db.queries[0].sql).toContain('on conflict (resource_type, resource_id)');
+    expect(db.queries[0].params).toContain('buyer_key');
+    expect(db.queries[0].params).toContain('buyer_1');
+    expect(db.queries[0].params).toContain('cutover');
+  });
+
+  it('releases active freezes with actor and reason metadata', async () => {
+    const db = new MockSqlClient({ rows: [], rowCount: 1 });
+    const repo = new PilotAdmissionFreezeRepository(db);
+
+    const released = await repo.releaseFreeze({
+      resourceType: 'token_credential',
+      resourceId: 'cred_1',
+      releasedByUserId: 'user_admin',
+      releaseReason: 'cutover_committed'
+    });
+
+    expect(released).toBe(true);
+    expect(db.queries[0].sql).toContain('update in_pilot_admission_freezes');
+    expect(db.queries[0].sql).toContain('set');
+    expect(db.queries[0].sql).toContain('released_at = now()');
+    expect(db.queries[0].params).toContain('token_credential');
+    expect(db.queries[0].params).toContain('cred_1');
+    expect(db.queries[0].params).toContain('cutover_committed');
+  });
+
+  it('reads an active freeze for a resource', async () => {
+    const db = new SequenceSqlClient([
+      {
+        rows: [{
+          id: 'freeze_1',
+          resource_type: 'buyer_key',
+          resource_id: 'buyer_1',
+          operation_kind: 'rollback',
+          source_org_id: 'org_fnf',
+          target_org_id: 'org_innies',
+          actor_user_id: 'user_admin',
+          released_at: null,
+          release_reason: null,
+          released_by_user_id: null,
+          last_error: 'reserve floor migration failed',
+          created_at: '2026-03-20T00:00:00Z',
+          updated_at: '2026-03-20T00:00:00Z'
+        }],
+        rowCount: 1
+      }
+    ]);
+    const repo = new PilotAdmissionFreezeRepository(db);
+
+    const row = await repo.findActiveFreeze('buyer_key', 'buyer_1');
+
+    expect(row?.id).toBe('freeze_1');
+    expect(db.queries[0].sql).toContain('where resource_type = $1');
+    expect(db.queries[0].sql).toContain('and resource_id = $2');
+    expect(db.queries[0].sql).toContain('and released_at is null');
+  });
+
+  it('records failure details without releasing the freeze', async () => {
+    const db = new MockSqlClient({ rows: [], rowCount: 1 });
+    const repo = new PilotAdmissionFreezeRepository(db);
+
+    const updated = await repo.recordFailure({
+      resourceType: 'buyer_key',
+      resourceId: 'buyer_1',
+      errorMessage: 'reserve floor migration failed'
+    });
+
+    expect(updated).toBe(true);
+    expect(db.queries[0].sql).toContain('update in_pilot_admission_freezes');
+    expect(db.queries[0].sql).toContain('set last_error = $3');
+    expect(db.queries[0].sql).toContain('and released_at is null');
+  });
+});

--- a/api/tests/pilotCutoverService.test.ts
+++ b/api/tests/pilotCutoverService.test.ts
@@ -7,6 +7,9 @@ function createService(overrides?: Partial<ConstructorParameters<typeof PilotCut
     releaseFreeze: vi.fn().mockResolvedValue(true),
     recordFailure: vi.fn().mockResolvedValue(true)
   };
+  const transactionalFreezeRepository = {
+    releaseFreeze: vi.fn().mockResolvedValue(true)
+  };
 
   const identityRepository = {
     ensureOrg: vi.fn().mockResolvedValue({ id: 'org_fnf', slug: 'fnf', name: 'Friends & Family' }),
@@ -42,6 +45,7 @@ function createService(overrides?: Partial<ConstructorParameters<typeof PilotCut
     createIdentityRepository: vi.fn().mockReturnValue(identityRepository),
     createFnfOwnershipRepository: vi.fn().mockReturnValue(fnfOwnershipRepository),
     createPilotCutoverRepository: vi.fn().mockReturnValue(cutoverRepository),
+    createFreezeRepository: vi.fn().mockReturnValue(transactionalFreezeRepository as any),
     ...overrides
   });
 
@@ -49,6 +53,7 @@ function createService(overrides?: Partial<ConstructorParameters<typeof PilotCut
     service,
     sql,
     freezeRepository,
+    transactionalFreezeRepository,
     identityRepository,
     fnfOwnershipRepository,
     cutoverRepository,
@@ -57,6 +62,50 @@ function createService(overrides?: Partial<ConstructorParameters<typeof PilotCut
 }
 
 describe('PilotCutoverService', () => {
+  it('does not release freezes through the global repository before commit succeeds', async () => {
+    const freezeRepository = {
+      activateFreeze: vi.fn().mockResolvedValue(undefined),
+      releaseFreeze: vi.fn().mockResolvedValue(true),
+      recordFailure: vi.fn().mockResolvedValue(true)
+    };
+    const txFreezeRepository = {
+      releaseFreeze: vi.fn().mockResolvedValue(true)
+    };
+    const reserveFloorMigration = {
+      migrateReserveFloors: vi.fn().mockResolvedValue(undefined)
+    };
+    const sql = {
+      query: vi.fn(),
+      transaction: vi.fn(async (run: (tx: object) => Promise<unknown>) => {
+        await run({ kind: 'tx' });
+        throw new Error('commit failed');
+      })
+    };
+
+    const { service } = createService({
+      sql: sql as any,
+      freezeRepository: freezeRepository as any,
+      reserveFloorMigration,
+      ...({
+        createFreezeRepository: vi.fn().mockReturnValue(txFreezeRepository)
+      } as any)
+    });
+
+    await expect(service.cutover({
+      sourceOrgId: 'org_innies',
+      targetOrgSlug: 'fnf',
+      targetOrgName: 'Friends & Family',
+      targetUserEmail: 'darryn@example.com',
+      targetUserDisplayName: 'Darryn',
+      buyerKeyIds: ['buyer_1'],
+      tokenCredentialIds: ['cred_1']
+    } as any)).rejects.toThrow('commit failed');
+
+    expect(freezeRepository.releaseFreeze).not.toHaveBeenCalled();
+    expect(txFreezeRepository.releaseFreeze).toHaveBeenCalledTimes(2);
+    expect(freezeRepository.recordFailure).toHaveBeenCalledTimes(2);
+  });
+
   it('releases freezes inside the cutover transaction and passes the transaction to reserve-floor migration', async () => {
     const tx = { kind: 'cutover-transaction' };
     const callOrder: string[] = [];
@@ -67,11 +116,14 @@ describe('PilotCutoverService', () => {
     };
     const freezeRepository = {
       activateFreeze: vi.fn().mockResolvedValue(undefined),
+      releaseFreeze: vi.fn().mockResolvedValue(true),
+      recordFailure: vi.fn().mockResolvedValue(true)
+    };
+    const txFreezeRepository = {
       releaseFreeze: vi.fn().mockImplementation(async () => {
         callOrder.push('freeze:release');
         return true;
       }),
-      recordFailure: vi.fn().mockResolvedValue(true)
     };
     const sql = {
       query: vi.fn(),
@@ -86,7 +138,13 @@ describe('PilotCutoverService', () => {
     const { service } = createService({
       sql: sql as any,
       freezeRepository: freezeRepository as any,
-      reserveFloorMigration
+      reserveFloorMigration,
+      ...({
+        createFreezeRepository: vi.fn().mockImplementation((input: object) => {
+          callOrder.push(input === tx ? 'freeze-repo:tx' : 'freeze-repo:other');
+          return txFreezeRepository;
+        })
+      } as any)
     });
 
     await service.cutover({
@@ -95,19 +153,21 @@ describe('PilotCutoverService', () => {
       targetOrgName: 'Friends & Family',
       targetUserEmail: 'darryn@example.com',
       targetUserDisplayName: 'Darryn',
-      targetGithubLogin: 'darryn',
       buyerKeyIds: ['buyer_1'],
       tokenCredentialIds: ['cred_1']
-    });
+    } as any);
 
+    expect(callOrder).toContain('freeze-repo:tx');
     expect(callOrder).toContain('migrate:tx');
     expect(callOrder.lastIndexOf('freeze:release')).toBeLessThan(callOrder.indexOf('tx:after-work'));
+    expect(freezeRepository.releaseFreeze).not.toHaveBeenCalled();
   });
 
   it('cuts over buyer keys and token credentials, then releases freezes after reserve-floor migration succeeds', async () => {
     const {
       service,
       freezeRepository,
+      transactionalFreezeRepository,
       identityRepository,
       fnfOwnershipRepository,
       cutoverRepository,
@@ -120,12 +180,11 @@ describe('PilotCutoverService', () => {
       targetOrgName: 'Friends & Family',
       targetUserEmail: 'darryn@example.com',
       targetUserDisplayName: 'Darryn',
-      targetGithubLogin: 'darryn',
       buyerKeyIds: ['buyer_1'],
       tokenCredentialIds: ['cred_1'],
       actorUserId: 'user_admin',
       effectiveAt: new Date('2026-03-20T00:00:00Z')
-    });
+    } as any);
 
     expect(freezeRepository.activateFreeze).toHaveBeenCalledTimes(2);
     expect(identityRepository.ensureOrg).toHaveBeenCalledWith({
@@ -174,7 +233,8 @@ describe('PilotCutoverService', () => {
       cutoverId: 'cut_1',
       actorUserId: 'user_admin'
     });
-    expect(freezeRepository.releaseFreeze).toHaveBeenCalledTimes(2);
+    expect(freezeRepository.releaseFreeze).not.toHaveBeenCalled();
+    expect(transactionalFreezeRepository.releaseFreeze).toHaveBeenCalledTimes(2);
     expect(result.cutoverRecord.id).toBe('cut_1');
   });
 
@@ -193,10 +253,9 @@ describe('PilotCutoverService', () => {
       targetOrgName: 'Friends & Family',
       targetUserEmail: 'darryn@example.com',
       targetUserDisplayName: 'Darryn',
-      targetGithubLogin: 'darryn',
       buyerKeyIds: ['buyer_1'],
       tokenCredentialIds: ['cred_1']
-    })).rejects.toThrow('reserve floor migration failed');
+    } as any)).rejects.toThrow('reserve floor migration failed');
 
     expect(freezeRepository.recordFailure).toHaveBeenCalledTimes(2);
     expect(freezeRepository.releaseFreeze).not.toHaveBeenCalled();
@@ -206,6 +265,7 @@ describe('PilotCutoverService', () => {
     const {
       service,
       freezeRepository,
+      transactionalFreezeRepository,
       identityRepository,
       fnfOwnershipRepository,
       cutoverRepository,
@@ -246,7 +306,8 @@ describe('PilotCutoverService', () => {
       revertedProviderCredentialTargetOrgId: 'org_innies',
       createdByUserId: 'user_admin'
     });
-    expect(freezeRepository.releaseFreeze).toHaveBeenCalledTimes(2);
+    expect(freezeRepository.releaseFreeze).not.toHaveBeenCalled();
+    expect(transactionalFreezeRepository.releaseFreeze).toHaveBeenCalledTimes(2);
     expect(reserveFloorMigration.migrateReserveFloors).not.toHaveBeenCalled();
     expect(result.rollbackRecord.id).toBe('rollback_1');
   });

--- a/api/tests/pilotCutoverService.test.ts
+++ b/api/tests/pilotCutoverService.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it, vi } from 'vitest';
+import { PilotCutoverService } from '../src/services/pilot/pilotCutoverService.js';
+
+function createService(overrides?: Partial<ConstructorParameters<typeof PilotCutoverService>[0]>) {
+  const freezeRepository = {
+    activateFreeze: vi.fn().mockResolvedValue(undefined),
+    releaseFreeze: vi.fn().mockResolvedValue(true),
+    recordFailure: vi.fn().mockResolvedValue(true)
+  };
+
+  const identityRepository = {
+    ensureOrg: vi.fn().mockResolvedValue({ id: 'org_fnf', slug: 'fnf', name: 'Friends & Family' }),
+    ensureUser: vi.fn().mockResolvedValue({ id: 'user_darryn', email: 'darryn@example.com', display_name: 'Darryn' }),
+    ensureMembership: vi.fn().mockResolvedValue({ id: 'membership_1', org_id: 'org_fnf', user_id: 'user_darryn', role: 'buyer' }),
+    reassignBuyerKeysToOrg: vi.fn().mockResolvedValue(['buyer_1']),
+    reassignTokenCredentialsToOrg: vi.fn().mockResolvedValue(['cred_1'])
+  };
+
+  const fnfOwnershipRepository = {
+    upsertBuyerKeyOwnership: vi.fn().mockResolvedValue({}),
+    upsertTokenCredentialOwnership: vi.fn().mockResolvedValue({})
+  };
+
+  const cutoverRepository = {
+    createCutoverRecord: vi.fn().mockResolvedValue({ id: 'cut_1', target_org_id: 'org_fnf' }),
+    createRollbackRecord: vi.fn().mockResolvedValue({ id: 'rollback_1' })
+  };
+
+  const reserveFloorMigration = {
+    migrateReserveFloors: vi.fn().mockResolvedValue(undefined)
+  };
+
+  const sql = {
+    query: vi.fn(),
+    transaction: vi.fn(async (run: (tx: object) => Promise<unknown>) => run({}))
+  };
+
+  const service = new PilotCutoverService({
+    sql: sql as any,
+    freezeRepository: freezeRepository as any,
+    reserveFloorMigration,
+    createIdentityRepository: vi.fn().mockReturnValue(identityRepository),
+    createFnfOwnershipRepository: vi.fn().mockReturnValue(fnfOwnershipRepository),
+    createPilotCutoverRepository: vi.fn().mockReturnValue(cutoverRepository),
+    ...overrides
+  });
+
+  return {
+    service,
+    sql,
+    freezeRepository,
+    identityRepository,
+    fnfOwnershipRepository,
+    cutoverRepository,
+    reserveFloorMigration
+  };
+}
+
+describe('PilotCutoverService', () => {
+  it('releases freezes inside the cutover transaction and passes the transaction to reserve-floor migration', async () => {
+    const tx = { kind: 'cutover-transaction' };
+    const callOrder: string[] = [];
+    const reserveFloorMigration = {
+      migrateReserveFloors: vi.fn().mockImplementation(async (input: { db?: object }) => {
+        callOrder.push(input.db === tx ? 'migrate:tx' : 'migrate:other');
+      })
+    };
+    const freezeRepository = {
+      activateFreeze: vi.fn().mockResolvedValue(undefined),
+      releaseFreeze: vi.fn().mockImplementation(async () => {
+        callOrder.push('freeze:release');
+        return true;
+      }),
+      recordFailure: vi.fn().mockResolvedValue(true)
+    };
+    const sql = {
+      query: vi.fn(),
+      transaction: vi.fn(async (run: (input: object) => Promise<unknown>) => {
+        callOrder.push('tx:before-commit');
+        const result = await run(tx);
+        callOrder.push('tx:after-work');
+        return result;
+      })
+    };
+
+    const { service } = createService({
+      sql: sql as any,
+      freezeRepository: freezeRepository as any,
+      reserveFloorMigration
+    });
+
+    await service.cutover({
+      sourceOrgId: 'org_innies',
+      targetOrgSlug: 'fnf',
+      targetOrgName: 'Friends & Family',
+      targetUserEmail: 'darryn@example.com',
+      targetUserDisplayName: 'Darryn',
+      targetGithubLogin: 'darryn',
+      buyerKeyIds: ['buyer_1'],
+      tokenCredentialIds: ['cred_1']
+    });
+
+    expect(callOrder).toContain('migrate:tx');
+    expect(callOrder.lastIndexOf('freeze:release')).toBeLessThan(callOrder.indexOf('tx:after-work'));
+  });
+
+  it('cuts over buyer keys and token credentials, then releases freezes after reserve-floor migration succeeds', async () => {
+    const {
+      service,
+      freezeRepository,
+      identityRepository,
+      fnfOwnershipRepository,
+      cutoverRepository,
+      reserveFloorMigration
+    } = createService();
+
+    const result = await service.cutover({
+      sourceOrgId: 'org_innies',
+      targetOrgSlug: 'fnf',
+      targetOrgName: 'Friends & Family',
+      targetUserEmail: 'darryn@example.com',
+      targetUserDisplayName: 'Darryn',
+      targetGithubLogin: 'darryn',
+      buyerKeyIds: ['buyer_1'],
+      tokenCredentialIds: ['cred_1'],
+      actorUserId: 'user_admin',
+      effectiveAt: new Date('2026-03-20T00:00:00Z')
+    });
+
+    expect(freezeRepository.activateFreeze).toHaveBeenCalledTimes(2);
+    expect(identityRepository.ensureOrg).toHaveBeenCalledWith({
+      slug: 'fnf',
+      name: 'Friends & Family'
+    });
+    expect(identityRepository.ensureUser).toHaveBeenCalledWith({
+      email: 'darryn@example.com',
+      displayName: 'Darryn'
+    });
+    expect(identityRepository.ensureMembership).toHaveBeenCalledWith({
+      orgId: 'org_fnf',
+      userId: 'user_darryn',
+      role: 'buyer'
+    });
+    expect(identityRepository.reassignBuyerKeysToOrg).toHaveBeenCalledWith({
+      apiKeyIds: ['buyer_1'],
+      targetOrgId: 'org_fnf'
+    });
+    expect(identityRepository.reassignTokenCredentialsToOrg).toHaveBeenCalledWith({
+      tokenCredentialIds: ['cred_1'],
+      targetOrgId: 'org_fnf'
+    });
+    expect(fnfOwnershipRepository.upsertBuyerKeyOwnership).toHaveBeenCalledWith({
+      apiKeyId: 'buyer_1',
+      ownerOrgId: 'org_fnf',
+      ownerUserId: 'user_darryn'
+    });
+    expect(fnfOwnershipRepository.upsertTokenCredentialOwnership).toHaveBeenCalledWith({
+      tokenCredentialId: 'cred_1',
+      ownerOrgId: 'org_fnf',
+      capacityOwnerUserId: 'user_darryn'
+    });
+    expect(cutoverRepository.createCutoverRecord).toHaveBeenCalledWith(expect.objectContaining({
+      sourceOrgId: 'org_innies',
+      targetOrgId: 'org_fnf',
+      buyerKeyOwnershipSwapped: true,
+      providerCredentialOwnershipSwapped: true,
+      reserveFloorMigrationCompleted: true
+    }));
+    expect(reserveFloorMigration.migrateReserveFloors).toHaveBeenCalledWith({
+      db: expect.any(Object),
+      fromOrgId: 'org_innies',
+      toOrgId: 'org_fnf',
+      targetUserId: 'user_darryn',
+      cutoverId: 'cut_1',
+      actorUserId: 'user_admin'
+    });
+    expect(freezeRepository.releaseFreeze).toHaveBeenCalledTimes(2);
+    expect(result.cutoverRecord.id).toBe('cut_1');
+  });
+
+  it('records failure details and keeps admissions fail-closed when reserve-floor migration fails', async () => {
+    const reserveFloorMigration = {
+      migrateReserveFloors: vi.fn().mockRejectedValue(new Error('reserve floor migration failed'))
+    };
+    const {
+      service,
+      freezeRepository
+    } = createService({ reserveFloorMigration });
+
+    await expect(service.cutover({
+      sourceOrgId: 'org_innies',
+      targetOrgSlug: 'fnf',
+      targetOrgName: 'Friends & Family',
+      targetUserEmail: 'darryn@example.com',
+      targetUserDisplayName: 'Darryn',
+      targetGithubLogin: 'darryn',
+      buyerKeyIds: ['buyer_1'],
+      tokenCredentialIds: ['cred_1']
+    })).rejects.toThrow('reserve floor migration failed');
+
+    expect(freezeRepository.recordFailure).toHaveBeenCalledTimes(2);
+    expect(freezeRepository.releaseFreeze).not.toHaveBeenCalled();
+  });
+
+  it('rolls ownership back and releases freezes after writing the rollback record', async () => {
+    const {
+      service,
+      freezeRepository,
+      identityRepository,
+      fnfOwnershipRepository,
+      cutoverRepository,
+      reserveFloorMigration
+    } = createService();
+
+    const result = await service.rollback({
+      sourceCutoverId: 'cut_1',
+      targetOrgId: 'org_innies',
+      buyerKeyIds: ['buyer_1'],
+      tokenCredentialIds: ['cred_1'],
+      actorUserId: 'user_admin',
+      effectiveAt: new Date('2026-03-20T01:00:00Z')
+    });
+
+    expect(identityRepository.reassignBuyerKeysToOrg).toHaveBeenCalledWith({
+      apiKeyIds: ['buyer_1'],
+      targetOrgId: 'org_innies'
+    });
+    expect(identityRepository.reassignTokenCredentialsToOrg).toHaveBeenCalledWith({
+      tokenCredentialIds: ['cred_1'],
+      targetOrgId: 'org_innies'
+    });
+    expect(fnfOwnershipRepository.upsertBuyerKeyOwnership).toHaveBeenCalledWith({
+      apiKeyId: 'buyer_1',
+      ownerOrgId: 'org_innies',
+      ownerUserId: null
+    });
+    expect(fnfOwnershipRepository.upsertTokenCredentialOwnership).toHaveBeenCalledWith({
+      tokenCredentialId: 'cred_1',
+      ownerOrgId: 'org_innies',
+      capacityOwnerUserId: null
+    });
+    expect(cutoverRepository.createRollbackRecord).toHaveBeenCalledWith({
+      sourceCutoverId: 'cut_1',
+      effectiveAt: new Date('2026-03-20T01:00:00Z'),
+      revertedBuyerKeyTargetOrgId: 'org_innies',
+      revertedProviderCredentialTargetOrgId: 'org_innies',
+      createdByUserId: 'user_admin'
+    });
+    expect(freezeRepository.releaseFreeze).toHaveBeenCalledTimes(2);
+    expect(reserveFloorMigration.migrateReserveFloors).not.toHaveBeenCalled();
+    expect(result.rollbackRecord.id).toBe('rollback_1');
+  });
+});

--- a/api/tests/pilotGithubAuthService.test.ts
+++ b/api/tests/pilotGithubAuthService.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PilotGithubAuthService } from '../src/services/pilot/pilotGithubAuthService.js';
+
+describe('PilotGithubAuthService', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('exchanges the GitHub callback, enforces the allowlist, and issues a Darryn self-session', async () => {
+    const identityRepository = {
+      ensureOrg: vi.fn().mockResolvedValue({ id: 'org_fnf', slug: 'fnf', name: 'Friends & Family' }),
+      ensureUser: vi.fn().mockResolvedValue({ id: 'user_darryn', email: 'darryn@example.com' }),
+      ensureMembership: vi.fn().mockResolvedValue({ id: 'membership_1' })
+    };
+    const sessionService = {
+      issueSession: vi.fn().mockReturnValue('signed-session-token')
+    };
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: 'gho_123' })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ login: 'darryn', email: null, name: 'Darryn' })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ([{ email: 'darryn@example.com', primary: true, verified: true }])
+      });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const service = new PilotGithubAuthService({
+      clientId: 'github-client-id',
+      clientSecret: 'github-client-secret',
+      callbackUrl: 'https://innies.example.com/v1/pilot/auth/github/callback',
+      allowlistedLogins: ['darryn'],
+      allowlistedEmails: [],
+      identityRepository: identityRepository as any,
+      sessionService: sessionService as any,
+      targetOrgSlug: 'fnf',
+      targetOrgName: 'Friends & Family',
+      stateSecret: 'pilot-oauth-state-secret',
+      now: () => new Date('2026-03-20T00:00:00Z')
+    });
+
+    const state = service.createOauthState({ returnTo: '/pilot' });
+    const result = await service.finishOauthCallback({
+      code: 'oauth-code',
+      state
+    });
+
+    expect(identityRepository.ensureOrg).toHaveBeenCalledWith({
+      slug: 'fnf',
+      name: 'Friends & Family'
+    });
+    expect(identityRepository.ensureUser).toHaveBeenCalledWith({
+      email: 'darryn@example.com',
+      displayName: 'Darryn'
+    });
+    expect(identityRepository.ensureMembership).toHaveBeenCalledWith({
+      orgId: 'org_fnf',
+      userId: 'user_darryn',
+      role: 'buyer'
+    });
+    expect(sessionService.issueSession).toHaveBeenCalledWith(expect.objectContaining({
+      sessionKind: 'darryn_self',
+      actorUserId: 'user_darryn',
+      effectiveOrgId: 'org_fnf',
+      githubLogin: 'darryn',
+      userEmail: 'darryn@example.com'
+    }));
+    expect(result).toEqual(expect.objectContaining({
+      sessionToken: 'signed-session-token',
+      returnTo: '/pilot'
+    }));
+  });
+
+  it('rejects GitHub users that are not on the Darryn allowlist', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: 'gho_123' })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ login: 'someone-else', email: null, name: 'Someone Else' })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ([{ email: 'else@example.com', primary: true, verified: true }])
+      });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const service = new PilotGithubAuthService({
+      clientId: 'github-client-id',
+      clientSecret: 'github-client-secret',
+      callbackUrl: 'https://innies.example.com/v1/pilot/auth/github/callback',
+      allowlistedLogins: ['darryn'],
+      allowlistedEmails: ['darryn@example.com'],
+      identityRepository: {
+        ensureOrg: vi.fn(),
+        ensureUser: vi.fn(),
+        ensureMembership: vi.fn()
+      } as any,
+      sessionService: {
+        issueSession: vi.fn()
+      } as any,
+      targetOrgSlug: 'fnf',
+      targetOrgName: 'Friends & Family',
+      stateSecret: 'pilot-oauth-state-secret',
+      now: () => new Date('2026-03-20T00:00:00Z')
+    });
+
+    const state = service.createOauthState({ returnTo: '/pilot' });
+
+    await expect(service.finishOauthCallback({
+      code: 'oauth-code',
+      state
+    })).rejects.toThrow('GitHub user is not allowlisted for the pilot');
+  });
+
+  it('does not treat an unverified user.email fallback as an email-allowlist match', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: 'gho_123' })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ login: 'someone-else', email: 'darryn@example.com', name: 'Someone Else' })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ([{ email: 'darryn@example.com', primary: true, verified: false }])
+      });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const service = new PilotGithubAuthService({
+      clientId: 'github-client-id',
+      clientSecret: 'github-client-secret',
+      callbackUrl: 'https://innies.example.com/v1/pilot/auth/github/callback',
+      allowlistedLogins: [],
+      allowlistedEmails: ['darryn@example.com'],
+      identityRepository: {
+        ensureOrg: vi.fn(),
+        ensureUser: vi.fn(),
+        ensureMembership: vi.fn()
+      } as any,
+      sessionService: {
+        issueSession: vi.fn()
+      } as any,
+      targetOrgSlug: 'fnf',
+      targetOrgName: 'Friends & Family',
+      stateSecret: 'pilot-oauth-state-secret',
+      now: () => new Date('2026-03-20T00:00:00Z')
+    });
+
+    const state = service.createOauthState({ returnTo: '/pilot' });
+
+    await expect(service.finishOauthCallback({
+      code: 'oauth-code',
+      state
+    })).rejects.toThrow('GitHub user is not allowlisted for the pilot');
+  });
+});

--- a/api/tests/pilotGithubAuthService.test.ts
+++ b/api/tests/pilotGithubAuthService.test.ts
@@ -166,4 +166,49 @@ describe('PilotGithubAuthService', () => {
       state
     })).rejects.toThrow('GitHub user is not allowlisted for the pilot');
   });
+
+  it('rejects login-allowlisted users that do not have a verified GitHub email for provisioning', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: 'gho_123' })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ login: 'darryn', email: 'darryn@example.com', name: 'Darryn' })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ([{ email: 'darryn@example.com', primary: true, verified: false }])
+      });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const service = new PilotGithubAuthService({
+      clientId: 'github-client-id',
+      clientSecret: 'github-client-secret',
+      callbackUrl: 'https://innies.example.com/v1/pilot/auth/github/callback',
+      allowlistedLogins: ['darryn'],
+      allowlistedEmails: [],
+      identityRepository: {
+        ensureOrg: vi.fn(),
+        ensureUser: vi.fn(),
+        ensureMembership: vi.fn()
+      } as any,
+      sessionService: {
+        issueSession: vi.fn()
+      } as any,
+      targetOrgSlug: 'fnf',
+      targetOrgName: 'Friends & Family',
+      stateSecret: 'pilot-oauth-state-secret',
+      now: () => new Date('2026-03-20T00:00:00Z')
+    });
+
+    const state = service.createOauthState({ returnTo: '/pilot' });
+
+    await expect(service.finishOauthCallback({
+      code: 'oauth-code',
+      state
+    })).rejects.toThrow('GitHub user does not have a verified email for the pilot');
+  });
 });

--- a/api/tests/pilotIdentityRepository.test.ts
+++ b/api/tests/pilotIdentityRepository.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import { PilotIdentityRepository } from '../src/repos/pilotIdentityRepository.js';
+import { MockSqlClient, SequenceSqlClient } from './testHelpers.js';
+
+describe('PilotIdentityRepository', () => {
+  it('creates the fnf org when the slug does not exist', async () => {
+    const db = new SequenceSqlClient([
+      { rows: [], rowCount: 0 },
+      {
+        rows: [{ id: 'org_fnf', slug: 'fnf', name: 'Friends & Family' }],
+        rowCount: 1
+      }
+    ]);
+    const repo = new PilotIdentityRepository(db, () => 'generated_1');
+
+    const row = await repo.ensureOrg({
+      slug: 'fnf',
+      name: 'Friends & Family'
+    });
+
+    expect(row.id).toBe('org_fnf');
+    expect(db.queries[0].sql).toContain('from in_orgs');
+    expect(db.queries[1].sql).toContain('insert into in_orgs');
+    expect(db.queries[1].params).toContain('fnf');
+  });
+
+  it('creates the target user when the email does not exist', async () => {
+    const db = new SequenceSqlClient([
+      { rows: [], rowCount: 0 },
+      {
+        rows: [{ id: 'user_darryn', email: 'darryn@example.com', display_name: 'Darryn' }],
+        rowCount: 1
+      }
+    ]);
+    const repo = new PilotIdentityRepository(db, () => 'generated_2');
+
+    const row = await repo.ensureUser({
+      email: 'darryn@example.com',
+      displayName: 'Darryn'
+    });
+
+    expect(row.id).toBe('user_darryn');
+    expect(db.queries[0].sql).toContain('from in_users');
+    expect(db.queries[1].sql).toContain('insert into in_users');
+    expect(db.queries[1].params).toContain('darryn@example.com');
+  });
+
+  it('ensures membership idempotently for the target org and user', async () => {
+    const db = new MockSqlClient({
+      rows: [{ id: 'membership_1', org_id: 'org_fnf', user_id: 'user_darryn', role: 'buyer' }],
+      rowCount: 1
+    });
+    const repo = new PilotIdentityRepository(db, () => 'membership_1');
+
+    const row = await repo.ensureMembership({
+      orgId: 'org_fnf',
+      userId: 'user_darryn',
+      role: 'buyer'
+    });
+
+    expect(row.id).toBe('membership_1');
+    expect(db.queries[0].sql).toContain('insert into in_memberships');
+    expect(db.queries[0].sql).toContain('on conflict (org_id, user_id)');
+    expect(db.queries[0].params).toContain('buyer');
+  });
+
+  it('reassigns buyer keys to the target org', async () => {
+    const db = new MockSqlClient({
+      rows: [{ id: 'buyer_1' }, { id: 'buyer_2' }],
+      rowCount: 2
+    });
+    const repo = new PilotIdentityRepository(db);
+
+    const updatedIds = await repo.reassignBuyerKeysToOrg({
+      apiKeyIds: ['buyer_1', 'buyer_2'],
+      targetOrgId: 'org_fnf'
+    });
+
+    expect(updatedIds).toEqual(['buyer_1', 'buyer_2']);
+    expect(db.queries[0].sql).toContain('update in_api_keys');
+    expect(db.queries[0].sql).toContain('where id = any($1::uuid[])');
+    expect(db.queries[0].params?.[1]).toBe('org_fnf');
+  });
+
+  it('reassigns token credentials to the target org', async () => {
+    const db = new MockSqlClient({
+      rows: [{ id: 'cred_1' }],
+      rowCount: 1
+    });
+    const repo = new PilotIdentityRepository(db);
+
+    const updatedIds = await repo.reassignTokenCredentialsToOrg({
+      tokenCredentialIds: ['cred_1'],
+      targetOrgId: 'org_fnf'
+    });
+
+    expect(updatedIds).toEqual(['cred_1']);
+    expect(db.queries[0].sql).toContain('update in_token_credentials');
+    expect(db.queries[0].sql).toContain('where id = any($1::uuid[])');
+    expect(db.queries[0].params?.[1]).toBe('org_fnf');
+  });
+});

--- a/api/tests/pilotSessionService.test.ts
+++ b/api/tests/pilotSessionService.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { PilotSessionService } from '../src/services/pilot/pilotSessionService.js';
+
+describe('PilotSessionService', () => {
+  it('signs and verifies Darryn self-session tokens', () => {
+    const service = new PilotSessionService({
+      secret: 'pilot-session-secret',
+      now: () => new Date('2026-03-20T00:00:00Z'),
+      ttlSeconds: 3600
+    });
+
+    const token = service.issueSession({
+      sessionKind: 'darryn_self',
+      actorUserId: 'user_darryn',
+      actorApiKeyId: null,
+      actorOrgId: 'org_fnf',
+      effectiveOrgId: 'org_fnf',
+      effectiveOrgSlug: 'fnf',
+      effectiveOrgName: 'Friends & Family',
+      githubLogin: 'darryn',
+      userEmail: 'darryn@example.com',
+      impersonatedUserId: null
+    });
+
+    expect(service.readSession(token)).toEqual(expect.objectContaining({
+      sessionKind: 'darryn_self',
+      actorUserId: 'user_darryn',
+      effectiveOrgId: 'org_fnf',
+      githubLogin: 'darryn',
+      userEmail: 'darryn@example.com'
+    }));
+  });
+
+  it('rejects tampered session tokens', () => {
+    const service = new PilotSessionService({
+      secret: 'pilot-session-secret',
+      now: () => new Date('2026-03-20T00:00:00Z'),
+      ttlSeconds: 3600
+    });
+    const token = service.issueSession({
+      sessionKind: 'admin_impersonation',
+      actorUserId: null,
+      actorApiKeyId: 'admin_key_1',
+      actorOrgId: 'org_innies',
+      effectiveOrgId: 'org_fnf',
+      effectiveOrgSlug: 'fnf',
+      effectiveOrgName: 'Friends & Family',
+      githubLogin: null,
+      userEmail: null,
+      impersonatedUserId: 'user_darryn'
+    });
+
+    expect(service.readSession(`${token}tampered`)).toBeNull();
+  });
+
+  it('prefers bearer tokens over cookies when reading request session tokens', () => {
+    const service = new PilotSessionService({
+      secret: 'pilot-session-secret',
+      now: () => new Date('2026-03-20T00:00:00Z'),
+      ttlSeconds: 3600
+    });
+
+    expect(service.readTokenFromRequest({
+      header(name: string) {
+        if (name.toLowerCase() === 'authorization') {
+          return 'Bearer bearer-token';
+        }
+        if (name.toLowerCase() === 'cookie') {
+          return 'other=1; innies_pilot_session=cookie-token';
+        }
+        return undefined;
+      }
+    } as any)).toBe('bearer-token');
+  });
+});

--- a/api/tests/runtime.pilotCutoverService.test.ts
+++ b/api/tests/runtime.pilotCutoverService.test.ts
@@ -1,0 +1,30 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+type RuntimeModule = typeof import('../src/services/runtime.js');
+
+describe('runtime pilot cutover service', () => {
+  let runtimeModule: RuntimeModule;
+
+  beforeAll(async () => {
+    process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgres://postgres:postgres@127.0.0.1:5432/innies_test';
+    process.env.SELLER_SECRET_ENC_KEY_B64 = process.env.SELLER_SECRET_ENC_KEY_B64 || Buffer.alloc(32, 7).toString('base64');
+    runtimeModule = await import('../src/services/runtime.js');
+  });
+
+  it('fails closed when reserve-floor migration is not configured yet', async () => {
+    const adapter = (runtimeModule.runtime.services.pilotCutovers as any).reserveFloorMigration;
+
+    await expect(adapter.migrateReserveFloors({
+      db: {},
+      fromOrgId: 'org_innies',
+      toOrgId: 'org_fnf',
+      targetUserId: 'user_darryn',
+      cutoverId: 'cut_1',
+      actorUserId: null
+    })).rejects.toMatchObject({
+      code: 'service_unavailable',
+      status: 503,
+      message: 'Pilot cutover unavailable until reserve-floor migration adapter is configured'
+    });
+  });
+});

--- a/api/tests/tokenCredentialRepository.test.ts
+++ b/api/tests/tokenCredentialRepository.test.ts
@@ -29,6 +29,12 @@ function createMissingContributionCapColumnError(column: 'five_hour_reserve_perc
   });
 }
 
+function createMissingFreezeTableError(): Error {
+  return Object.assign(new Error('relation "in_pilot_admission_freezes" does not exist'), {
+    code: '42P01'
+  });
+}
+
 describe('tokenCredentialRepository', () => {
   it('creates encrypted token credential row', async () => {
     process.env.SELLER_SECRET_ENC_KEY_B64 = Buffer.alloc(32, 7).toString('base64');
@@ -86,6 +92,38 @@ describe('tokenCredentialRepository', () => {
     expect(found?.refreshToken).toBe('refresh-live');
     expect(db.queries[0].sql).toContain("and expires_at > now()");
     expect(db.queries[0].sql).toContain('rate_limited_until is null or rate_limited_until <= now()');
+  });
+
+  it('excludes token credentials that are actively frozen for cutover admissions', async () => {
+    process.env.SELLER_SECRET_ENC_KEY_B64 = Buffer.alloc(32, 21).toString('base64');
+    const db = new SequenceSqlClient([{
+      rows: [{
+        id: 'cred_1',
+        org_id: '00000000-0000-0000-0000-000000000001',
+        provider: 'anthropic',
+        auth_scheme: 'x_api_key',
+        encrypted_access_token: encryptSecret('access-live'),
+        encrypted_refresh_token: encryptSecret('refresh-live'),
+        expires_at: '2026-03-02T00:00:00Z',
+        status: 'active',
+        rotation_version: 1,
+        created_at: '2026-03-01T00:00:00Z',
+        updated_at: '2026-03-01T00:00:00Z',
+        revoked_at: null,
+        monthly_contribution_limit_units: null,
+        monthly_contribution_used_units: 0,
+        monthly_window_start_at: '2026-03-01T00:00:00Z'
+      }],
+      rowCount: 1
+    }]);
+    const repo = new TokenCredentialRepository(db);
+
+    await repo.listActiveForRouting('00000000-0000-0000-0000-000000000001', 'anthropic');
+
+    expect(db.queries[0].sql).toContain('left join in_pilot_admission_freezes paf');
+    expect(db.queries[0].sql).toContain("paf.resource_type = 'token_credential'");
+    expect(db.queries[0].sql).toContain('paf.released_at is null');
+    expect(db.queries[0].sql).toContain('and paf.id is null');
   });
 
   it('treats canonical openai routing reads as including legacy codex credentials', async () => {
@@ -171,6 +209,53 @@ describe('tokenCredentialRepository', () => {
     expect(db.queries[0].sql).toContain('five_hour_reserve_percent');
     expect(db.queries[1].sql).toContain('0::integer as five_hour_reserve_percent');
     expect(db.queries[1].sql).toContain('0::integer as seven_day_reserve_percent');
+  });
+
+  it('falls back cleanly when the freeze table is missing from routing reads', async () => {
+    process.env.SELLER_SECRET_ENC_KEY_B64 = Buffer.alloc(32, 24).toString('base64');
+    const db = new SequenceSqlClient([
+      createMissingFreezeTableError(),
+      {
+        rows: [{
+          id: 'cred_legacy_1',
+          org_id: '00000000-0000-0000-0000-000000000001',
+          provider: 'anthropic',
+          auth_scheme: 'x_api_key',
+          encrypted_access_token: encryptSecret('access-legacy'),
+          encrypted_refresh_token: encryptSecret('refresh-legacy'),
+          expires_at: '2026-03-02T00:00:00Z',
+          status: 'active',
+          rotation_version: 1,
+          created_at: '2026-03-01T00:00:00Z',
+          updated_at: '2026-03-01T00:00:00Z',
+          revoked_at: null,
+          monthly_contribution_limit_units: null,
+          monthly_contribution_used_units: 0,
+          monthly_window_start_at: '2026-03-01T00:00:00Z',
+          five_hour_reserve_percent: 0,
+          seven_day_reserve_percent: 0,
+          debug_label: null,
+          consecutive_failure_count: 0,
+          consecutive_rate_limit_count: 0,
+          last_failed_status: null,
+          last_failed_at: null,
+          last_rate_limited_at: null,
+          maxed_at: null,
+          rate_limited_until: null,
+          next_probe_at: null,
+          last_probe_at: null
+        }],
+        rowCount: 1
+      }
+    ]);
+    const repo = new TokenCredentialRepository(db);
+
+    const [found] = await repo.listActiveForRouting('00000000-0000-0000-0000-000000000001', 'anthropic');
+
+    expect(found?.accessToken).toBe('access-legacy');
+    expect(db.queries).toHaveLength(2);
+    expect(db.queries[0].sql).toContain('in_pilot_admission_freezes');
+    expect(db.queries[1].sql).not.toContain('in_pilot_admission_freezes');
   });
 
   it('rotates active credential with deterministic status updates', async () => {

--- a/api/tests/tokenCredentialService.test.ts
+++ b/api/tests/tokenCredentialService.test.ts
@@ -219,7 +219,7 @@ describe('tokenCredentialService', () => {
         provider: 'anthropic',
         debugLabel: 'main-1',
         status: id === 'cred_pause' ? 'active' : 'paused',
-        expiresAt: new Date('2026-03-20T00:00:00Z'),
+        expiresAt: new Date('2026-04-20T00:00:00Z'),
       })),
       pause: vi.fn(async () => true),
       unpause: vi.fn(async () => true),
@@ -271,7 +271,7 @@ describe('tokenCredentialService', () => {
             provider: 'anthropic',
             debugLabel: 'main-1',
             status: 'maxed',
-            expiresAt: new Date('2026-03-20T00:00:00Z'),
+            expiresAt: new Date('2026-04-20T00:00:00Z'),
           };
         }
         return {

--- a/docs/migrations/018_darryn_cutover_access.sql
+++ b/docs/migrations/018_darryn_cutover_access.sql
@@ -1,0 +1,27 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS in_pilot_admission_freezes (
+  id uuid PRIMARY KEY,
+  resource_type text NOT NULL CHECK (resource_type IN ('buyer_key', 'token_credential')),
+  resource_id uuid NOT NULL,
+  operation_kind text NOT NULL CHECK (operation_kind IN ('cutover', 'rollback')),
+  source_org_id uuid REFERENCES in_orgs(id) ON DELETE SET NULL,
+  target_org_id uuid REFERENCES in_orgs(id) ON DELETE SET NULL,
+  actor_user_id uuid REFERENCES in_users(id) ON DELETE SET NULL,
+  released_at timestamptz,
+  release_reason text,
+  released_by_user_id uuid REFERENCES in_users(id) ON DELETE SET NULL,
+  last_error text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_in_pilot_admission_freezes_active_resource
+  ON in_pilot_admission_freezes (resource_type, resource_id)
+  WHERE released_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_in_pilot_admission_freezes_active_lookup
+  ON in_pilot_admission_freezes (resource_type, resource_id, created_at DESC)
+  WHERE released_at IS NULL;
+
+COMMIT;

--- a/docs/migrations/018_darryn_cutover_access_no_extensions.sql
+++ b/docs/migrations/018_darryn_cutover_access_no_extensions.sql
@@ -1,0 +1,27 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS in_pilot_admission_freezes (
+  id uuid PRIMARY KEY,
+  resource_type text NOT NULL CHECK (resource_type IN ('buyer_key', 'token_credential')),
+  resource_id uuid NOT NULL,
+  operation_kind text NOT NULL CHECK (operation_kind IN ('cutover', 'rollback')),
+  source_org_id uuid REFERENCES in_orgs(id) ON DELETE SET NULL,
+  target_org_id uuid REFERENCES in_orgs(id) ON DELETE SET NULL,
+  actor_user_id uuid REFERENCES in_users(id) ON DELETE SET NULL,
+  released_at timestamptz,
+  release_reason text,
+  released_by_user_id uuid REFERENCES in_users(id) ON DELETE SET NULL,
+  last_error text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_in_pilot_admission_freezes_active_resource
+  ON in_pilot_admission_freezes (resource_type, resource_id)
+  WHERE released_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_in_pilot_admission_freezes_active_lookup
+  ON in_pilot_admission_freezes (resource_type, resource_id, created_at DESC)
+  WHERE released_at IS NULL;
+
+COMMIT;

--- a/docs/ops/RUNBOOK.md
+++ b/docs/ops/RUNBOOK.md
@@ -224,3 +224,87 @@ curl -s -H "Authorization: Bearer $ADMIN_TOKEN" \
 ```
 
 You should see a `paused` event for the token you just paused. If `probe_failed` events continue on other tokens, investigate those too.
+
+---
+
+## 4. Darryn Pilot Cutover / Rollback
+
+Goal: move Darryn between `innies` and `fnf` without admitting new traffic during the ownership swap, and recover cleanly if the cutover fails before commit.
+
+### Preconditions
+
+- `PILOT_GITHUB_ALLOWLIST_LOGINS` and / or `PILOT_GITHUB_ALLOWLIST_EMAILS` include Darryn.
+- The routing reserve-floor migration adapter is configured. If it is not, `/v1/admin/pilot/cutover` fails closed and records freeze errors instead of committing the cutover.
+- The buyer keys and token credentials you plan to move are identified up front.
+
+### Step 1 — Start the cutover
+
+```bash
+curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$BASE_URL/v1/admin/pilot/cutover" \
+  -d '{
+    "sourceOrgId": "org_innies",
+    "targetOrgSlug": "fnf",
+    "targetOrgName": "Friends & Family",
+    "targetUserEmail": "darryn@example.com",
+    "targetUserDisplayName": "Darryn",
+    "targetGithubLogin": "darryn",
+    "buyerKeyIds": ["BUYER_KEY_ID"],
+    "tokenCredentialIds": ["TOKEN_CREDENTIAL_ID"]
+  }'
+```
+
+Expected result:
+- `200`
+- `cutoverId`
+- `targetOrgId`
+- `targetUserId`
+
+What happens:
+- active buyer-key and token-credential freezes are written first
+- base-table `org_id` ownership and F&F ownership mappings move inside one transaction
+- reserve-floor migration runs before the cutover transaction commits
+
+### Step 2 — Verify admissions are no longer frozen
+
+Successful cutover releases the active freezes automatically. New buyer-key auth should stop returning `423 cutover_in_progress`, and token routing should stop excluding the moved credentials for freeze reasons.
+
+### Step 3 — If cutover fails before commit
+
+Symptoms:
+- the API returns an error instead of `200`
+- buyer-key auth stays fail-closed with `423 cutover_in_progress`
+- token routing keeps excluding the migrating credentials
+
+Operator action:
+- inspect the error returned by `/v1/admin/pilot/cutover`
+- fix the underlying issue, most commonly the missing reserve-floor adapter
+- re-run the same cutover request once the dependency is healthy
+
+Cutover-access records the failure message on the active freeze rows; it does not silently reopen admissions after a failed pre-commit cutover.
+
+### Step 4 — Roll back to `innies`
+
+```bash
+curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  "$BASE_URL/v1/admin/pilot/rollback" \
+  -d '{
+    "sourceCutoverId": "CUTOVER_ID",
+    "targetOrgId": "org_innies",
+    "buyerKeyIds": ["BUYER_KEY_ID"],
+    "tokenCredentialIds": ["TOKEN_CREDENTIAL_ID"]
+  }'
+```
+
+Expected result:
+- `200`
+- `rollbackId`
+
+What happens:
+- the same admission surfaces freeze first
+- buyer-key and token-credential base ownership moves back to the reverted target org
+- F&F ownership rows are updated to match the reverted state
+- the rollback marker is written
+- the active freezes are released only after the rollback commits

--- a/docs/ops/RUNBOOK.md
+++ b/docs/ops/RUNBOOK.md
@@ -249,7 +249,6 @@ curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
     "targetOrgName": "Friends & Family",
     "targetUserEmail": "darryn@example.com",
     "targetUserDisplayName": "Darryn",
-    "targetGithubLogin": "darryn",
     "buyerKeyIds": ["BUYER_KEY_ID"],
     "tokenCredentialIds": ["TOKEN_CREDENTIAL_ID"]
   }'

--- a/docs/superpowers/plans/2026-03-20-darryn-phase2-cutover-access-implementation.md
+++ b/docs/superpowers/plans/2026-03-20-darryn-phase2-cutover-access-implementation.md
@@ -1,0 +1,325 @@
+# Darryn Phase 2 Cutover And Access Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the Darryn-specific cutover and access backend seam so `fnf` can be created, Darryn can authenticate via GitHub, admins can impersonate his pilot context, and buyer-key / token-credential ownership can move to `fnf` without transient dual-home admissions.
+
+**Architecture:** Keep base-table `org_id` ownership authoritative after cutover so existing buyer keys and token credentials resolve to `fnf` without reconnects. Add one explicit admission-freeze layer for in-flight cutover/rollback windows, plus one signed pilot-session contract for Darryn GitHub auth and admin impersonation. Cutover orchestration owns the freeze lifecycle, ownership-table writes, base-table reassignments, and cutover/rollback record creation, but it only completes cutover after a reserve-floor migration adapter reports success.
+
+**Tech Stack:** TypeScript, Express, Postgres SQL migrations, Vitest, signed HMAC session tokens, GitHub OAuth HTTP calls
+
+---
+
+## Contract
+
+### Auth / session APIs
+
+- `GET /v1/pilot/session`
+  - Auth: signed pilot session token from `Authorization: Bearer <token>` or `innies_pilot_session` cookie
+  - Response: `200` with `sessionKind` in `darryn_self | admin_self | admin_impersonation`, actor metadata, effective org context, and impersonation metadata when present
+- `GET /v1/pilot/auth/github/start`
+  - Query: optional `returnTo`
+  - Response: `302` redirect to GitHub OAuth authorize URL with signed state
+- `GET /v1/pilot/auth/github/callback`
+  - Query: `code`, `state`
+  - Behavior: exchange code, fetch GitHub user, enforce allowlist, ensure Darryn user + `fnf` membership exist, mint pilot session token, set `innies_pilot_session`, redirect to `returnTo`
+- `POST /v1/pilot/session/logout`
+  - Behavior: clear `innies_pilot_session`
+- `POST /v1/admin/pilot/session`
+  - Auth: existing admin API key
+  - Body: `{ mode: 'self' }` or `{ mode: 'impersonation', targetUserId: string, targetOrgId?: string }`
+  - Response: `200` with pilot session token and the same session payload returned by `GET /v1/pilot/session`
+
+### Cutover / rollback APIs
+
+- `POST /v1/admin/pilot/cutover`
+  - Auth: existing admin API key
+  - Body:
+    - `sourceOrgId`
+    - `targetOrgSlug`
+    - `targetOrgName`
+    - `targetUserEmail`
+    - `targetUserDisplayName`
+    - `targetGithubLogin`
+    - `buyerKeyIds[]`
+    - `tokenCredentialIds[]`
+    - optional `effectiveAt`
+  - Behavior:
+    - create / find `fnf` org
+    - create / find Darryn user
+    - ensure Darryn membership in `fnf`
+    - create visible admission freezes for the migrating buyer keys and token credentials
+    - inside one DB transaction: update base-table `org_id` ownership, upsert F&F ownership rows, call reserve-floor migration adapter, create committed cutover row
+    - release freezes after success; retain failure details if the cutover aborts before commit
+- `POST /v1/admin/pilot/rollback`
+  - Auth: existing admin API key
+  - Body:
+    - optional `sourceCutoverId`
+    - `targetOrgId`
+    - `buyerKeyIds[]`
+    - `tokenCredentialIds[]`
+    - optional `effectiveAt`
+  - Behavior:
+    - freeze the same admission surfaces
+    - move buyer keys and credentials back to the reverted target org
+    - refresh F&F ownership rows to match the reverted state
+    - create rollback row
+    - release freezes after success
+
+### Runtime seams
+
+- Buyer-key admissions fail closed when an active buyer-key migration freeze exists.
+- Token-credential sold admissions fail closed when an active token-credential migration freeze exists.
+- Reserve-floor migration is an injected adapter:
+  - `migrateReserveFloors({ fromOrgId, toOrgId, targetUserId, cutoverId, actorUserId })`
+  - runtime default may be a not-configured adapter until routing lands
+
+## Chunk 1: Freeze And Ownership Foundations
+
+### Task 1: Add the cutover-access storage contract
+
+**Files:**
+- Create: `docs/migrations/018_darryn_cutover_access.sql`
+- Create: `docs/migrations/018_darryn_cutover_access_no_extensions.sql`
+- Test: `api/tests/darrynCutoverAccessMigrations.test.ts`
+
+- [ ] **Step 1: Write the failing migration test**
+
+Cover:
+- active admission-freeze storage for `buyer_key` and `token_credential`
+- indexes for active-freeze reads
+- any support columns needed for failure metadata / release metadata
+
+- [ ] **Step 2: Run the focused migration test and verify RED**
+
+Run: `npm test -- --run tests/darrynCutoverAccessMigrations.test.ts`
+Expected: FAIL because migration files do not exist yet
+
+- [ ] **Step 3: Add the minimal migration pair**
+
+Constraints:
+- no routing reserve-floor storage here
+- no wallet / earnings schema here
+- only cutover-access-local operational storage
+
+- [ ] **Step 4: Re-run the focused migration test and verify GREEN**
+
+Run: `npm test -- --run tests/darrynCutoverAccessMigrations.test.ts`
+Expected: PASS
+
+### Task 2: Add repository seams for org/user/membership bootstrap and admission freezes
+
+**Files:**
+- Create: `api/src/repos/pilotIdentityRepository.ts`
+- Create: `api/src/repos/pilotAdmissionFreezeRepository.ts`
+- Modify: `api/src/repos/tableNames.ts`
+- Test: `api/tests/pilotIdentityRepository.test.ts`
+- Test: `api/tests/pilotAdmissionFreezeRepository.test.ts`
+
+- [ ] **Step 1: Write the failing repository tests**
+
+Cover:
+- create/find org by slug
+- create/find user by email
+- ensure membership idempotently
+- reassign API key org ids
+- reassign token credential org ids
+- activate and release admission freezes
+- read active buyer-key freeze
+- exclude released freezes from reads
+
+- [ ] **Step 2: Run the focused repository tests and verify RED**
+
+Run: `npm test -- --run tests/pilotIdentityRepository.test.ts tests/pilotAdmissionFreezeRepository.test.ts`
+Expected: FAIL because the repos do not exist yet
+
+- [ ] **Step 3: Implement the minimal repositories**
+
+Requirements:
+- use base tables for authoritative `org_id` reassignment
+- keep F&F ownership tables as explicit mappings, not substitutes for base-table ownership
+- keep freeze reads small and deterministic
+
+- [ ] **Step 4: Re-run the focused repository tests and verify GREEN**
+
+Run: `npm test -- --run tests/pilotIdentityRepository.test.ts tests/pilotAdmissionFreezeRepository.test.ts`
+Expected: PASS
+
+## Chunk 2: Cutover Service And Freeze Enforcement
+
+### Task 3: Add the cutover / rollback orchestration service
+
+**Files:**
+- Create: `api/src/services/pilot/pilotCutoverService.ts`
+- Modify: `api/src/repos/fnfOwnershipRepository.ts`
+- Modify: `api/src/repos/pilotCutoverRepository.ts`
+- Modify: `api/src/services/runtime.ts`
+- Test: `api/tests/pilotCutoverService.test.ts`
+
+- [ ] **Step 1: Write the failing service tests**
+
+Cover:
+- cutover success path creates org/user/membership, writes base-table ownership changes, upserts F&F ownership rows, calls reserve-floor migration adapter, creates committed cutover row, and releases freezes
+- cutover failure before reserve-floor migration success leaves no committed cutover row and keeps admissions fail-closed
+- rollback success reassigns ownership back, creates rollback row, and releases freezes
+- actor user id is optional for admin API-key initiated operations
+
+- [ ] **Step 2: Run the focused service test and verify RED**
+
+Run: `npm test -- --run tests/pilotCutoverService.test.ts`
+Expected: FAIL because the service does not exist yet
+
+- [ ] **Step 3: Implement the minimal orchestration service**
+
+Requirements:
+- visible freeze rows are committed before migration work starts
+- base-table ownership changes and cutover / rollback rows are inside one DB transaction
+- cutover row is inserted only after `migrateReserveFloors(...)` succeeds
+- no wallet, routing policy, or reserve-floor storage logic in this service
+
+- [ ] **Step 4: Re-run the focused service test and verify GREEN**
+
+Run: `npm test -- --run tests/pilotCutoverService.test.ts`
+Expected: PASS
+
+### Task 4: Enforce fail-closed freezes in auth and token routing
+
+**Files:**
+- Modify: `api/src/middleware/auth.ts`
+- Modify: `api/src/repos/apiKeyRepository.ts`
+- Modify: `api/src/repos/tokenCredentialRepository.ts`
+- Modify: `api/src/services/runtime.ts`
+- Test: `api/tests/auth.middleware.test.ts`
+- Test: `api/tests/tokenCredentialRepository.test.ts`
+
+- [ ] **Step 1: Write the failing freeze-enforcement tests**
+
+Cover:
+- buyer-key auth rejects requests when the key has an active migration freeze
+- token credential routing excludes actively frozen credentials
+- released freezes no longer block admissions
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run: `npm test -- --run tests/auth.middleware.test.ts tests/tokenCredentialRepository.test.ts`
+Expected: FAIL on the new freeze cases
+
+- [ ] **Step 3: Implement the minimal enforcement**
+
+Requirements:
+- buyer-key failures use an explicit fail-closed application error
+- token-credential filtering does not mutate existing provider-lane or contribution-cap logic
+
+- [ ] **Step 4: Re-run the focused tests and verify GREEN**
+
+Run: `npm test -- --run tests/auth.middleware.test.ts tests/tokenCredentialRepository.test.ts`
+Expected: PASS
+
+## Chunk 3: Pilot Session And Route Wiring
+
+### Task 5: Add signed pilot-session and GitHub auth services
+
+**Files:**
+- Create: `api/src/services/pilot/pilotSessionService.ts`
+- Create: `api/src/services/pilot/pilotGithubAuthService.ts`
+- Modify: `api/src/types/express.d.ts`
+- Test: `api/tests/pilotSessionService.test.ts`
+- Test: `api/tests/pilotGithubAuthService.test.ts`
+
+- [ ] **Step 1: Write the failing auth/session tests**
+
+Cover:
+- session token sign/verify for `darryn_self`, `admin_self`, and `admin_impersonation`
+- cookie or bearer extraction for session reads
+- GitHub callback allowlists by login / verified email
+- successful callback ensures Darryn membership in `fnf`
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run: `npm test -- --run tests/pilotSessionService.test.ts tests/pilotGithubAuthService.test.ts`
+Expected: FAIL because the services do not exist yet
+
+- [ ] **Step 3: Implement the minimal services**
+
+Requirements:
+- keep the session payload small and explicit
+- use one signing secret
+- do not add server-side session storage unless tests force it
+
+- [ ] **Step 4: Re-run the focused tests and verify GREEN**
+
+Run: `npm test -- --run tests/pilotSessionService.test.ts tests/pilotGithubAuthService.test.ts`
+Expected: PASS
+
+### Task 6: Wire the pilot and admin routes plus runbook docs
+
+**Files:**
+- Create: `api/src/routes/pilot.ts`
+- Modify: `api/src/routes/admin.ts`
+- Modify: `api/src/server.ts`
+- Modify: `docs/ops/RUNBOOK.md`
+- Test: `api/tests/pilot.route.test.ts`
+- Test: `api/tests/admin.pilot.route.test.ts`
+
+- [ ] **Step 1: Write the failing route tests**
+
+Cover:
+- GitHub auth start / callback / logout
+- `GET /v1/pilot/session`
+- `POST /v1/admin/pilot/session`
+- `POST /v1/admin/pilot/cutover`
+- `POST /v1/admin/pilot/rollback`
+- route-level validation and auth failures
+
+- [ ] **Step 2: Run the focused route tests and verify RED**
+
+Run: `npm test -- --run tests/pilot.route.test.ts tests/admin.pilot.route.test.ts`
+Expected: FAIL because the routes do not exist yet
+
+- [ ] **Step 3: Implement the minimal route wiring and runbook updates**
+
+Runbook must cover:
+- safe cutover sequence
+- reserve-floor adapter dependency
+- rollback sequence
+- freeze cleanup when a cutover attempt aborts
+
+- [ ] **Step 4: Re-run the focused route tests and verify GREEN**
+
+Run: `npm test -- --run tests/pilot.route.test.ts tests/admin.pilot.route.test.ts`
+Expected: PASS
+
+## Chunk 4: Verification And Integration
+
+### Task 7: Run verification and capture the remaining dependency seam cleanly
+
+**Files:**
+- Read: `docs/planning/PHASE2_DARRYN_PILOT_SCOPE.md`
+- Read: `docs/planning/PHASE2_IMPLEMENTATION_SCOPE.md`
+- Read: `docs/superpowers/specs/2026-03-19-darryn-pilot-workspace-split-design.md`
+- Read: `docs/superpowers/plans/2026-03-19-darryn-pilot-workspace-launch.md`
+
+- [ ] **Step 1: Run the targeted cutover/access suite**
+
+Run: `npm test -- --run tests/darrynCutoverAccessMigrations.test.ts tests/pilotIdentityRepository.test.ts tests/pilotAdmissionFreezeRepository.test.ts tests/pilotCutoverService.test.ts tests/auth.middleware.test.ts tests/pilotSessionService.test.ts tests/pilotGithubAuthService.test.ts tests/pilot.route.test.ts tests/admin.pilot.route.test.ts`
+Expected: PASS
+
+- [ ] **Step 2: Run the full backend suite**
+
+Run: `npm test`
+Expected: PASS
+
+- [ ] **Step 3: Build the backend**
+
+Run: `npm run build`
+Expected: PASS
+
+- [ ] **Step 4: Verify the requirements checklist**
+
+Confirm:
+- base-table buyer-key and token-credential ownership can move to `fnf`
+- active migration windows fail closed
+- committed cutover and rollback rows are created explicitly
+- Darryn GitHub auth and admin impersonation session seams exist
+- reserve-floor migration is an explicit dependency seam, not hidden routing logic in this branch
+

--- a/docs/superpowers/plans/2026-03-20-darryn-phase2-cutover-access-implementation.md
+++ b/docs/superpowers/plans/2026-03-20-darryn-phase2-cutover-access-implementation.md
@@ -40,7 +40,6 @@
     - `targetOrgName`
     - `targetUserEmail`
     - `targetUserDisplayName`
-    - `targetGithubLogin`
     - `buyerKeyIds[]`
     - `tokenCredentialIds[]`
     - optional `effectiveAt`
@@ -322,4 +321,3 @@ Confirm:
 - committed cutover and rollback rows are created explicitly
 - Darryn GitHub auth and admin impersonation session seams exist
 - reserve-floor migration is an explicit dependency seam, not hidden routing logic in this branch
-


### PR DESCRIPTION
## Summary
- add the Darryn cutover/access backend seam: pilot session auth, GitHub OAuth allowlist flow, admin impersonation, cutover/rollback orchestration, admission freezes, and the migration/runbook updates
- make buyer-key auth and sold token-credential routing fail closed during cutover windows, with rollout-safe fallbacks before migration 018 exists
- keep the reserve-floor handshake explicit: cutover now passes the transaction seam through and returns a clear 503 until the routing reserve-floor adapter is wired

## Test Plan
- npm test
- npm run build