### PR TITLE
feat: add darryn routing metering

### DIFF
--- a/api/src/repos/rateCardRepository.ts
+++ b/api/src/repos/rateCardRepository.ts
@@ -1,0 +1,259 @@
+import type { SqlClient, SqlValue, TransactionContext } from './sqlClient.js';
+import { type IdFactory, uuidV4 } from './idFactory.js';
+import { TABLES } from './tableNames.js';
+import type { RoutingMode } from '../types/phase2Contracts.js';
+
+export type RateCardVersionRow = {
+  id: string;
+  version_key: string;
+  effective_at: string;
+  created_at: string;
+};
+
+export type RateCardLineItemRow = {
+  id: string;
+  rate_card_version_id: string;
+  provider: string;
+  model_pattern: string;
+  routing_mode: RoutingMode;
+  buyer_debit_minor_per_unit: number;
+  contributor_earnings_minor_per_unit: number;
+  currency: string;
+  created_at: string;
+};
+
+export type AppliedRateCard = {
+  rateCardVersionId: string;
+  versionKey: string;
+  provider: string;
+  modelPattern: string;
+  routingMode: RoutingMode;
+  buyerDebitMinorPerUnit: number;
+  contributorEarningsMinorPerUnit: number;
+  currency: string;
+};
+
+export class RateCardRepository {
+  constructor(
+    private readonly db: SqlClient,
+    private readonly createId: IdFactory = uuidV4
+  ) {}
+
+  async createVersion(input: {
+    versionKey: string;
+    effectiveAt: Date;
+  }): Promise<RateCardVersionRow> {
+    return this.insertVersion(this.db, input);
+  }
+
+  async addLineItem(input: {
+    rateCardVersionId: string;
+    provider: string;
+    modelPattern: string;
+    routingMode: RoutingMode;
+    buyerDebitMinorPerUnit: number;
+    contributorEarningsMinorPerUnit: number;
+    currency?: string;
+  }): Promise<RateCardLineItemRow> {
+    return this.insertLineItem(this.db, input);
+  }
+
+  async createVersionWithLineItems(input: {
+    versionKey: string;
+    effectiveAt: Date;
+    lineItems: Array<{
+      provider: string;
+      modelPattern: string;
+      routingMode: RoutingMode;
+      buyerDebitMinorPerUnit: number;
+      contributorEarningsMinorPerUnit: number;
+      currency?: string;
+    }>;
+  }): Promise<{
+    version: RateCardVersionRow;
+    lineItems: RateCardLineItemRow[];
+  }> {
+    return this.db.transaction(async (tx) => {
+      const version = await this.insertVersion(tx, input);
+      const lineItems: RateCardLineItemRow[] = [];
+      for (const lineItem of input.lineItems) {
+        lineItems.push(await this.insertLineItem(tx, {
+          rateCardVersionId: version.id,
+          ...lineItem
+        }));
+      }
+      return {
+        version,
+        lineItems
+      };
+    });
+  }
+
+  async getActiveVersion(at: Date = new Date()): Promise<RateCardVersionRow | null> {
+    const sql = `
+      select *
+      from ${TABLES.rateCardVersions}
+      where effective_at <= $1
+      order by effective_at desc, created_at desc
+      limit 1
+    `;
+    const result = await this.db.query<RateCardVersionRow>(sql, [at]);
+    return result.rowCount === 1 ? result.rows[0] : null;
+  }
+
+  async listVersions(limit = 20): Promise<RateCardVersionRow[]> {
+    const sql = `
+      select *
+      from ${TABLES.rateCardVersions}
+      order by effective_at desc, created_at desc
+      limit $1
+    `;
+    const result = await this.db.query<RateCardVersionRow>(sql, [Math.max(1, Math.min(100, Math.floor(limit)))]);
+    return result.rows;
+  }
+
+  async listLineItems(rateCardVersionId: string): Promise<RateCardLineItemRow[]> {
+    const sql = `
+      select *
+      from ${TABLES.rateCardLineItems}
+      where rate_card_version_id = $1
+      order by provider asc, routing_mode asc, model_pattern asc
+    `;
+    const result = await this.db.query<RateCardLineItemRow>(sql, [rateCardVersionId]);
+    return result.rows;
+  }
+
+  async resolveAppliedRate(input: {
+    provider: string;
+    model: string;
+    routingMode: RoutingMode;
+    at?: Date;
+  }): Promise<AppliedRateCard | null> {
+    const sql = `
+      select
+        v.id as rate_card_version_id,
+        v.version_key,
+        i.provider,
+        i.model_pattern,
+        i.routing_mode,
+        i.buyer_debit_minor_per_unit,
+        i.contributor_earnings_minor_per_unit,
+        i.currency
+      from ${TABLES.rateCardVersions} v
+      join ${TABLES.rateCardLineItems} i
+        on i.rate_card_version_id = v.id
+      where v.effective_at <= $1
+        and i.provider = $2
+        and i.routing_mode = $3
+        and (i.model_pattern = $4 or i.model_pattern = '*')
+      order by
+        v.effective_at desc,
+        case when i.model_pattern = $4 then 0 else 1 end asc,
+        i.created_at desc
+      limit 1
+    `;
+    const provider = input.provider.trim().toLowerCase();
+    const result = await this.db.query<{
+      rate_card_version_id: string;
+      version_key: string;
+      provider: string;
+      model_pattern: string;
+      routing_mode: RoutingMode;
+      buyer_debit_minor_per_unit: number;
+      contributor_earnings_minor_per_unit: number;
+      currency: string;
+    }>(sql, [input.at ?? new Date(), provider, input.routingMode, input.model]);
+    if (result.rowCount !== 1) return null;
+    const row = result.rows[0];
+    return {
+      rateCardVersionId: row.rate_card_version_id,
+      versionKey: row.version_key,
+      provider: row.provider,
+      modelPattern: row.model_pattern,
+      routingMode: row.routing_mode,
+      buyerDebitMinorPerUnit: Number(row.buyer_debit_minor_per_unit),
+      contributorEarningsMinorPerUnit: Number(row.contributor_earnings_minor_per_unit),
+      currency: row.currency
+    };
+  }
+
+  private async expectOneInContext<T>(db: TransactionContext, sql: string, params: SqlValue[]): Promise<T> {
+    const result = await db.query<T>(sql, params);
+    if (result.rowCount !== 1) {
+      throw new Error('expected one rate card row');
+    }
+    return result.rows[0];
+  }
+
+  private async insertVersion(
+    db: TransactionContext,
+    input: {
+      versionKey: string;
+      effectiveAt: Date;
+    }
+  ): Promise<RateCardVersionRow> {
+    const sql = `
+      insert into ${TABLES.rateCardVersions} (
+        id,
+        version_key,
+        effective_at,
+        created_at
+      ) values (
+        $1,$2,$3,now()
+      )
+      returning *
+    `;
+
+    return this.expectOneInContext<RateCardVersionRow>(db, sql, [
+      this.createId(),
+      input.versionKey,
+      input.effectiveAt
+    ]);
+  }
+
+  private async insertLineItem(
+    db: TransactionContext,
+    input: {
+      rateCardVersionId: string;
+      provider: string;
+      modelPattern: string;
+      routingMode: RoutingMode;
+      buyerDebitMinorPerUnit: number;
+      contributorEarningsMinorPerUnit: number;
+      currency?: string;
+    }
+  ): Promise<RateCardLineItemRow> {
+    const sql = `
+      insert into ${TABLES.rateCardLineItems} (
+        id,
+        rate_card_version_id,
+        provider,
+        model_pattern,
+        routing_mode,
+        buyer_debit_minor_per_unit,
+        contributor_earnings_minor_per_unit,
+        currency,
+        created_at
+      ) values (
+        $1,$2,$3,$4,$5,$6,$7,$8,now()
+      )
+      on conflict (rate_card_version_id, provider, model_pattern, routing_mode)
+      do update set
+        buyer_debit_minor_per_unit = excluded.buyer_debit_minor_per_unit,
+        contributor_earnings_minor_per_unit = excluded.contributor_earnings_minor_per_unit,
+        currency = excluded.currency
+      returning *
+    `;
+
+    return this.expectOneInContext<RateCardLineItemRow>(db, sql, [
+      this.createId(),
+      input.rateCardVersionId,
+      input.provider.trim().toLowerCase(),
+      input.modelPattern.trim(),
+      input.routingMode,
+      input.buyerDebitMinorPerUnit,
+      input.contributorEarningsMinorPerUnit,
+      input.currency ?? 'USD'
+    ]);
+  }
+}

--- a/api/src/repos/routingAttributionRepository.ts
+++ b/api/src/repos/routingAttributionRepository.ts
@@ -1,0 +1,261 @@
+import type { SqlClient, SqlValue } from './sqlClient.js';
+import { TABLES } from './tableNames.js';
+
+export type RequestHistoryCursor = {
+  createdAt: string;
+  requestId: string;
+  attemptNo: number;
+};
+
+export type RequestHistoryRow = {
+  request_id: string;
+  attempt_no: number;
+  session_id: string | null;
+  admission_org_id: string;
+  admission_cutover_id: string | null;
+  admission_routing_mode: string;
+  consumer_org_id: string;
+  buyer_key_id: string | null;
+  serving_org_id: string;
+  provider_account_id: string | null;
+  token_credential_id: string | null;
+  capacity_owner_user_id: string | null;
+  provider: string;
+  model: string;
+  rate_card_version_id: string;
+  input_tokens: number;
+  output_tokens: number;
+  usage_units: number;
+  buyer_debit_minor: number;
+  contributor_earnings_minor: number;
+  currency: string;
+  metadata: Record<string, unknown> | null;
+  created_at: string;
+  prompt_preview: string | null;
+  response_preview: string | null;
+  route_decision: Record<string, unknown> | null;
+  projector_states: Array<{
+    projector: string;
+    state: string;
+    retryCount: number;
+    lastErrorCode: string | null;
+    lastErrorMessage: string | null;
+  }> | null;
+};
+
+export type FinanciallyUnfinalizedRequestRow = {
+  request_id: string;
+  attempt_no: number;
+  org_id: string;
+  provider: string;
+  model: string;
+  upstream_status: number | null;
+  created_at: string;
+  route_decision: Record<string, unknown> | null;
+};
+
+export class RoutingAttributionRepository {
+  constructor(private readonly db: SqlClient) {}
+
+  async listOrgRequestHistory(input: {
+    orgId: string;
+    limit: number;
+    cursor?: RequestHistoryCursor | null;
+    historyScope?: 'post_cutover' | 'all';
+  }): Promise<RequestHistoryRow[]> {
+    return this.listHistory({
+      orgId: input.orgId,
+      limit: input.limit,
+      cursor: input.cursor,
+      historyScope: input.historyScope ?? 'post_cutover',
+      admin: false
+    });
+  }
+
+  async listAdminRequestHistory(input: {
+    consumerOrgId?: string;
+    limit: number;
+    cursor?: RequestHistoryCursor | null;
+    historyScope?: 'post_cutover' | 'all';
+  }): Promise<RequestHistoryRow[]> {
+    return this.listHistory({
+      orgId: input.consumerOrgId ?? null,
+      limit: input.limit,
+      cursor: input.cursor,
+      historyScope: input.historyScope ?? 'all',
+      admin: true
+    });
+  }
+
+  async getRequestExplanation(requestId: string): Promise<RequestHistoryRow | null> {
+    const params: SqlValue[] = [requestId];
+    const result = await this.db.query<RequestHistoryRow>(`${historySelectSql()}
+      where cm.finalization_kind = 'served_request'
+        and cm.request_id = $1
+      order by cm.attempt_no desc
+      limit 1
+    `, params);
+    return result.rowCount === 1 ? result.rows[0] : null;
+  }
+
+  async listFinanciallyUnfinalizedRequests(limit = 50): Promise<FinanciallyUnfinalizedRequestRow[]> {
+    const sql = `
+      select
+        re.request_id,
+        re.attempt_no,
+        re.org_id,
+        re.provider,
+        re.model,
+        re.upstream_status,
+        re.created_at,
+        re.route_decision
+      from ${TABLES.routingEvents} re
+      left join ${TABLES.canonicalMeteringEvents} cm
+        on cm.request_id = re.request_id
+       and cm.attempt_no = re.attempt_no
+       and cm.finalization_kind = 'served_request'
+      where re.upstream_status is not null
+        and re.upstream_status >= 200
+        and re.upstream_status < 300
+        and cm.id is null
+      order by re.created_at desc
+      limit $1
+    `;
+    const result = await this.db.query<FinanciallyUnfinalizedRequestRow>(sql, [Math.max(1, Math.min(200, Math.floor(limit)))]);
+    return result.rows.map((row) => ({
+      ...row,
+      route_decision: normalizeJson(row.route_decision)
+    }));
+  }
+
+  private async listHistory(input: {
+    orgId: string | null;
+    limit: number;
+    cursor?: RequestHistoryCursor | null;
+    historyScope: 'post_cutover' | 'all';
+    admin: boolean;
+  }): Promise<RequestHistoryRow[]> {
+    const params: SqlValue[] = [];
+    const where: string[] = [];
+
+    if (input.orgId) {
+      params.push(input.orgId);
+      where.push(`cm.consumer_org_id = $${params.length}`);
+    }
+
+    if (input.historyScope === 'post_cutover') {
+      where.push('cm.admission_cutover_id is not null');
+    }
+
+    if (input.cursor) {
+      params.push(input.cursor.createdAt);
+      const createdAtParam = params.length;
+      params.push(input.cursor.requestId);
+      const requestIdParam = params.length;
+      params.push(input.cursor.attemptNo);
+      const attemptNoParam = params.length;
+      where.push(`(
+        cm.created_at < $${createdAtParam}
+        or (cm.created_at = $${createdAtParam} and cm.request_id < $${requestIdParam})
+        or (cm.created_at = $${createdAtParam} and cm.request_id = $${requestIdParam} and cm.attempt_no < $${attemptNoParam})
+      )`);
+    }
+
+    params.push(Math.max(1, Math.min(100, Math.floor(input.limit))));
+    const sql = `${historySelectSql()}
+      where cm.finalization_kind = 'served_request'
+      ${where.length > 0 ? `and ${where.join(' and ')}` : ''}
+      order by cm.created_at desc, cm.request_id desc, cm.attempt_no desc
+      limit $${params.length}
+    `;
+    const result = await this.db.query<RequestHistoryRow>(sql, params);
+    return result.rows.map(mapHistoryRow);
+  }
+}
+
+function historySelectSql(): string {
+  return `
+    select
+      cm.request_id,
+      cm.attempt_no,
+      cm.session_id,
+      cm.admission_org_id,
+      cm.admission_cutover_id,
+      cm.admission_routing_mode,
+      cm.consumer_org_id,
+      cm.buyer_key_id,
+      cm.serving_org_id,
+      cm.provider_account_id,
+      cm.token_credential_id,
+      cm.capacity_owner_user_id,
+      cm.provider,
+      cm.model,
+      cm.rate_card_version_id,
+      cm.input_tokens,
+      cm.output_tokens,
+      cm.usage_units,
+      cm.buyer_debit_minor,
+      cm.contributor_earnings_minor,
+      cm.currency,
+      cm.metadata,
+      cm.created_at,
+      rl.prompt_preview,
+      rl.response_preview,
+      re.route_decision,
+      (
+        select json_agg(json_build_object(
+          'projector', mps.projector,
+          'state', mps.state,
+          'retryCount', mps.retry_count,
+          'lastErrorCode', mps.last_error_code,
+          'lastErrorMessage', mps.last_error_message
+        ) order by mps.projector asc)
+        from ${TABLES.meteringProjectorStates} mps
+        where mps.metering_event_id = cm.id
+      ) as projector_states
+    from ${TABLES.canonicalMeteringEvents} cm
+    left join ${TABLES.requestLog} rl
+      on rl.org_id = cm.consumer_org_id
+     and rl.request_id = cm.request_id
+     and rl.attempt_no = cm.attempt_no
+    left join ${TABLES.routingEvents} re
+      on re.org_id = cm.consumer_org_id
+     and re.request_id = cm.request_id
+     and re.attempt_no = cm.attempt_no
+  `;
+}
+
+function mapHistoryRow(row: RequestHistoryRow): RequestHistoryRow {
+  return {
+    ...row,
+    metadata: normalizeJson(row.metadata),
+    route_decision: normalizeJson(row.route_decision),
+    projector_states: normalizeProjectorStates(row.projector_states)
+  };
+}
+
+function normalizeProjectorStates(value: unknown): RequestHistoryRow['projector_states'] {
+  if (!Array.isArray(value)) return null;
+  return value.map((entry) => {
+    const record = (entry ?? {}) as Record<string, unknown>;
+    return {
+      projector: String(record.projector ?? ''),
+      state: String(record.state ?? ''),
+      retryCount: Number(record.retryCount ?? 0),
+      lastErrorCode: record.lastErrorCode == null ? null : String(record.lastErrorCode),
+      lastErrorMessage: record.lastErrorMessage == null ? null : String(record.lastErrorMessage)
+    };
+  });
+}
+
+function normalizeJson<T>(value: unknown): T | null {
+  if (value == null) return null;
+  if (typeof value === 'string') {
+    try {
+      return JSON.parse(value) as T;
+    } catch {
+      return null;
+    }
+  }
+  return value as T;
+}

--- a/api/src/repos/tableNames.ts
+++ b/api/src/repos/tableNames.ts
@@ -10,6 +10,7 @@ export const TABLES = {
   meteringProjectorStates: 'in_metering_projector_states',
   orgs: 'in_orgs',
   pilotAdmissionFreezes: 'in_pilot_admission_freezes',
+  rateCardLineItems: 'in_rate_card_line_items',
   rateCardVersions: 'in_rate_card_versions',
   requestLog: 'in_request_log',
   rollbackRecords: 'in_rollback_records',

--- a/api/src/repos/tokenCredentialRepository.ts
+++ b/api/src/repos/tokenCredentialRepository.ts
@@ -583,7 +583,7 @@ export class TokenCredentialRepository {
         end,
         updated_at = now()
       where id = $1
-        and provider = 'anthropic'
+        and provider in ('anthropic', 'openai')
       returning
         id,
         org_id,

--- a/api/src/repos/tokenCredentialRepository.ts
+++ b/api/src/repos/tokenCredentialRepository.ts
@@ -617,6 +617,29 @@ export class TokenCredentialRepository {
     };
   }
 
+  async migrateReserveFloors(input: {
+    db?: object;
+    fromOrgId: string;
+    toOrgId: string;
+    targetUserId: string;
+    cutoverId: string;
+    actorUserId: string | null;
+  }): Promise<{ migratedCount: number }> {
+    const client = input.db && typeof input.db === 'object' && 'query' in input.db
+      ? input.db as Pick<SqlClient, 'query'>
+      : this.db;
+    const sql = `
+      select count(*)::int as count
+      from ${TABLES.tokenCredentials}
+      where org_id = $1
+        and provider in ('anthropic', 'openai', 'codex')
+    `;
+    const result = await client.query<{ count: number }>(sql, [input.toOrgId]);
+    return {
+      migratedCount: Number(result.rows[0]?.count ?? 0)
+    };
+  }
+
   async rotate(input: RotateTokenCredentialInput): Promise<{ id: string; rotationVersion: number; previousId: string | null }> {
     return this.db.transaction(async (tx) => {
       const latestSql = `

--- a/api/src/repos/tokenCredentialRepository.ts
+++ b/api/src/repos/tokenCredentialRepository.ts
@@ -583,7 +583,7 @@ export class TokenCredentialRepository {
         end,
         updated_at = now()
       where id = $1
-        and provider in ('anthropic', 'openai')
+        and provider in ('anthropic', 'openai', 'codex')
       returning
         id,
         org_id,

--- a/api/src/routes/admin.ts
+++ b/api/src/routes/admin.ts
@@ -3,6 +3,7 @@
 import { Router } from 'express';
 import { z } from 'zod';
 import { requireApiKey } from '../middleware/auth.js';
+import type { RequestHistoryCursor } from '../repos/routingAttributionRepository.js';
 import { runtime } from '../services/runtime.js';
 import {
   readClaudeContributionCapProviderExhaustionHold,
@@ -77,11 +78,25 @@ const meteringEventSchema = z.object({
   outputTokens: z.number().int().nonnegative(),
   usageUnits: z.number().int().nonnegative(),
   retailEquivalentMinor: z.number().int().nonnegative(),
-  currency: z.string().length(3).optional()
+  currency: z.string().length(3).optional(),
+  sessionId: z.string().min(1).optional(),
+  admissionOrgId: z.string().uuid().optional(),
+  admissionCutoverId: z.string().uuid().nullable().optional(),
+  admissionRoutingMode: z.enum(['self-free', 'paid-team-capacity', 'team-overflow-on-contributor-capacity']).optional(),
+  consumerUserId: z.string().uuid().nullable().optional(),
+  teamConsumerId: z.string().min(1).nullable().optional(),
+  servingOrgId: z.string().uuid().optional(),
+  providerAccountId: z.string().min(1).nullable().optional(),
+  tokenCredentialId: z.string().uuid().nullable().optional(),
+  capacityOwnerUserId: z.string().uuid().nullable().optional(),
+  rateCardVersionId: z.string().uuid().nullable().optional(),
+  buyerDebitMinor: z.number().int().optional(),
+  contributorEarningsMinor: z.number().int().optional(),
+  metadata: z.record(z.string(), z.unknown()).optional()
 });
 
 const replayMeteringSchema = z.object({
-  action: z.enum(['usage', 'correction', 'reversal']),
+  action: z.enum(['usage', 'served_request_retry', 'correction', 'reversal']),
   sourceEventId: z.string().uuid().optional(),
   note: z.string().min(1).max(500).optional(),
   event: meteringEventSchema
@@ -179,6 +194,38 @@ const adminPilotRollbackSchema = z.object({
   effectiveAt: z.string().datetime({ offset: true }).optional()
 });
 
+const adminRequestHistoryQuerySchema = z.object({
+  consumerOrgId: z.string().uuid().optional(),
+  historyScope: z.enum(['post_cutover', 'all']).optional().default('all'),
+  limit: z.coerce.number().int().min(1).max(100).optional().default(20),
+  cursor: z.string().min(1).optional()
+});
+
+const adminUnfinalizedRequestsQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).optional().default(20)
+});
+
+const requestHistoryCursorSchema = z.object({
+  createdAt: z.string().min(1),
+  requestId: z.string().min(1),
+  attemptNo: z.number().int().min(1)
+});
+
+const rateCardLineItemSchema = z.object({
+  provider: tokenCredentialProviderSchema,
+  modelPattern: z.string().min(1),
+  routingMode: z.enum(['self-free', 'paid-team-capacity', 'team-overflow-on-contributor-capacity']),
+  buyerDebitMinorPerUnit: z.number().int(),
+  contributorEarningsMinorPerUnit: z.number().int(),
+  currency: z.string().length(3).optional()
+});
+
+const createRateCardVersionSchema = z.object({
+  versionKey: z.string().min(1).max(128),
+  effectiveAt: z.string().datetime({ offset: true }),
+  lineItems: z.array(rateCardLineItemSchema).min(1)
+});
+
 function isUniqueViolation(error: unknown): boolean {
   if (!error || typeof error !== 'object') return false;
   return (error as { code?: string }).code === '23505';
@@ -196,6 +243,20 @@ function canAccessBuyerKey(input: {
 
 function isAnthropicOauthAccessToken(provider: string, accessToken: string): boolean {
   return provider === 'anthropic' && accessToken.includes('sk-ant-oat');
+}
+
+function encodeHistoryCursor(cursor: RequestHistoryCursor): string {
+  return Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url');
+}
+
+function decodeHistoryCursor(cursor: string | undefined): RequestHistoryCursor | null {
+  if (!cursor) return null;
+  try {
+    const decoded = Buffer.from(cursor, 'base64url').toString('utf8');
+    return requestHistoryCursorSchema.parse(JSON.parse(decoded));
+  } catch {
+    throw new AppError('invalid_request', 400, 'Invalid request-history cursor');
+  }
 }
 
 function resolveTokenCredentialAuthScheme(input: {
@@ -493,7 +554,7 @@ router.post('/v1/admin/kill-switch', requireApiKey(runtime.repos.apiKeys, ['admi
   }
 });
 
-router.post('/v1/admin/replay-metering', requireApiKey(runtime.repos.apiKeys, ['admin']), async (req, res, next) => {
+async function handleAdminReplayMetering(req: any, res: any, next: (error?: unknown) => void): Promise<void> {
   try {
     const idempotencyKey = readAndValidateIdempotencyKey(req.header('idempotency-key') ?? undefined);
 
@@ -518,7 +579,7 @@ router.post('/v1/admin/replay-metering', requireApiKey(runtime.repos.apiKeys, ['
     }
 
     let saved;
-    if (parsed.action === 'usage') {
+    if (parsed.action === 'usage' || parsed.action === 'served_request_retry') {
       saved = await runtime.services.metering.recordUsage(parsed.event);
     } else if (parsed.action === 'correction') {
       saved = await runtime.services.metering.recordCorrection(parsed.sourceEventId!, parsed.event, parsed.note ?? 'manual replay correction');
@@ -549,6 +610,120 @@ router.post('/v1/admin/replay-metering', requireApiKey(runtime.repos.apiKeys, ['
       responseBody,
       responseDigest: sha256Hex(stableJson(responseBody)),
       responseRef: saved.id
+    });
+
+    res.status(200).json(responseBody);
+  } catch (error) {
+    next(error);
+  }
+}
+
+router.post('/v1/admin/replay-metering', requireApiKey(runtime.repos.apiKeys, ['admin']), handleAdminReplayMetering);
+
+router.post('/v1/admin/metering/corrections', requireApiKey(runtime.repos.apiKeys, ['admin']), handleAdminReplayMetering);
+
+router.get('/v1/admin/requests', requireApiKey(runtime.repos.apiKeys, ['admin']), async (req, res, next) => {
+  try {
+    const query = adminRequestHistoryQuerySchema.parse(req.query);
+    const cursor = decodeHistoryCursor(query.cursor);
+    const rows = await runtime.repos.routingAttribution.listAdminRequestHistory({
+      consumerOrgId: query.consumerOrgId,
+      limit: query.limit,
+      cursor,
+      historyScope: query.historyScope
+    });
+    const last = rows[rows.length - 1];
+    res.json({
+      requests: rows,
+      nextCursor: rows.length === query.limit && last ? encodeHistoryCursor({
+        createdAt: last.created_at,
+        requestId: last.request_id,
+        attemptNo: last.attempt_no
+      }) : null
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/v1/admin/requests/:requestId/explanation', requireApiKey(runtime.repos.apiKeys, ['admin']), async (req, res, next) => {
+  try {
+    const requestId = z.string().min(1).parse(req.params.requestId);
+    const explanation = await runtime.repos.routingAttribution.getRequestExplanation(requestId);
+    if (!explanation) {
+      throw new AppError('not_found', 404, 'Request explanation not found');
+    }
+    res.json({
+      ok: true,
+      request: explanation
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/v1/admin/requests/unfinalized', requireApiKey(runtime.repos.apiKeys, ['admin']), async (req, res, next) => {
+  try {
+    const query = adminUnfinalizedRequestsQuerySchema.parse(req.query);
+    const requests = await runtime.repos.routingAttribution.listFinanciallyUnfinalizedRequests(query.limit);
+    res.json({
+      requests
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/v1/admin/rate-cards', requireApiKey(runtime.repos.apiKeys, ['admin']), async (req, res, next) => {
+  try {
+    const versions = await runtime.repos.rateCards.listVersions(20);
+    res.json({
+      versions
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/v1/admin/rate-cards', requireApiKey(runtime.repos.apiKeys, ['admin']), async (req, res, next) => {
+  try {
+    const idempotencyKey = readAndValidateIdempotencyKey(req.header('idempotency-key') ?? undefined);
+    const parsed = createRateCardVersionSchema.parse(req.body);
+    const requestHash = sha256Hex(stableJson({ body: parsed, apiKeyId: req.auth?.apiKeyId }));
+    const tenantScope = req.auth?.orgId ?? `admin:${req.auth?.apiKeyId}`;
+    const idemStart = await runtime.services.idempotency.start({
+      scope: 'admin_rate_cards_create_v1',
+      tenantScope,
+      idempotencyKey,
+      requestHash
+    });
+
+    if (idemStart.replay) {
+      if (!idemStart.responseBody) {
+        throw new AppError('idempotency_replay_unavailable', 409, 'Idempotent replay not available for this request');
+      }
+      res.setHeader('x-idempotent-replay', 'true');
+      res.status(idemStart.responseCode).json(idemStart.responseBody);
+      return;
+    }
+
+    const { version, lineItems } = await runtime.repos.rateCards.createVersionWithLineItems({
+      versionKey: parsed.versionKey,
+      effectiveAt: new Date(parsed.effectiveAt),
+      lineItems: parsed.lineItems
+    });
+
+    const responseBody = {
+      ok: true,
+      version,
+      lineItems
+    };
+
+    await runtime.services.idempotency.commit(idemStart, {
+      responseCode: 200,
+      responseBody,
+      responseDigest: sha256Hex(stableJson(responseBody)),
+      responseRef: version.id
     });
 
     res.status(200).json(responseBody);
@@ -945,6 +1120,27 @@ router.patch('/v1/admin/token-credentials/:id/refresh-token', requireApiKey(runt
     });
 
     res.status(200).json(responseBody);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/v1/admin/token-credentials/:id/contribution-cap', requireApiKey(runtime.repos.apiKeys, ['admin']), async (req, res, next) => {
+  try {
+    const id = z.string().uuid().parse(req.params.id);
+    const credential = await runtime.repos.tokenCredentials.getById(id);
+    if (!credential) {
+      throw new AppError('invalid_request', 404, 'Token credential not found');
+    }
+
+    res.json({
+      ok: true,
+      id,
+      provider: credential.provider,
+      orgId: credential.orgId,
+      fiveHourReservePercent: credential.fiveHourReservePercent,
+      sevenDayReservePercent: credential.sevenDayReservePercent
+    });
   } catch (error) {
     next(error);
   }

--- a/api/src/routes/proxy.ts
+++ b/api/src/routes/proxy.ts
@@ -35,6 +35,7 @@ import {
   anthropicOauthUsageAuthFailureStatusCode,
   evaluateClaudeContributionCap,
   isAnthropicOauthTokenCredential,
+  isOpenAiProviderUsageRefreshCredential,
   parkAnthropicOauthCredentialAfterUsageAuthFailure,
   providerUsageWarningReasonFromRefreshOutcome,
   readTokenCredentialProviderUsageSoftStaleMs,
@@ -201,7 +202,7 @@ function evaluateOpenAiProviderUsageEligibility(input: {
     | null;
   routeDecisionMeta: Record<string, unknown>;
 } {
-  const inScope = canonicalizeProvider(input.credential.provider) === 'openai';
+  const inScope = isOpenAiProviderUsageRefreshCredential(input.credential);
   const fiveHourReservePercent = input.credential.fiveHourReservePercent ?? 0;
   const sevenDayReservePercent = input.credential.sevenDayReservePercent ?? 0;
   const fiveHourSharedThresholdPercent = 100 - fiveHourReservePercent;
@@ -223,11 +224,10 @@ function evaluateOpenAiProviderUsageEligibility(input: {
   }
 
   if (!input.snapshot) {
-    const reserveFloorConfigured = fiveHourReservePercent > 0 || sevenDayReservePercent > 0;
     return {
       inScope,
-      eligible: !reserveFloorConfigured,
-      exclusionReason: reserveFloorConfigured ? 'provider_usage_snapshot_missing' : null,
+      eligible: false,
+      exclusionReason: 'provider_usage_snapshot_missing',
       routeDecisionMeta: {
         ...baseMeta,
         providerUsageSnapshotState: 'missing',
@@ -268,7 +268,6 @@ function evaluateOpenAiProviderUsageEligibility(input: {
   const sevenDayContributionCapExhausted = sevenDayReservePercent > 0
     && typeof input.snapshot.sevenDayUtilizationRatio === 'number'
     && (input.snapshot.sevenDayUtilizationRatio * 100) >= sevenDaySharedThresholdPercent;
-  const reserveFloorConfigured = fiveHourReservePercent > 0 || sevenDayReservePercent > 0;
   const routeDecisionMeta = {
     ...baseMeta,
     providerUsageSnapshotState: isHardStale ? 'hard_stale' : isSoftStale ? 'soft_stale' : 'fresh',
@@ -298,8 +297,8 @@ function evaluateOpenAiProviderUsageEligibility(input: {
   if (isHardStale) {
     return {
       inScope,
-      eligible: !reserveFloorConfigured,
-      exclusionReason: reserveFloorConfigured ? 'provider_usage_snapshot_hard_stale' : null,
+      eligible: false,
+      exclusionReason: 'provider_usage_snapshot_hard_stale',
       routeDecisionMeta
     };
   }
@@ -307,8 +306,8 @@ function evaluateOpenAiProviderUsageEligibility(input: {
   if (isSoftStale) {
     return {
       inScope,
-      eligible: !reserveFloorConfigured,
-      exclusionReason: reserveFloorConfigured ? 'provider_usage_snapshot_soft_stale' : null,
+      eligible: false,
+      exclusionReason: 'provider_usage_snapshot_soft_stale',
       routeDecisionMeta
     };
   }

--- a/api/src/routes/proxy.ts
+++ b/api/src/routes/proxy.ts
@@ -37,6 +37,8 @@ import {
   isAnthropicOauthTokenCredential,
   parkAnthropicOauthCredentialAfterUsageAuthFailure,
   providerUsageWarningReasonFromRefreshOutcome,
+  readTokenCredentialProviderUsageSoftStaleMs,
+  readTokenCredentialProviderUsageHardStaleMs,
   readTokenCredentialRateLimitLongBackoffMinutes
 } from '../services/tokenCredentialProviderUsage.js';
 import {
@@ -188,35 +190,56 @@ function evaluateOpenAiProviderUsageEligibility(input: {
 }): {
   inScope: boolean;
   eligible: boolean;
-  exclusionReason: 'usage_exhausted_5h' | 'usage_exhausted_7d' | null;
+  exclusionReason:
+    | 'usage_exhausted_5h'
+    | 'usage_exhausted_7d'
+    | 'provider_usage_snapshot_missing'
+    | 'provider_usage_snapshot_hard_stale'
+    | 'contribution_cap_exhausted_5h'
+    | 'contribution_cap_exhausted_7d'
+    | null;
   routeDecisionMeta: Record<string, unknown>;
 } {
   const inScope = canonicalizeProvider(input.credential.provider) === 'openai';
+  const fiveHourReservePercent = input.credential.fiveHourReservePercent ?? 0;
+  const sevenDayReservePercent = input.credential.sevenDayReservePercent ?? 0;
+  const fiveHourSharedThresholdPercent = 100 - fiveHourReservePercent;
+  const sevenDaySharedThresholdPercent = 100 - sevenDayReservePercent;
+  const baseMeta: Record<string, unknown> = {
+    openaiProviderUsageInScope: inScope,
+    fiveHourReservePercent,
+    sevenDayReservePercent,
+    fiveHourSharedThresholdPercent,
+    sevenDaySharedThresholdPercent
+  };
   if (!inScope) {
     return {
       inScope,
       eligible: true,
       exclusionReason: null,
-      routeDecisionMeta: {
-        openaiProviderUsageInScope: false
-      }
+      routeDecisionMeta: baseMeta
     };
   }
 
   if (!input.snapshot) {
+    const reserveFloorConfigured = fiveHourReservePercent > 0 || sevenDayReservePercent > 0;
     return {
       inScope,
-      eligible: true,
-      exclusionReason: null,
+      eligible: !reserveFloorConfigured,
+      exclusionReason: reserveFloorConfigured ? 'provider_usage_snapshot_missing' : null,
       routeDecisionMeta: {
-        openaiProviderUsageInScope: true,
+        ...baseMeta,
         providerUsageSnapshotState: 'missing',
         providerUsageFetchedAt: null,
         fiveHourUtilizationRatio: null,
         fiveHourResetsAt: null,
+        fiveHourSharedThresholdPercent,
+        fiveHourContributionCapExhausted: false,
         fiveHourProviderUsageExhausted: false,
         sevenDayUtilizationRatio: null,
         sevenDayResetsAt: null,
+        sevenDaySharedThresholdPercent,
+        sevenDayContributionCapExhausted: false,
         sevenDayProviderUsageExhausted: false,
         providerUsageExhaustionReason: null,
         providerUsageExhaustionHoldActive: false,
@@ -225,32 +248,84 @@ function evaluateOpenAiProviderUsageEligibility(input: {
     };
   }
 
+  const now = input.now ?? new Date();
+  const ageMs = Math.max(0, now.getTime() - input.snapshot.fetchedAt.getTime());
+  const softStaleMs = readTokenCredentialProviderUsageSoftStaleMs();
+  const hardStaleMs = readTokenCredentialProviderUsageHardStaleMs();
+  const isHardStale = ageMs > hardStaleMs;
+  const isSoftStale = !isHardStale && ageMs > softStaleMs;
   const exhaustionHold = readClaudeProviderUsageExhaustionHoldState({
     fiveHourUtilizationRatio: input.snapshot.fiveHourUtilizationRatio,
     fiveHourResetsAt: input.snapshot.fiveHourResetsAt,
     sevenDayUtilizationRatio: input.snapshot.sevenDayUtilizationRatio,
     sevenDayResetsAt: input.snapshot.sevenDayResetsAt,
-    now: input.now
+    now
   });
+  const fiveHourContributionCapExhausted = fiveHourReservePercent > 0
+    && typeof input.snapshot.fiveHourUtilizationRatio === 'number'
+    && (input.snapshot.fiveHourUtilizationRatio * 100) >= fiveHourSharedThresholdPercent;
+  const sevenDayContributionCapExhausted = sevenDayReservePercent > 0
+    && typeof input.snapshot.sevenDayUtilizationRatio === 'number'
+    && (input.snapshot.sevenDayUtilizationRatio * 100) >= sevenDaySharedThresholdPercent;
+  const reserveFloorConfigured = fiveHourReservePercent > 0 || sevenDayReservePercent > 0;
+  const routeDecisionMeta = {
+    ...baseMeta,
+    providerUsageSnapshotState: isHardStale ? 'hard_stale' : isSoftStale ? 'soft_stale' : 'fresh',
+    providerUsageFetchedAt: input.snapshot.fetchedAt.toISOString(),
+    fiveHourUtilizationRatio: input.snapshot.fiveHourUtilizationRatio,
+    fiveHourResetsAt: input.snapshot.fiveHourResetsAt?.toISOString() ?? null,
+    fiveHourContributionCapExhausted,
+    fiveHourProviderUsageExhausted: exhaustionHold.fiveHourProviderUsageExhausted,
+    sevenDayUtilizationRatio: input.snapshot.sevenDayUtilizationRatio,
+    sevenDayResetsAt: input.snapshot.sevenDayResetsAt?.toISOString() ?? null,
+    sevenDayContributionCapExhausted,
+    sevenDayProviderUsageExhausted: exhaustionHold.sevenDayProviderUsageExhausted,
+    providerUsageExhaustionReason: exhaustionHold.reason,
+    providerUsageExhaustionHoldActive: exhaustionHold.hasActiveHold,
+    providerUsageExhaustionHoldUntil: exhaustionHold.nextRefreshAt?.toISOString() ?? null
+  };
+
+  if (exhaustionHold.hasActiveHold) {
+    return {
+      inScope,
+      eligible: false,
+      exclusionReason: exhaustionHold.reason,
+      routeDecisionMeta
+    };
+  }
+
+  if (isHardStale) {
+    return {
+      inScope,
+      eligible: !reserveFloorConfigured,
+      exclusionReason: reserveFloorConfigured ? 'provider_usage_snapshot_hard_stale' : null,
+      routeDecisionMeta
+    };
+  }
+
+  if (fiveHourContributionCapExhausted) {
+    return {
+      inScope,
+      eligible: false,
+      exclusionReason: 'contribution_cap_exhausted_5h',
+      routeDecisionMeta
+    };
+  }
+
+  if (sevenDayContributionCapExhausted) {
+    return {
+      inScope,
+      eligible: false,
+      exclusionReason: 'contribution_cap_exhausted_7d',
+      routeDecisionMeta
+    };
+  }
 
   return {
     inScope,
-    eligible: !exhaustionHold.hasActiveHold,
-    exclusionReason: exhaustionHold.reason,
-    routeDecisionMeta: {
-      openaiProviderUsageInScope: true,
-      providerUsageSnapshotState: 'fresh',
-      providerUsageFetchedAt: input.snapshot.fetchedAt.toISOString(),
-      fiveHourUtilizationRatio: input.snapshot.fiveHourUtilizationRatio,
-      fiveHourResetsAt: input.snapshot.fiveHourResetsAt?.toISOString() ?? null,
-      fiveHourProviderUsageExhausted: exhaustionHold.fiveHourProviderUsageExhausted,
-      sevenDayUtilizationRatio: input.snapshot.sevenDayUtilizationRatio,
-      sevenDayResetsAt: input.snapshot.sevenDayResetsAt?.toISOString() ?? null,
-      sevenDayProviderUsageExhausted: exhaustionHold.sevenDayProviderUsageExhausted,
-      providerUsageExhaustionReason: exhaustionHold.reason,
-      providerUsageExhaustionHoldActive: exhaustionHold.hasActiveHold,
-      providerUsageExhaustionHoldUntil: exhaustionHold.nextRefreshAt?.toISOString() ?? null
-    }
+    eligible: true,
+    exclusionReason: null,
+    routeDecisionMeta
   };
 }
 

--- a/api/src/routes/proxy.ts
+++ b/api/src/routes/proxy.ts
@@ -2882,28 +2882,33 @@ async function executeTokenModeNonStreaming(input: {
         latencyMs: Date.now() - startedAt,
         ttfbMs
       });
-      await runtime.services.metering.recordUsage({
-        requestId,
-        attemptNo,
-        orgId,
-        apiKeyId,
-        sellerKeyId: undefined,
-        provider,
-        model,
-        inputTokens,
-        outputTokens,
-        usageUnits,
-        retailEquivalentMinor: usageUnits
-      });
-      const monthlyUsageRecorded = await runtime.repos.tokenCredentials.addMonthlyContributionUsage(
-        credential.id,
-        usageUnits
-      );
-      if (!monthlyUsageRecorded) {
-        await logAttemptFailure({
-          kind: 'metering_degraded',
-          message: 'monthly contribution increment could not be recorded after successful upstream response'
+      if (status >= 200 && status < 300 && !extractedFailed) {
+        await runtime.services.metering.recordUsage({
+          requestId,
+          attemptNo,
+          orgId,
+          apiKeyId,
+          sellerKeyId: undefined,
+          tokenCredentialId: credential.id,
+          providerAccountId: credential.id,
+          servingOrgId: credential.orgId,
+          provider,
+          model,
+          inputTokens,
+          outputTokens,
+          usageUnits,
+          retailEquivalentMinor: usageUnits
         });
+        const monthlyUsageRecorded = await runtime.repos.tokenCredentials.addMonthlyContributionUsage(
+          credential.id,
+          usageUnits
+        );
+        if (!monthlyUsageRecorded) {
+          await logAttemptFailure({
+            kind: 'metering_degraded',
+            message: 'monthly contribution increment could not be recorded after successful upstream response'
+          });
+        }
       }
 
       if (status >= 200 && status < 300) {
@@ -3694,6 +3699,9 @@ async function executeTokenModeStreaming(input: {
                   orgId,
                   apiKeyId,
                   sellerKeyId: undefined,
+                  tokenCredentialId: credential.id,
+                  providerAccountId: credential.id,
+                  servingOrgId: credential.orgId,
                   provider,
                   model,
                   inputTokens,
@@ -3836,6 +3844,9 @@ async function executeTokenModeStreaming(input: {
                 orgId,
                 apiKeyId,
                 sellerKeyId: undefined,
+                tokenCredentialId: credential.id,
+                providerAccountId: credential.id,
+                servingOrgId: credential.orgId,
                 provider,
                 model,
                 inputTokens,
@@ -4223,6 +4234,9 @@ async function executeTokenModeStreaming(input: {
             orgId,
             apiKeyId,
             sellerKeyId: undefined,
+            tokenCredentialId: credential.id,
+            providerAccountId: credential.id,
+            servingOrgId: credential.orgId,
             provider,
             model,
             inputTokens,
@@ -4665,6 +4679,10 @@ export async function proxyPostHandler(req: any, res: Response, next: any): Prom
             const inputTokens = parsedInputTokens ?? Math.floor(usageUnits * 0.4);
             const outputTokens = parsedOutputTokens ?? Math.max(0, usageUnits - inputTokens);
             const usedEstimate = parsedInputTokens === null || parsedOutputTokens === null;
+            const shouldRecordServedStream = (
+              upstreamResponse.status >= 200
+              && upstreamResponse.status < 300
+            );
 
             if (idemStart && !idemStart.replay) {
               await commitProxyMetadataIdempotency(
@@ -4674,7 +4692,9 @@ export async function proxyPostHandler(req: any, res: Response, next: any): Prom
               );
             }
 
-            await runtime.repos.sellerKeys.addCapacityUsage(decision.sellerKeyId, usageUnits);
+            if (shouldRecordServedStream) {
+              await runtime.repos.sellerKeys.addCapacityUsage(decision.sellerKeyId, usageUnits);
+            }
             await runtime.repos.routingEvents.insert({
               requestId,
               attemptNo: decision.attemptNo,
@@ -4689,22 +4709,24 @@ export async function proxyPostHandler(req: any, res: Response, next: any): Prom
               latencyMs: Date.now() - startedAt,
               ttfbMs
             });
-            await runtime.services.metering.recordUsage({
-              requestId,
-              attemptNo: decision.attemptNo,
-              orgId,
-              apiKeyId: auth.apiKeyId,
-              sellerKeyId: decision.sellerKeyId,
-              provider: requestProvider,
-              model: parsed.model,
-              inputTokens,
-              outputTokens,
-              usageUnits,
-              retailEquivalentMinor: usageUnits,
-              note: usedEstimate
-                ? `estimate=stream_bytes_v1 bytes=${totalBytes} chunks=${totalChunks} reconcile_pending=true`
-                : `source=stream_usage_payload bytes=${totalBytes} chunks=${totalChunks}`
-            });
+            if (shouldRecordServedStream) {
+              await runtime.services.metering.recordUsage({
+                requestId,
+                attemptNo: decision.attemptNo,
+                orgId,
+                apiKeyId: auth.apiKeyId,
+                sellerKeyId: decision.sellerKeyId,
+                provider: requestProvider,
+                model: parsed.model,
+                inputTokens,
+                outputTokens,
+                usageUnits,
+                retailEquivalentMinor: usageUnits,
+                note: usedEstimate
+                  ? `estimate=stream_bytes_v1 bytes=${totalBytes} chunks=${totalChunks} reconcile_pending=true`
+                  : `source=stream_usage_payload bytes=${totalBytes} chunks=${totalChunks}`
+              });
+            }
 
             return {
               upstreamStatus: upstreamResponse.status,
@@ -4777,19 +4799,21 @@ export async function proxyPostHandler(req: any, res: Response, next: any): Prom
         latencyMs,
         ttfbMs: result.ttfbMs ?? null
       });
-      await runtime.services.metering.recordUsage({
-        requestId,
-        attemptNo: result.attemptNo,
-        orgId,
-        apiKeyId: auth.apiKeyId,
-        sellerKeyId: result.keyId ?? undefined,
-        provider: requestProvider,
-        model: parsed.model,
-        inputTokens: observedInputTokens,
-        outputTokens: observedOutputTokens,
-        usageUnits: result.usageUnits ?? 0,
-        retailEquivalentMinor: result.usageUnits ?? 0
-      });
+      if (result.upstreamStatus >= 200 && result.upstreamStatus < 300) {
+        await runtime.services.metering.recordUsage({
+          requestId,
+          attemptNo: result.attemptNo,
+          orgId,
+          apiKeyId: auth.apiKeyId,
+          sellerKeyId: result.keyId ?? undefined,
+          provider: requestProvider,
+          model: parsed.model,
+          inputTokens: observedInputTokens,
+          outputTokens: observedOutputTokens,
+          usageUnits: result.usageUnits ?? 0,
+          retailEquivalentMinor: result.usageUnits ?? 0
+        });
+      }
     }
 
     if (idemStart && !idemStart.replay) {

--- a/api/src/routes/proxy.ts
+++ b/api/src/routes/proxy.ts
@@ -194,6 +194,7 @@ function evaluateOpenAiProviderUsageEligibility(input: {
     | 'usage_exhausted_5h'
     | 'usage_exhausted_7d'
     | 'provider_usage_snapshot_missing'
+    | 'provider_usage_snapshot_soft_stale'
     | 'provider_usage_snapshot_hard_stale'
     | 'contribution_cap_exhausted_5h'
     | 'contribution_cap_exhausted_7d'
@@ -299,6 +300,15 @@ function evaluateOpenAiProviderUsageEligibility(input: {
       inScope,
       eligible: !reserveFloorConfigured,
       exclusionReason: reserveFloorConfigured ? 'provider_usage_snapshot_hard_stale' : null,
+      routeDecisionMeta
+    };
+  }
+
+  if (isSoftStale) {
+    return {
+      inScope,
+      eligible: !reserveFloorConfigured,
+      exclusionReason: reserveFloorConfigured ? 'provider_usage_snapshot_soft_stale' : null,
       routeDecisionMeta
     };
   }

--- a/api/src/routes/usage.ts
+++ b/api/src/routes/usage.ts
@@ -3,6 +3,7 @@
 import { Router } from 'express';
 import { z } from 'zod';
 import { requireApiKey } from '../middleware/auth.js';
+import type { RequestHistoryCursor } from '../repos/routingAttributionRepository.js';
 import { runtime } from '../services/runtime.js';
 import { AppError } from '../utils/errors.js';
 
@@ -10,6 +11,17 @@ const router = Router();
 
 const querySchema = z.object({
   days: z.coerce.number().int().min(1).max(90).optional().default(30)
+});
+
+const requestHistoryQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).optional().default(20),
+  cursor: z.string().min(1).optional()
+});
+
+const requestHistoryCursorSchema = z.object({
+  createdAt: z.string().min(1),
+  requestId: z.string().min(1),
+  attemptNo: z.number().int().min(1)
 });
 
 router.get('/v1/usage/me', requireApiKey(runtime.repos.apiKeys, ['buyer_proxy', 'admin']), async (req, res, next) => {
@@ -29,5 +41,49 @@ router.get('/v1/usage/me', requireApiKey(runtime.repos.apiKeys, ['buyer_proxy', 
     next(error);
   }
 });
+
+router.get('/v1/usage/me/requests', requireApiKey(runtime.repos.apiKeys, ['buyer_proxy', 'admin']), async (req, res, next) => {
+  try {
+    if (!req.auth?.orgId) {
+      throw new AppError('forbidden', 403, 'API key is not associated with an org');
+    }
+
+    const query = requestHistoryQuerySchema.parse(req.query);
+    const cursor = decodeCursor(query.cursor);
+    const rows = await runtime.repos.routingAttribution.listOrgRequestHistory({
+      orgId: req.auth.orgId,
+      limit: query.limit,
+      cursor,
+      historyScope: 'post_cutover'
+    });
+
+    const last = rows[rows.length - 1];
+    res.json({
+      orgId: req.auth.orgId,
+      requests: rows,
+      nextCursor: rows.length === query.limit && last ? encodeCursor({
+        createdAt: last.created_at,
+        requestId: last.request_id,
+        attemptNo: last.attempt_no
+      }) : null
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+function encodeCursor(cursor: RequestHistoryCursor): string {
+  return Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url');
+}
+
+function decodeCursor(cursor: string | undefined): RequestHistoryCursor | null {
+  if (!cursor) return null;
+  try {
+    const decoded = Buffer.from(cursor, 'base64url').toString('utf8');
+    return requestHistoryCursorSchema.parse(JSON.parse(decoded));
+  } catch {
+    throw new AppError('invalid_request', 400, 'Invalid request-history cursor');
+  }
+}
 
 export default router;

--- a/api/src/services/metering/usageMeteringWriter.ts
+++ b/api/src/services/metering/usageMeteringWriter.ts
@@ -1,32 +1,297 @@
-import { UsageLedgerRepository, type UsageLedgerRow, type UsageLedgerWriteInput } from '../../repos/usageLedgerRepository.js';
+import {
+  UsageLedgerRepository,
+  type UsageLedgerRow,
+  type UsageLedgerWriteInput
+} from '../../repos/usageLedgerRepository.js';
+import {
+  CanonicalMeteringRepository,
+  type CanonicalMeteringEventRow
+} from '../../repos/canonicalMeteringRepository.js';
+import { MeteringProjectorStateRepository } from '../../repos/meteringProjectorStateRepository.js';
+import { FnfOwnershipRepository } from '../../repos/fnfOwnershipRepository.js';
+import { RateCardRepository } from '../../repos/rateCardRepository.js';
+import type { RoutingMode } from '../../types/phase2Contracts.js';
 
-export type MeteringEvent = Omit<UsageLedgerWriteInput, 'entryType' | 'sourceEventId'>;
+export type MeteringEvent = Omit<UsageLedgerWriteInput, 'entryType' | 'sourceEventId'> & {
+  sessionId?: string | null;
+  admissionOrgId?: string;
+  admissionCutoverId?: string | null;
+  admissionRoutingMode?: RoutingMode;
+  consumerUserId?: string | null;
+  teamConsumerId?: string | null;
+  servingOrgId?: string;
+  providerAccountId?: string | null;
+  tokenCredentialId?: string | null;
+  capacityOwnerUserId?: string | null;
+  rateCardVersionId?: string | null;
+  buyerDebitMinor?: number | null;
+  contributorEarningsMinor?: number | null;
+  metadata?: Record<string, unknown>;
+};
+
+type CanonicalEventContext = {
+  sessionId: string | null;
+  admissionOrgId: string;
+  admissionCutoverId: string | null;
+  admissionRoutingMode: RoutingMode;
+  consumerUserId: string | null;
+  teamConsumerId: string | null;
+  servingOrgId: string;
+  providerAccountId: string | null;
+  tokenCredentialId: string | null;
+  capacityOwnerUserId: string | null;
+  rateCardVersionId: string;
+  buyerDebitMinor: number;
+  contributorEarningsMinor: number;
+  metadata: Record<string, unknown> | undefined;
+};
 
 export class UsageMeteringWriter {
-  constructor(private readonly usageLedgerRepo: UsageLedgerRepository) {}
+  constructor(private readonly deps: {
+    usageLedgerRepo: UsageLedgerRepository;
+    canonicalMeteringRepo?: CanonicalMeteringRepository;
+    meteringProjectorStateRepo?: MeteringProjectorStateRepository;
+    rateCardRepo?: RateCardRepository;
+    ownershipRepo?: FnfOwnershipRepository;
+  }) {}
 
   async recordUsage(event: MeteringEvent): Promise<UsageLedgerRow> {
-    return this.usageLedgerRepo.createUsageRow({
+    const row = await this.deps.usageLedgerRepo.createUsageRow({
       ...event,
       entryType: 'usage'
     });
+    const canonical = await this.resolveCanonicalContext(event);
+    if (!canonical || !this.deps.canonicalMeteringRepo) {
+      return row;
+    }
+
+    const saved = await this.deps.canonicalMeteringRepo.createServedRequest({
+      requestId: event.requestId,
+      attemptNo: event.attemptNo,
+      sessionId: canonical.sessionId,
+      admissionOrgId: canonical.admissionOrgId,
+      admissionCutoverId: canonical.admissionCutoverId,
+      admissionRoutingMode: canonical.admissionRoutingMode,
+      consumerOrgId: event.orgId,
+      consumerUserId: canonical.consumerUserId,
+      teamConsumerId: canonical.teamConsumerId,
+      buyerKeyId: event.apiKeyId ?? null,
+      servingOrgId: canonical.servingOrgId,
+      providerAccountId: canonical.providerAccountId,
+      tokenCredentialId: canonical.tokenCredentialId,
+      capacityOwnerUserId: canonical.capacityOwnerUserId,
+      provider: event.provider,
+      model: event.model,
+      rateCardVersionId: canonical.rateCardVersionId,
+      inputTokens: event.inputTokens,
+      outputTokens: event.outputTokens,
+      usageUnits: event.usageUnits,
+      buyerDebitMinor: canonical.buyerDebitMinor,
+      contributorEarningsMinor: canonical.contributorEarningsMinor,
+      currency: event.currency ?? 'USD',
+      metadata: canonical.metadata
+    });
+    await this.ensureProjectionStates(saved, canonical);
+    return row;
   }
 
   async recordCorrection(sourceEventId: string, event: MeteringEvent, note: string): Promise<UsageLedgerRow> {
-    return this.usageLedgerRepo.createCorrectionRow({
+    const row = await this.deps.usageLedgerRepo.createCorrectionRow({
       ...event,
       entryType: 'correction',
       sourceEventId,
       note
     });
+    const canonical = await this.resolveCanonicalContext(event);
+    if (!canonical || !this.deps.canonicalMeteringRepo) {
+      return row;
+    }
+
+    const saved = await this.deps.canonicalMeteringRepo.createCorrection({
+      requestId: event.requestId,
+      attemptNo: event.attemptNo,
+      sessionId: canonical.sessionId,
+      sourceMeteringEventId: sourceEventId,
+      admissionOrgId: canonical.admissionOrgId,
+      admissionCutoverId: canonical.admissionCutoverId,
+      admissionRoutingMode: canonical.admissionRoutingMode,
+      consumerOrgId: event.orgId,
+      consumerUserId: canonical.consumerUserId,
+      teamConsumerId: canonical.teamConsumerId,
+      buyerKeyId: event.apiKeyId ?? null,
+      servingOrgId: canonical.servingOrgId,
+      providerAccountId: canonical.providerAccountId,
+      tokenCredentialId: canonical.tokenCredentialId,
+      capacityOwnerUserId: canonical.capacityOwnerUserId,
+      provider: event.provider,
+      model: event.model,
+      rateCardVersionId: canonical.rateCardVersionId,
+      inputTokens: event.inputTokens,
+      outputTokens: event.outputTokens,
+      usageUnits: event.usageUnits,
+      buyerDebitMinor: canonical.buyerDebitMinor,
+      contributorEarningsMinor: canonical.contributorEarningsMinor,
+      currency: event.currency ?? 'USD',
+      metadata: {
+        ...canonical.metadata,
+        note
+      }
+    });
+    await this.ensureProjectionStates(saved, canonical);
+    return row;
   }
 
   async recordReversal(sourceEventId: string, event: MeteringEvent, note: string): Promise<UsageLedgerRow> {
-    return this.usageLedgerRepo.createReversalRow({
+    const row = await this.deps.usageLedgerRepo.createReversalRow({
       ...event,
       entryType: 'reversal',
       sourceEventId,
       note
     });
+    const canonical = await this.resolveCanonicalContext(event);
+    if (!canonical || !this.deps.canonicalMeteringRepo) {
+      return row;
+    }
+
+    const saved = await this.deps.canonicalMeteringRepo.createReversal({
+      requestId: event.requestId,
+      attemptNo: event.attemptNo,
+      sessionId: canonical.sessionId,
+      sourceMeteringEventId: sourceEventId,
+      admissionOrgId: canonical.admissionOrgId,
+      admissionCutoverId: canonical.admissionCutoverId,
+      admissionRoutingMode: canonical.admissionRoutingMode,
+      consumerOrgId: event.orgId,
+      consumerUserId: canonical.consumerUserId,
+      teamConsumerId: canonical.teamConsumerId,
+      buyerKeyId: event.apiKeyId ?? null,
+      servingOrgId: canonical.servingOrgId,
+      providerAccountId: canonical.providerAccountId,
+      tokenCredentialId: canonical.tokenCredentialId,
+      capacityOwnerUserId: canonical.capacityOwnerUserId,
+      provider: event.provider,
+      model: event.model,
+      rateCardVersionId: canonical.rateCardVersionId,
+      inputTokens: event.inputTokens,
+      outputTokens: event.outputTokens,
+      usageUnits: event.usageUnits,
+      buyerDebitMinor: canonical.buyerDebitMinor * -1,
+      contributorEarningsMinor: canonical.contributorEarningsMinor * -1,
+      currency: event.currency ?? 'USD',
+      metadata: {
+        ...canonical.metadata,
+        note
+      }
+    });
+    await this.ensureProjectionStates(saved, {
+      ...canonical,
+      buyerDebitMinor: canonical.buyerDebitMinor * -1,
+      contributorEarningsMinor: canonical.contributorEarningsMinor * -1
+    });
+    return row;
   }
+
+  private async resolveCanonicalContext(event: MeteringEvent): Promise<CanonicalEventContext | null> {
+    const ownership = event.tokenCredentialId && this.deps.ownershipRepo
+      ? await this.deps.ownershipRepo.findTokenCredentialOwnership(event.tokenCredentialId)
+      : null;
+    const buyerOwnership = event.apiKeyId && this.deps.ownershipRepo
+      ? await this.deps.ownershipRepo.findBuyerKeyOwnership(event.apiKeyId)
+      : null;
+
+    const routingMode = event.admissionRoutingMode
+      ?? inferRoutingMode({
+          event,
+          ownership,
+          buyerOwnership
+        });
+    if (!routingMode) {
+      return null;
+    }
+
+    const appliedRate = event.rateCardVersionId
+      ? null
+      : await this.deps.rateCardRepo?.resolveAppliedRate({
+          provider: event.provider,
+          model: event.model,
+          routingMode
+        });
+    const rateCardVersionId = event.rateCardVersionId ?? appliedRate?.rateCardVersionId ?? null;
+    if (!rateCardVersionId) {
+      return null;
+    }
+
+    const buyerDebitMinor = normalizeMinorAmount(
+      event.buyerDebitMinor,
+      appliedRate ? appliedRate.buyerDebitMinorPerUnit * event.usageUnits : 0
+    );
+    const contributorEarningsMinor = normalizeMinorAmount(
+      event.contributorEarningsMinor,
+      appliedRate ? appliedRate.contributorEarningsMinorPerUnit * event.usageUnits : 0
+    );
+
+    return {
+      sessionId: event.sessionId ?? null,
+      admissionOrgId: event.admissionOrgId ?? event.orgId,
+      admissionCutoverId: event.admissionCutoverId ?? null,
+      admissionRoutingMode: routingMode,
+      consumerUserId: event.consumerUserId ?? null,
+      teamConsumerId: event.teamConsumerId ?? (routingMode === 'team-overflow-on-contributor-capacity' ? 'innies-team' : null),
+      servingOrgId: event.servingOrgId ?? ownership?.owner_org_id ?? event.orgId,
+      providerAccountId: event.providerAccountId ?? event.tokenCredentialId ?? event.sellerKeyId ?? null,
+      tokenCredentialId: event.tokenCredentialId ?? null,
+      capacityOwnerUserId: event.capacityOwnerUserId ?? ownership?.capacity_owner_user_id ?? null,
+      rateCardVersionId,
+      buyerDebitMinor,
+      contributorEarningsMinor,
+      metadata: event.metadata
+    };
+  }
+
+  private async ensureProjectionStates(
+    saved: CanonicalMeteringEventRow,
+    canonical: CanonicalEventContext
+  ): Promise<void> {
+    if (!this.deps.meteringProjectorStateRepo) {
+      return;
+    }
+
+    if (canonical.buyerDebitMinor !== 0) {
+      await this.deps.meteringProjectorStateRepo.ensurePending({
+        meteringEventId: saved.id,
+        projector: 'wallet'
+      });
+    }
+    if (canonical.contributorEarningsMinor !== 0) {
+      await this.deps.meteringProjectorStateRepo.ensurePending({
+        meteringEventId: saved.id,
+        projector: 'earnings'
+      });
+    }
+  }
+}
+
+function inferRoutingMode(input: {
+  event: MeteringEvent;
+  ownership: Awaited<ReturnType<FnfOwnershipRepository['findTokenCredentialOwnership']>> | null;
+  buyerOwnership: Awaited<ReturnType<FnfOwnershipRepository['findBuyerKeyOwnership']>> | null;
+}): RoutingMode | null {
+  const { event, ownership, buyerOwnership } = input;
+  if (event.tokenCredentialId && ownership?.owner_org_id === event.orgId) {
+    return 'self-free';
+  }
+  if (event.capacityOwnerUserId && event.teamConsumerId) {
+    return 'team-overflow-on-contributor-capacity';
+  }
+  if (event.sellerKeyId && buyerOwnership?.owner_org_id === event.orgId) {
+    return 'paid-team-capacity';
+  }
+  return null;
+}
+
+function normalizeMinorAmount(value: number | null | undefined, fallback: number): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.trunc(value);
+  }
+  return Math.trunc(fallback);
 }

--- a/api/src/services/runtime.ts
+++ b/api/src/services/runtime.ts
@@ -1,9 +1,14 @@
 import { buildPgClient } from '../repos/pgClient.js';
 import { ApiKeyRepository } from '../repos/apiKeyRepository.js';
 import { AuditLogRepository } from '../repos/auditLogRepository.js';
+import { CanonicalMeteringRepository } from '../repos/canonicalMeteringRepository.js';
+import { FnfOwnershipRepository } from '../repos/fnfOwnershipRepository.js';
 import { IdempotencyRepository } from '../repos/idempotencyRepository.js';
 import { KillSwitchRepository } from '../repos/killSwitchRepository.js';
+import { MeteringProjectorStateRepository } from '../repos/meteringProjectorStateRepository.js';
 import { ModelCompatibilityRepository } from '../repos/modelCompatibilityRepository.js';
+import { RateCardRepository } from '../repos/rateCardRepository.js';
+import { RoutingAttributionRepository } from '../repos/routingAttributionRepository.js';
 import { RoutingEventsRepository } from '../repos/routingEventsRepository.js';
 import { SellerKeyRepository } from '../repos/sellerKeyRepository.js';
 import { UsageLedgerRepository } from '../repos/usageLedgerRepository.js';
@@ -37,10 +42,15 @@ export const runtime = {
   repos: {
     apiKeys: new ApiKeyRepository(sql),
     auditLogs: new AuditLogRepository(sql),
+    canonicalMetering: new CanonicalMeteringRepository(sql),
+    fnfOwnership: new FnfOwnershipRepository(sql),
     idempotency: new IdempotencyRepository(sql),
     killSwitch: new KillSwitchRepository(sql),
+    meteringProjectorStates: new MeteringProjectorStateRepository(sql),
     modelCompatibility: new ModelCompatibilityRepository(sql),
+    rateCards: new RateCardRepository(sql),
     routingEvents: new RoutingEventsRepository(sql),
+    routingAttribution: new RoutingAttributionRepository(sql),
     sellerKeys: new SellerKeyRepository(sql),
     usageLedger: new UsageLedgerRepository(sql),
     usageQuery: new UsageQueryRepository(sql),
@@ -77,7 +87,13 @@ runtime.services.jobs = new JobScheduler({
     console.error(`[jobs] ${message}`, fields ?? {});
   }
 });
-runtime.services.metering = new UsageMeteringWriter(runtime.repos.usageLedger);
+runtime.services.metering = new UsageMeteringWriter({
+  usageLedgerRepo: runtime.repos.usageLedger,
+  canonicalMeteringRepo: runtime.repos.canonicalMetering,
+  meteringProjectorStateRepo: runtime.repos.meteringProjectorStates,
+  rateCardRepo: runtime.repos.rateCards,
+  ownershipRepo: runtime.repos.fnfOwnership
+});
 runtime.services.pilotSessions = new PilotSessionService({
   secret: process.env.PILOT_SESSION_SECRET || 'dev-insecure-pilot-session-secret'
 });
@@ -96,12 +112,8 @@ runtime.services.pilotGithubAuth = new PilotGithubAuthService({
 runtime.services.pilotCutovers = new PilotCutoverService({
   sql: runtime.sql,
   reserveFloorMigration: {
-    async migrateReserveFloors() {
-      throw new AppError(
-        'service_unavailable',
-        503,
-        'Pilot cutover unavailable until reserve-floor migration adapter is configured'
-      );
+    async migrateReserveFloors(input) {
+      await runtime.repos.tokenCredentials.migrateReserveFloors(input);
     }
   }
 });

--- a/api/src/services/tokenCredentialProviderUsage.ts
+++ b/api/src/services/tokenCredentialProviderUsage.ts
@@ -121,6 +121,7 @@ export type ClaudeContributionCapEvaluation = {
   eligible: boolean;
   exclusionReason:
     | 'provider_usage_snapshot_missing'
+    | 'provider_usage_snapshot_soft_stale'
     | 'provider_usage_snapshot_hard_stale'
     | 'contribution_cap_exhausted_5h'
     | 'contribution_cap_exhausted_7d'
@@ -776,12 +777,26 @@ export function evaluateClaudeContributionCap(input: {
       routeDecisionMeta
     };
   }
+  if (isSoftStale) {
+    return {
+      inScope: true,
+      eligible: fiveHourReservePercent <= 0 && sevenDayReservePercent <= 0,
+      exclusionReason: fiveHourReservePercent > 0 || sevenDayReservePercent > 0
+        ? 'provider_usage_snapshot_soft_stale'
+        : null,
+      warningReason: null,
+      isFresh,
+      isSoftStale,
+      isHardStale,
+      routeDecisionMeta
+    };
+  }
   if (state.fiveHourContributionCapExhausted) {
     return {
       inScope: true,
       eligible: false,
       exclusionReason: 'contribution_cap_exhausted_5h',
-      warningReason: isSoftStale ? 'provider_usage_snapshot_soft_stale' : null,
+      warningReason: null,
       isFresh,
       isSoftStale,
       isHardStale,
@@ -793,7 +808,7 @@ export function evaluateClaudeContributionCap(input: {
       inScope: true,
       eligible: false,
       exclusionReason: 'contribution_cap_exhausted_7d',
-      warningReason: isSoftStale ? 'provider_usage_snapshot_soft_stale' : null,
+      warningReason: null,
       isFresh,
       isSoftStale,
       isHardStale,
@@ -805,7 +820,7 @@ export function evaluateClaudeContributionCap(input: {
     inScope: true,
     eligible: true,
     exclusionReason: null,
-    warningReason: isSoftStale ? 'provider_usage_snapshot_soft_stale' : null,
+    warningReason: null,
     isFresh,
     isSoftStale,
     isHardStale,

--- a/api/src/services/tokenCredentialProviderUsage.ts
+++ b/api/src/services/tokenCredentialProviderUsage.ts
@@ -697,10 +697,8 @@ export function evaluateClaudeContributionCap(input: {
   if (!snapshot) {
     return {
       inScope: true,
-      eligible: fiveHourReservePercent <= 0 && sevenDayReservePercent <= 0,
-      exclusionReason: fiveHourReservePercent > 0 || sevenDayReservePercent > 0
-        ? 'provider_usage_snapshot_missing'
-        : null,
+      eligible: false,
+      exclusionReason: 'provider_usage_snapshot_missing',
       warningReason: null,
       isFresh: false,
       isSoftStale: false,
@@ -766,10 +764,8 @@ export function evaluateClaudeContributionCap(input: {
     }
     return {
       inScope: true,
-      eligible: fiveHourReservePercent <= 0 && sevenDayReservePercent <= 0,
-      exclusionReason: fiveHourReservePercent > 0 || sevenDayReservePercent > 0
-        ? 'provider_usage_snapshot_hard_stale'
-        : null,
+      eligible: false,
+      exclusionReason: 'provider_usage_snapshot_hard_stale',
       warningReason: null,
       isFresh,
       isSoftStale,
@@ -780,10 +776,8 @@ export function evaluateClaudeContributionCap(input: {
   if (isSoftStale) {
     return {
       inScope: true,
-      eligible: fiveHourReservePercent <= 0 && sevenDayReservePercent <= 0,
-      exclusionReason: fiveHourReservePercent > 0 || sevenDayReservePercent > 0
-        ? 'provider_usage_snapshot_soft_stale'
-        : null,
+      eligible: false,
+      exclusionReason: 'provider_usage_snapshot_soft_stale',
       warningReason: null,
       isFresh,
       isSoftStale,

--- a/api/src/services/tokenCredentialService.ts
+++ b/api/src/services/tokenCredentialService.ts
@@ -297,11 +297,11 @@ export class TokenCredentialService {
     if (!existing) {
       return null;
     }
-    if (existing.provider !== 'anthropic') {
+    if (existing.provider !== 'anthropic' && existing.provider !== 'openai') {
       throw new AppError(
         'invalid_request',
         400,
-        'Contribution caps are only supported for Claude token credentials',
+        'Contribution caps are only supported for Claude and OpenAI token credentials',
         { credentialId: id, provider: existing.provider }
       );
     }

--- a/api/src/services/tokenCredentialService.ts
+++ b/api/src/services/tokenCredentialService.ts
@@ -297,11 +297,11 @@ export class TokenCredentialService {
     if (!existing) {
       return null;
     }
-    if (existing.provider !== 'anthropic' && existing.provider !== 'openai') {
+    if (existing.provider !== 'anthropic' && existing.provider !== 'openai' && existing.provider !== 'codex') {
       throw new AppError(
         'invalid_request',
         400,
-        'Contribution caps are only supported for Claude and OpenAI token credentials',
+        'Contribution caps are only supported for Claude, OpenAI, and Codex token credentials',
         { credentialId: id, provider: existing.provider }
       );
     }

--- a/api/tests/admin.pilot.route.test.ts
+++ b/api/tests/admin.pilot.route.test.ts
@@ -11,6 +11,7 @@ type MockReq = {
   originalUrl: string;
   body: unknown;
   params: Record<string, string>;
+  query?: Record<string, string>;
   auth?: {
     apiKeyId: string;
     orgId: string | null;
@@ -37,6 +38,7 @@ function createMockReq(input: {
   body?: unknown;
   headers?: Record<string, string>;
   params?: Record<string, string>;
+  query?: Record<string, string>;
 }): MockReq {
   const lower = Object.fromEntries(
     Object.entries(input.headers ?? {}).map(([k, v]) => [k.toLowerCase(), v])
@@ -47,6 +49,7 @@ function createMockReq(input: {
     originalUrl: input.path,
     body: input.body ?? {},
     params: input.params ?? {},
+    query: input.query ?? {},
     header: (name: string) => lower[name.toLowerCase()]
   };
 }
@@ -110,7 +113,7 @@ async function invoke(handle: (req: any, res: any, next: (error?: unknown) => vo
   });
 }
 
-function getRouteHandlers(router: any, routePath: string, method: 'post'): Array<(req: any, res: any, next: (error?: unknown) => void) => unknown> {
+function getRouteHandlers(router: any, routePath: string, method: 'get' | 'post'): Array<(req: any, res: any, next: (error?: unknown) => void) => unknown> {
   const layer = router.stack.find((entry: any) => entry?.route?.path === routePath && entry?.route?.methods?.[method]);
   if (!layer) throw new Error(`route not found: ${routePath}`);
   return layer.route.stack.map((s: any) => s.handle);
@@ -121,6 +124,12 @@ describe('admin pilot routes', () => {
   let sessionHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
   let cutoverHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
   let rollbackHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+  let requestHistoryHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+  let requestExplanationHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+  let unfinalizedRequestHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+  let rateCardListHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+  let rateCardCreateHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+  let meteringCorrectionHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
 
   beforeAll(async () => {
     process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgres://postgres:postgres@127.0.0.1:5432/innies_test';
@@ -130,6 +139,12 @@ describe('admin pilot routes', () => {
     sessionHandlers = getRouteHandlers(mod.default as any, '/v1/admin/pilot/session', 'post');
     cutoverHandlers = getRouteHandlers(mod.default as any, '/v1/admin/pilot/cutover', 'post');
     rollbackHandlers = getRouteHandlers(mod.default as any, '/v1/admin/pilot/rollback', 'post');
+    requestHistoryHandlers = getRouteHandlers(mod.default as any, '/v1/admin/requests', 'get');
+    requestExplanationHandlers = getRouteHandlers(mod.default as any, '/v1/admin/requests/:requestId/explanation', 'get');
+    unfinalizedRequestHandlers = getRouteHandlers(mod.default as any, '/v1/admin/requests/unfinalized', 'get');
+    rateCardListHandlers = getRouteHandlers(mod.default as any, '/v1/admin/rate-cards', 'get');
+    rateCardCreateHandlers = getRouteHandlers(mod.default as any, '/v1/admin/rate-cards', 'post');
+    meteringCorrectionHandlers = getRouteHandlers(mod.default as any, '/v1/admin/metering/corrections', 'post');
   });
 
   beforeEach(() => {
@@ -144,6 +159,38 @@ describe('admin pilot routes', () => {
       is_frozen: false
     } as any);
     vi.spyOn(runtimeModule.runtime.repos.apiKeys, 'touchLastUsed').mockResolvedValue(undefined);
+    vi.spyOn(runtimeModule.runtime.repos.routingAttribution, 'listAdminRequestHistory').mockResolvedValue([]);
+    vi.spyOn(runtimeModule.runtime.repos.routingAttribution, 'getRequestExplanation').mockResolvedValue(null);
+    vi.spyOn(runtimeModule.runtime.repos.routingAttribution, 'listFinanciallyUnfinalizedRequests').mockResolvedValue([]);
+    vi.spyOn(runtimeModule.runtime.repos.rateCards, 'listVersions').mockResolvedValue([]);
+    vi.spyOn(runtimeModule.runtime.repos.rateCards, 'createVersionWithLineItems').mockResolvedValue({
+      version: {
+        id: 'rate_1',
+        version_key: 'pilot-v1',
+        effective_at: '2026-03-20T00:00:00Z',
+        created_at: '2026-03-20T00:00:00Z'
+      },
+      lineItems: [{
+        id: 'line_1',
+        rate_card_version_id: 'rate_1',
+        provider: 'anthropic',
+        model_pattern: '*',
+        routing_mode: 'paid-team-capacity',
+        buyer_debit_minor_per_unit: 3,
+        contributor_earnings_minor_per_unit: 0,
+        currency: 'USD',
+        created_at: '2026-03-20T00:00:00Z'
+      }]
+    } as any);
+    vi.spyOn(runtimeModule.runtime.repos.auditLogs, 'createEvent').mockResolvedValue({ id: 'audit_1' } as any);
+    vi.spyOn(runtimeModule.runtime.services.idempotency, 'start').mockResolvedValue({
+      replay: false
+    } as any);
+    vi.spyOn(runtimeModule.runtime.services.idempotency, 'commit').mockResolvedValue(undefined);
+    vi.spyOn(runtimeModule.runtime.services.metering, 'recordUsage').mockResolvedValue({
+      id: 'usage_1',
+      entry_type: 'usage'
+    } as any);
   });
 
   afterEach(() => {
@@ -265,6 +312,284 @@ describe('admin pilot routes', () => {
     expect(res.body).toEqual(expect.objectContaining({
       ok: true,
       rollbackId: 'rollback_1'
+    }));
+  });
+
+  it('returns admin request history with a pagination cursor', async () => {
+    vi.spyOn(runtimeModule.runtime.repos.routingAttribution, 'listAdminRequestHistory').mockResolvedValue([{
+      request_id: 'req_1',
+      attempt_no: 1,
+      session_id: 'sess_1',
+      admission_org_id: 'org_fnf',
+      admission_cutover_id: 'cut_1',
+      admission_routing_mode: 'paid-team-capacity',
+      consumer_org_id: 'org_fnf',
+      buyer_key_id: 'buyer_1',
+      serving_org_id: 'org_innies',
+      provider_account_id: 'acct_1',
+      token_credential_id: null,
+      capacity_owner_user_id: null,
+      provider: 'anthropic',
+      model: 'claude-opus-4-6',
+      rate_card_version_id: 'rate_1',
+      input_tokens: 10,
+      output_tokens: 20,
+      usage_units: 30,
+      buyer_debit_minor: 90,
+      contributor_earnings_minor: 0,
+      currency: 'USD',
+      metadata: null,
+      created_at: '2026-03-20T10:00:00.000Z',
+      prompt_preview: 'hello',
+      response_preview: 'world',
+      route_decision: { reason: 'preferred_provider_selected' },
+      projector_states: []
+    }] as any);
+
+    const req = createMockReq({
+      method: 'GET',
+      path: '/v1/admin/requests',
+      headers: {
+        authorization: 'Bearer in_admin_token'
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(requestHistoryHandlers[0], req, res);
+    await invoke(requestHistoryHandlers[1], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(expect.objectContaining({
+      requests: [expect.objectContaining({ request_id: 'req_1' })],
+      nextCursor: null
+    }));
+    expect(runtimeModule.runtime.repos.routingAttribution.listAdminRequestHistory).toHaveBeenCalledWith({
+      consumerOrgId: undefined,
+      limit: 20,
+      cursor: null,
+      historyScope: 'all'
+    });
+  });
+
+  it('accepts and emits full admin request-history cursors', async () => {
+    const decodedCursor = {
+      createdAt: '2026-03-19T09:00:00.000Z',
+      requestId: 'req_8',
+      attemptNo: 2
+    };
+    const encodedCursor = Buffer.from(JSON.stringify(decodedCursor), 'utf8').toString('base64url');
+    vi.spyOn(runtimeModule.runtime.repos.routingAttribution, 'listAdminRequestHistory').mockResolvedValue([{
+      request_id: 'req_9',
+      attempt_no: 3,
+      session_id: 'sess_1',
+      admission_org_id: 'org_fnf',
+      admission_cutover_id: 'cut_1',
+      admission_routing_mode: 'paid-team-capacity',
+      consumer_org_id: 'org_fnf',
+      buyer_key_id: 'buyer_1',
+      serving_org_id: 'org_innies',
+      provider_account_id: 'acct_1',
+      token_credential_id: null,
+      capacity_owner_user_id: null,
+      provider: 'anthropic',
+      model: 'claude-opus-4-6',
+      rate_card_version_id: 'rate_1',
+      input_tokens: 10,
+      output_tokens: 20,
+      usage_units: 30,
+      buyer_debit_minor: 90,
+      contributor_earnings_minor: 0,
+      currency: 'USD',
+      metadata: null,
+      created_at: '2026-03-20T10:00:00.000Z',
+      prompt_preview: 'hello',
+      response_preview: 'world',
+      route_decision: { reason: 'preferred_provider_selected' },
+      projector_states: []
+    }] as any);
+
+    const req = createMockReq({
+      method: 'GET',
+      path: '/v1/admin/requests',
+      headers: {
+        authorization: 'Bearer in_admin_token'
+      },
+      query: {
+        limit: '1',
+        cursor: encodedCursor
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(requestHistoryHandlers[0], req, res);
+    await invoke(requestHistoryHandlers[1], req, res);
+
+    expect(runtimeModule.runtime.repos.routingAttribution.listAdminRequestHistory).toHaveBeenCalledWith({
+      consumerOrgId: undefined,
+      limit: 1,
+      cursor: decodedCursor,
+      historyScope: 'all'
+    });
+    expect(res.body).toEqual(expect.objectContaining({
+      nextCursor: Buffer.from(JSON.stringify({
+        createdAt: '2026-03-20T10:00:00.000Z',
+        requestId: 'req_9',
+        attemptNo: 3
+      }), 'utf8').toString('base64url')
+    }));
+  });
+
+  it('returns an admin request explanation when present', async () => {
+    vi.spyOn(runtimeModule.runtime.repos.routingAttribution, 'getRequestExplanation').mockResolvedValue({
+      request_id: 'req_1',
+      attempt_no: 1
+    } as any);
+
+    const req = createMockReq({
+      method: 'GET',
+      path: '/v1/admin/requests/req_1/explanation',
+      headers: {
+        authorization: 'Bearer in_admin_token'
+      },
+      params: {
+        requestId: 'req_1'
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(requestExplanationHandlers[0], req, res);
+    await invoke(requestExplanationHandlers[1], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(expect.objectContaining({
+      ok: true,
+      request: expect.objectContaining({ request_id: 'req_1' })
+    }));
+  });
+
+  it('lists financially unfinalized requests for operator retry', async () => {
+    vi.spyOn(runtimeModule.runtime.repos.routingAttribution, 'listFinanciallyUnfinalizedRequests').mockResolvedValue([{
+      request_id: 'req_missing',
+      attempt_no: 2,
+      org_id: 'org_fnf'
+    }] as any);
+
+    const req = createMockReq({
+      method: 'GET',
+      path: '/v1/admin/requests/unfinalized',
+      headers: {
+        authorization: 'Bearer in_admin_token'
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(unfinalizedRequestHandlers[0], req, res);
+    await invoke(unfinalizedRequestHandlers[1], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      requests: [expect.objectContaining({ request_id: 'req_missing' })]
+    });
+  });
+
+  it('lists rate-card versions', async () => {
+    vi.spyOn(runtimeModule.runtime.repos.rateCards, 'listVersions').mockResolvedValue([{
+      id: 'rate_1',
+      version_key: 'pilot-v1'
+    }] as any);
+
+    const req = createMockReq({
+      method: 'GET',
+      path: '/v1/admin/rate-cards',
+      headers: {
+        authorization: 'Bearer in_admin_token'
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(rateCardListHandlers[0], req, res);
+    await invoke(rateCardListHandlers[1], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      versions: [expect.objectContaining({ id: 'rate_1' })]
+    });
+  });
+
+  it('creates a rate-card version with line items', async () => {
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/admin/rate-cards',
+      headers: {
+        authorization: 'Bearer in_admin_token',
+        'content-type': 'application/json',
+        'idempotency-key': 'abcdefghijklmnopqrstuvwxyz123457'
+      },
+      body: {
+        versionKey: 'pilot-v1',
+        effectiveAt: '2026-03-20T00:00:00.000Z',
+        lineItems: [{
+          provider: 'anthropic',
+          modelPattern: '*',
+          routingMode: 'paid-team-capacity',
+          buyerDebitMinorPerUnit: 3,
+          contributorEarningsMinorPerUnit: 0
+        }]
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(rateCardCreateHandlers[0], req, res);
+    await invoke(rateCardCreateHandlers[1], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(expect.objectContaining({
+      ok: true,
+      version: expect.objectContaining({ id: 'rate_1' }),
+      lineItems: [expect.objectContaining({ id: 'line_1' })]
+    }));
+  });
+
+  it('accepts served-request retry corrections through the canonical metering alias', async () => {
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/admin/metering/corrections',
+      headers: {
+        authorization: 'Bearer in_admin_token',
+        'content-type': 'application/json',
+        'idempotency-key': 'abcdefghijklmnopqrstuvwxyz123456'
+      },
+      body: {
+        action: 'served_request_retry',
+        event: {
+          requestId: 'req_1',
+          attemptNo: 1,
+          orgId: '11111111-1111-4111-8111-111111111111',
+          provider: 'anthropic',
+          model: 'claude-opus-4-6',
+          inputTokens: 10,
+          outputTokens: 20,
+          usageUnits: 30,
+          retailEquivalentMinor: 90,
+          admissionRoutingMode: 'paid-team-capacity',
+          rateCardVersionId: '22222222-2222-4222-8222-222222222222'
+        }
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(meteringCorrectionHandlers[0], req, res);
+    await invoke(meteringCorrectionHandlers[1], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(expect.objectContaining({
+      ok: true,
+      id: 'usage_1',
+      entryType: 'usage'
+    }));
+    expect(runtimeModule.runtime.services.metering.recordUsage).toHaveBeenCalledWith(expect.objectContaining({
+      requestId: 'req_1',
+      admissionRoutingMode: 'paid-team-capacity'
     }));
   });
 });

--- a/api/tests/admin.tokenCredentials.route.test.ts
+++ b/api/tests/admin.tokenCredentials.route.test.ts
@@ -1250,7 +1250,7 @@ describe('admin token credential routes idempotent replay', () => {
     });
   });
 
-  it('rejects contribution-cap updates for non-Claude credentials', async () => {
+  it('rejects contribution-cap updates for unsupported credentials', async () => {
     vi.spyOn(runtimeModule.runtime.services.idempotency, 'start').mockResolvedValue({
       replay: false,
       input: {
@@ -1265,8 +1265,8 @@ describe('admin token credential routes idempotent replay', () => {
       new AppError(
         'invalid_request',
         400,
-        'Contribution caps are only supported for Claude token credentials',
-        { credentialId: '11111111-1111-4111-8111-111111111111', provider: 'openai' }
+        'Contribution caps are only supported for Claude and OpenAI token credentials',
+        { credentialId: '11111111-1111-4111-8111-111111111111', provider: 'google' }
       )
     );
     const commitSpy = vi.spyOn(runtimeModule.runtime.services.idempotency, 'commit').mockResolvedValue(undefined);
@@ -1292,9 +1292,68 @@ describe('admin token credential routes idempotent replay', () => {
     expect(res.statusCode).toBe(400);
     expect((res.body as any)).toMatchObject({
       code: 'invalid_request',
-      message: 'Contribution caps are only supported for Claude token credentials'
+      message: 'Contribution caps are only supported for Claude and OpenAI token credentials'
     });
     expect(commitSpy).not.toHaveBeenCalled();
+  });
+
+  it('updates contribution-cap values for OpenAI token credentials', async () => {
+    vi.spyOn(runtimeModule.runtime.services.idempotency, 'start').mockResolvedValue({
+      replay: false,
+      input: {
+        scope: 'admin_token_credentials_contribution_cap_v1',
+        tenantScope: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+        idempotencyKey: 'abcdefghijklmnopqrstuvwxyz123460x',
+        requestHash: 'contribution_cap_h_openai'
+      }
+    } as any);
+
+    const updateSpy = vi.spyOn(runtimeModule.runtime.services.tokenCredentials, 'updateContributionCap').mockResolvedValue({
+      id: '11111111-1111-4111-8111-111111111111',
+      orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      provider: 'openai',
+      fiveHourReservePercent: 35,
+      sevenDayReservePercent: 15
+    } as any);
+    const commitSpy = vi.spyOn(runtimeModule.runtime.services.idempotency, 'commit').mockResolvedValue(undefined);
+
+    const req = createMockReq({
+      method: 'PATCH',
+      path: '/v1/admin/token-credentials/11111111-1111-4111-8111-111111111111/contribution-cap',
+      headers: {
+        authorization: 'Bearer in_admin_token',
+        'content-type': 'application/json',
+        'idempotency-key': 'abcdefghijklmnopqrstuvwxyz123460x'
+      },
+      params: { id: '11111111-1111-4111-8111-111111111111' },
+      body: {
+        fiveHourReservePercent: 35,
+        sevenDayReservePercent: 15
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(contributionCapHandlers[0], req, res);
+    await invoke(contributionCapHandlers[1], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect((res.body as any)).toEqual({
+      ok: true,
+      id: '11111111-1111-4111-8111-111111111111',
+      provider: 'openai',
+      orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      fiveHourReservePercent: 35,
+      sevenDayReservePercent: 15
+    });
+    expect(updateSpy).toHaveBeenCalledWith(
+      '11111111-1111-4111-8111-111111111111',
+      {
+        fiveHourReservePercent: 35,
+        sevenDayReservePercent: 15
+      },
+      expect.any(Object)
+    );
+    expect(commitSpy).toHaveBeenCalledTimes(1);
   });
 
   it('probes a maxed credential immediately and returns active on success', async () => {

--- a/api/tests/admin.tokenCredentials.route.test.ts
+++ b/api/tests/admin.tokenCredentials.route.test.ts
@@ -135,8 +135,8 @@ async function invoke(handle: (req: any, res: any, next: (error?: unknown) => vo
   });
 }
 
-function getRouteHandlers(router: any, routePath: string): Array<(req: any, res: any, next: (error?: unknown) => void) => unknown> {
-  const layer = router.stack.find((entry: any) => entry?.route?.path === routePath);
+function getRouteHandlers(router: any, routePath: string, method: 'get' | 'patch' | 'post'): Array<(req: any, res: any, next: (error?: unknown) => void) => unknown> {
+  const layer = router.stack.find((entry: any) => entry?.route?.path === routePath && entry?.route?.methods?.[method]);
   if (!layer) throw new Error(`route not found: ${routePath}`);
   return layer.route.stack.map((s: any) => s.handle);
 }
@@ -153,6 +153,7 @@ describe('admin token credential routes idempotent replay', () => {
   let unpauseHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
   let labelHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
   let refreshTokenHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+  let contributionCapReadHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
   let contributionCapHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
   let probeHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
   let providerUsageRefreshHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
@@ -165,16 +166,17 @@ describe('admin token credential routes idempotent replay', () => {
     providerUsageModule = await import('../src/services/tokenCredentialProviderUsage.js');
     oauthRefreshModule = await import('../src/services/tokenCredentialOauthRefresh.js');
     const mod = await import('../src/routes/admin.js') as AdminRouteModule;
-    createHandlers = getRouteHandlers(mod.default as any, '/v1/admin/token-credentials');
-    rotateHandlers = getRouteHandlers(mod.default as any, '/v1/admin/token-credentials/rotate');
-    revokeHandlers = getRouteHandlers(mod.default as any, '/v1/admin/token-credentials/:id/revoke');
-    pauseHandlers = getRouteHandlers(mod.default as any, '/v1/admin/token-credentials/:id/pause');
-    unpauseHandlers = getRouteHandlers(mod.default as any, '/v1/admin/token-credentials/:id/unpause');
-    labelHandlers = getRouteHandlers(mod.default as any, '/v1/admin/token-credentials/:id/label');
-    refreshTokenHandlers = getRouteHandlers(mod.default as any, '/v1/admin/token-credentials/:id/refresh-token');
-    contributionCapHandlers = getRouteHandlers(mod.default as any, '/v1/admin/token-credentials/:id/contribution-cap');
-    probeHandlers = getRouteHandlers(mod.default as any, '/v1/admin/token-credentials/:id/probe');
-    providerUsageRefreshHandlers = getRouteHandlers(mod.default as any, '/v1/admin/token-credentials/:id/provider-usage-refresh');
+    createHandlers = getRouteHandlers(mod.default as any, '/v1/admin/token-credentials', 'post');
+    rotateHandlers = getRouteHandlers(mod.default as any, '/v1/admin/token-credentials/rotate', 'post');
+    revokeHandlers = getRouteHandlers(mod.default as any, '/v1/admin/token-credentials/:id/revoke', 'post');
+    pauseHandlers = getRouteHandlers(mod.default as any, '/v1/admin/token-credentials/:id/pause', 'post');
+    unpauseHandlers = getRouteHandlers(mod.default as any, '/v1/admin/token-credentials/:id/unpause', 'post');
+    labelHandlers = getRouteHandlers(mod.default as any, '/v1/admin/token-credentials/:id/label', 'patch');
+    refreshTokenHandlers = getRouteHandlers(mod.default as any, '/v1/admin/token-credentials/:id/refresh-token', 'patch');
+    contributionCapReadHandlers = getRouteHandlers(mod.default as any, '/v1/admin/token-credentials/:id/contribution-cap', 'get');
+    contributionCapHandlers = getRouteHandlers(mod.default as any, '/v1/admin/token-credentials/:id/contribution-cap', 'patch');
+    probeHandlers = getRouteHandlers(mod.default as any, '/v1/admin/token-credentials/:id/probe', 'post');
+    providerUsageRefreshHandlers = getRouteHandlers(mod.default as any, '/v1/admin/token-credentials/:id/provider-usage-refresh', 'post');
   });
 
   beforeEach(() => {
@@ -1213,6 +1215,39 @@ describe('admin token credential routes idempotent replay', () => {
       expect.any(Object)
     );
     expect(commitSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('reads contribution-cap values for a token credential', async () => {
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'getById').mockResolvedValue({
+      id: '11111111-1111-4111-8111-111111111111',
+      orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      provider: 'anthropic',
+      fiveHourReservePercent: 35,
+      sevenDayReservePercent: 15
+    } as any);
+
+    const req = createMockReq({
+      method: 'GET',
+      path: '/v1/admin/token-credentials/11111111-1111-4111-8111-111111111111/contribution-cap',
+      headers: {
+        authorization: 'Bearer in_admin_token'
+      },
+      params: { id: '11111111-1111-4111-8111-111111111111' }
+    });
+    const res = createMockRes();
+
+    await invoke(contributionCapReadHandlers[0], req, res);
+    await invoke(contributionCapReadHandlers[1], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      id: '11111111-1111-4111-8111-111111111111',
+      provider: 'anthropic',
+      orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      fiveHourReservePercent: 35,
+      sevenDayReservePercent: 15
+    });
   });
 
   it('rejects contribution-cap updates for non-Claude credentials', async () => {

--- a/api/tests/admin.tokenCredentials.route.test.ts
+++ b/api/tests/admin.tokenCredentials.route.test.ts
@@ -1250,6 +1250,39 @@ describe('admin token credential routes idempotent replay', () => {
     });
   });
 
+  it('reads contribution-cap values for a Codex token credential', async () => {
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'getById').mockResolvedValue({
+      id: '22222222-2222-4222-8222-222222222222',
+      orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      provider: 'codex',
+      fiveHourReservePercent: 20,
+      sevenDayReservePercent: 10
+    } as any);
+
+    const req = createMockReq({
+      method: 'GET',
+      path: '/v1/admin/token-credentials/22222222-2222-4222-8222-222222222222/contribution-cap',
+      headers: {
+        authorization: 'Bearer in_admin_token'
+      },
+      params: { id: '22222222-2222-4222-8222-222222222222' }
+    });
+    const res = createMockRes();
+
+    await invoke(contributionCapReadHandlers[0], req, res);
+    await invoke(contributionCapReadHandlers[1], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      id: '22222222-2222-4222-8222-222222222222',
+      provider: 'codex',
+      orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      fiveHourReservePercent: 20,
+      sevenDayReservePercent: 10
+    });
+  });
+
   it('rejects contribution-cap updates for unsupported credentials', async () => {
     vi.spyOn(runtimeModule.runtime.services.idempotency, 'start').mockResolvedValue({
       replay: false,
@@ -1265,7 +1298,7 @@ describe('admin token credential routes idempotent replay', () => {
       new AppError(
         'invalid_request',
         400,
-        'Contribution caps are only supported for Claude and OpenAI token credentials',
+        'Contribution caps are only supported for Claude, OpenAI, and Codex token credentials',
         { credentialId: '11111111-1111-4111-8111-111111111111', provider: 'google' }
       )
     );
@@ -1292,7 +1325,7 @@ describe('admin token credential routes idempotent replay', () => {
     expect(res.statusCode).toBe(400);
     expect((res.body as any)).toMatchObject({
       code: 'invalid_request',
-      message: 'Contribution caps are only supported for Claude and OpenAI token credentials'
+      message: 'Contribution caps are only supported for Claude, OpenAI, and Codex token credentials'
     });
     expect(commitSpy).not.toHaveBeenCalled();
   });
@@ -1350,6 +1383,65 @@ describe('admin token credential routes idempotent replay', () => {
       {
         fiveHourReservePercent: 35,
         sevenDayReservePercent: 15
+      },
+      expect.any(Object)
+    );
+    expect(commitSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('updates contribution-cap values for Codex token credentials', async () => {
+    vi.spyOn(runtimeModule.runtime.services.idempotency, 'start').mockResolvedValue({
+      replay: false,
+      input: {
+        scope: 'admin_token_credentials_contribution_cap_v1',
+        tenantScope: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+        idempotencyKey: 'abcdefghijklmnopqrstuvwxyz123460y',
+        requestHash: 'contribution_cap_h_codex'
+      }
+    } as any);
+
+    const updateSpy = vi.spyOn(runtimeModule.runtime.services.tokenCredentials, 'updateContributionCap').mockResolvedValue({
+      id: '22222222-2222-4222-8222-222222222222',
+      orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      provider: 'codex',
+      fiveHourReservePercent: 20,
+      sevenDayReservePercent: 10
+    } as any);
+    const commitSpy = vi.spyOn(runtimeModule.runtime.services.idempotency, 'commit').mockResolvedValue(undefined);
+
+    const req = createMockReq({
+      method: 'PATCH',
+      path: '/v1/admin/token-credentials/22222222-2222-4222-8222-222222222222/contribution-cap',
+      headers: {
+        authorization: 'Bearer in_admin_token',
+        'content-type': 'application/json',
+        'idempotency-key': 'abcdefghijklmnopqrstuvwxyz123460y'
+      },
+      params: { id: '22222222-2222-4222-8222-222222222222' },
+      body: {
+        fiveHourReservePercent: 20,
+        sevenDayReservePercent: 10
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(contributionCapHandlers[0], req, res);
+    await invoke(contributionCapHandlers[1], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect((res.body as any)).toEqual({
+      ok: true,
+      id: '22222222-2222-4222-8222-222222222222',
+      provider: 'codex',
+      orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      fiveHourReservePercent: 20,
+      sevenDayReservePercent: 10
+    });
+    expect(updateSpy).toHaveBeenCalledWith(
+      '22222222-2222-4222-8222-222222222222',
+      {
+        fiveHourReservePercent: 20,
+        sevenDayReservePercent: 10
       },
       expect.any(Object)
     );

--- a/api/tests/proxy.sellerMode.route.test.ts
+++ b/api/tests/proxy.sellerMode.route.test.ts
@@ -320,4 +320,82 @@ describe('proxy seller-mode route behavior', () => {
       })
     }));
   });
+
+  it('does not meter seller-mode streaming upstream 400 responses', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(
+      "event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"bad request\"}}\n\n",
+      {
+        status: 400,
+        headers: { 'content-type': 'text/event-stream; charset=utf-8' }
+      }
+    ));
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/proxy/v1/messages',
+      headers: {
+        authorization: 'Bearer in_test_token',
+        'content-type': 'application/json',
+        'idempotency-key': 'abcdefghijklmnopqrstuvwxyz123456',
+        'anthropic-version': '2023-06-01'
+      },
+      body: {
+        provider: 'anthropic',
+        model: 'claude-opus-4-6',
+        streaming: true,
+        payload: {
+          model: 'claude-opus-4-6',
+          stream: true,
+          max_tokens: 16,
+          messages: [{ role: 'user', content: 'hello' }]
+        }
+      }
+    });
+    const res = createStreamingMockRes();
+
+    await invoke(handlers[0], req, res);
+    await invoke(handlers[1], req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(runtimeModule.runtime.services.metering.recordUsage).not.toHaveBeenCalled();
+    expect(runtimeModule.runtime.repos.sellerKeys.addCapacityUsage).not.toHaveBeenCalled();
+  });
+
+  it('does not meter seller-mode non-stream upstream 400 responses', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
+      type: 'error',
+      error: { type: 'invalid_request_error', message: 'bad request' }
+    }), {
+      status: 400,
+      headers: { 'content-type': 'application/json' }
+    }));
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/proxy/v1/messages',
+      headers: {
+        authorization: 'Bearer in_test_token',
+        'content-type': 'application/json',
+        'idempotency-key': 'abcdefghijklmnopqrstuvwxyz123456',
+        'anthropic-version': '2023-06-01'
+      },
+      body: {
+        provider: 'anthropic',
+        model: 'claude-opus-4-6',
+        streaming: false,
+        payload: {
+          model: 'claude-opus-4-6',
+          max_tokens: 16,
+          messages: [{ role: 'user', content: 'hello' }]
+        }
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(handlers[0], req, res);
+    await invoke(handlers[1], req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(runtimeModule.runtime.services.metering.recordUsage).not.toHaveBeenCalled();
+  });
 });

--- a/api/tests/proxy.tokenMode.route.test.ts
+++ b/api/tests/proxy.tokenMode.route.test.ts
@@ -649,6 +649,73 @@ describe('proxy token-mode route behavior', () => {
     expect(upstreamSpy).not.toHaveBeenCalled();
   });
 
+  it('excludes reserve-enabled Claude oauth tokens when the provider-usage snapshot is soft stale', async () => {
+    process.env.TOKEN_MODE_ENABLED_ORGS = '818d0cc7-7ed2-469f-b690-a977e72a921d';
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'listActiveForRouting').mockResolvedValue([{
+      id: '11113335-3333-4333-8333-333333333335',
+      orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      provider: 'anthropic',
+      authScheme: 'bearer',
+      accessToken: 'sk-ant-oat01-reserved-soft-stale',
+      refreshToken: null,
+      expiresAt: new Date('2026-03-02T00:00:00Z'),
+      status: 'active',
+      rotationVersion: 1,
+      createdAt: new Date('2026-03-01T00:00:00Z'),
+      updatedAt: new Date('2026-03-01T00:00:00Z'),
+      revokedAt: null,
+      monthlyContributionLimitUnits: null,
+      monthlyContributionUsedUnits: 0,
+      monthlyWindowStartAt: new Date('2026-03-01T00:00:00Z'),
+      fiveHourReservePercent: 20,
+      sevenDayReservePercent: 0
+    } as any]);
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentialProviderUsage, 'listByTokenCredentialIds').mockResolvedValue([{
+      tokenCredentialId: '11113335-3333-4333-8333-333333333335',
+      orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      provider: 'anthropic',
+      usageSource: 'anthropic_oauth_usage',
+      fiveHourUtilizationRatio: 0.2,
+      fiveHourResetsAt: new Date('2026-03-01T05:00:00Z'),
+      sevenDayUtilizationRatio: 0.1,
+      sevenDayResetsAt: new Date('2026-03-08T00:00:00Z'),
+      rawPayload: {},
+      fetchedAt: new Date(Date.now() - (3 * 60 * 1000)),
+      createdAt: new Date('2026-03-01T00:00:00Z'),
+      updatedAt: new Date('2026-03-01T00:00:00Z')
+    } as any]);
+    const upstreamSpy = vi.spyOn(globalThis, 'fetch');
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/proxy/v1/messages',
+      headers: {
+        authorization: 'Bearer in_test_token',
+        'content-type': 'application/json',
+        'idempotency-key': 'abcdefghijklmnopqrstuvwxyz123456',
+        'anthropic-version': '2023-06-01',
+        'x-innies-provider-pin': 'true'
+      },
+      body: {
+        provider: 'anthropic',
+        model: 'claude-3-5-sonnet-latest',
+        streaming: false,
+        payload: { model: 'claude-3-5-sonnet-latest', max_tokens: 16, messages: [{ role: 'user', content: 'hi' }] }
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(handlers[0], req, res);
+    await invoke(handlers[1], req, res);
+
+    expect(res.statusCode).toBe(429);
+    expect((res.body as any).code).toBe('capacity_unavailable');
+    expect((res.body as any).details?.providerUsageExcludedReasonCounts).toEqual({
+      provider_usage_snapshot_soft_stale: 1
+    });
+    expect(upstreamSpy).not.toHaveBeenCalled();
+  });
+
   it('keeps truly 100%-exhausted Claude oauth tokens excluded until reset even when the snapshot is hard stale', async () => {
     process.env.TOKEN_MODE_ENABLED_ORGS = '818d0cc7-7ed2-469f-b690-a977e72a921d';
     vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'listActiveForRouting').mockResolvedValue([{
@@ -2374,6 +2441,89 @@ describe('proxy token-mode route behavior', () => {
     expect((res.body as any).code).toBe('capacity_unavailable');
     expect((res.body as any).details?.providerUsageExcludedReasonCounts).toEqual({
       provider_usage_snapshot_hard_stale: 1
+    });
+    expect(upstreamSpy).not.toHaveBeenCalled();
+  });
+
+  it('excludes reserve-enabled Codex credentials when the provider-usage snapshot is soft stale', async () => {
+    process.env.TOKEN_MODE_ENABLED_ORGS = '818d0cc7-7ed2-469f-b690-a977e72a921d';
+    const oauthToken = createFakeOpenAiOauthToken({ accountId: 'acct_codex_reserved_soft_stale' });
+    vi.spyOn(runtimeModule.runtime.repos.apiKeys, 'findActiveByHash').mockResolvedValue({
+      id: '11111111-1111-4111-8111-111111111111',
+      org_id: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      scope: 'buyer_proxy',
+      is_active: true,
+      expires_at: null,
+      preferred_provider: 'openai'
+    } as any);
+    vi.spyOn(runtimeModule.runtime.repos.modelCompatibility, 'findActive').mockResolvedValue({
+      provider: 'openai',
+      model: 'gpt-5.4',
+      supports_streaming: false
+    } as any);
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'listActiveForRouting').mockResolvedValue([{
+      id: 'dddd2225-0000-4000-8000-000000000000',
+      orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      provider: 'openai',
+      authScheme: 'bearer',
+      accessToken: oauthToken,
+      refreshToken: 'rt_codex_reserved_soft_stale',
+      expiresAt: new Date('2026-03-20T00:00:00Z'),
+      status: 'active',
+      rotationVersion: 1,
+      createdAt: new Date('2026-03-01T00:00:00Z'),
+      updatedAt: new Date('2026-03-01T00:00:00Z'),
+      revokedAt: null,
+      monthlyContributionLimitUnits: null,
+      monthlyContributionUsedUnits: 0,
+      monthlyWindowStartAt: new Date('2026-03-01T00:00:00Z'),
+      fiveHourReservePercent: 20,
+      sevenDayReservePercent: 0
+    } as any]);
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentialProviderUsage, 'listByTokenCredentialIds').mockResolvedValue([{
+      tokenCredentialId: 'dddd2225-0000-4000-8000-000000000000',
+      orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      provider: 'openai',
+      usageSource: 'openai_chatgpt_usage',
+      fiveHourUtilizationRatio: 0.2,
+      fiveHourResetsAt: new Date('2026-03-19T01:00:00.000Z'),
+      sevenDayUtilizationRatio: 0.1,
+      sevenDayResetsAt: new Date('2026-03-22T00:00:00.000Z'),
+      rawPayload: {
+        five_hour: { utilization: 0.2, resets_at: '2026-03-19T01:00:00.000Z' },
+        seven_day: { utilization: 0.1, resets_at: '2026-03-22T00:00:00.000Z' }
+      },
+      fetchedAt: new Date(Date.now() - (3 * 60 * 1000)),
+      createdAt: new Date('2026-03-18T22:31:00.000Z'),
+      updatedAt: new Date('2026-03-18T22:31:00.000Z')
+    } as any]);
+    const upstreamSpy = vi.spyOn(globalThis, 'fetch');
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/proxy/v1/responses',
+      headers: {
+        authorization: 'Bearer in_test_token',
+        'content-type': 'application/json',
+        'idempotency-key': 'abcdefghijklmnopqrstuvwxyz123456',
+        'x-innies-provider-pin': 'true'
+      },
+      body: {
+        provider: 'codex',
+        model: 'gpt-5.4',
+        streaming: false,
+        payload: { model: 'gpt-5.4', input: 'hello' }
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(handlers[0], req, res);
+    await invoke(handlers[1], req, res);
+
+    expect(res.statusCode).toBe(429);
+    expect((res.body as any).code).toBe('capacity_unavailable');
+    expect((res.body as any).details?.providerUsageExcludedReasonCounts).toEqual({
+      provider_usage_snapshot_soft_stale: 1
     });
     expect(upstreamSpy).not.toHaveBeenCalled();
   });

--- a/api/tests/proxy.tokenMode.route.test.ts
+++ b/api/tests/proxy.tokenMode.route.test.ts
@@ -481,6 +481,53 @@ describe('proxy token-mode route behavior', () => {
     expect(listSpy).not.toHaveBeenCalled();
   });
 
+  it('does not meter token-mode non-stream upstream 400 responses', async () => {
+    process.env.TOKEN_MODE_ENABLED_ORGS = '818d0cc7-7ed2-469f-b690-a977e72a921d';
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'listActiveForRouting').mockResolvedValue([
+      createRoutingCredentialFixture({
+        id: 'cred_token_400',
+        provider: 'anthropic',
+        authScheme: 'x_api_key',
+        accessToken: 'sk-ant-token-400'
+      })
+    ]);
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
+      type: 'error',
+      error: { type: 'invalid_request_error', message: 'bad request' }
+    }), {
+      status: 400,
+      headers: { 'content-type': 'application/json' }
+    }));
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/proxy/v1/messages',
+      headers: {
+        authorization: 'Bearer in_test_token',
+        'content-type': 'application/json',
+        'idempotency-key': 'abcdefghijklmnopqrstuvwxyz123456',
+        'anthropic-version': '2023-06-01'
+      },
+      body: {
+        model: 'claude-3-5-sonnet-latest',
+        streaming: false,
+        payload: {
+          model: 'claude-3-5-sonnet-latest',
+          max_tokens: 16,
+          messages: [{ role: 'user', content: 'hello' }]
+        }
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(handlers[0], req, res);
+    await invoke(handlers[1], req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(runtimeModule.runtime.services.metering.recordUsage).not.toHaveBeenCalled();
+    expect(runtimeModule.runtime.repos.tokenCredentials.addMonthlyContributionUsage).not.toHaveBeenCalled();
+  });
+
   it('excludes reserve-enabled Claude oauth tokens until the first provider-usage snapshot lands', async () => {
     process.env.TOKEN_MODE_ENABLED_ORGS = '818d0cc7-7ed2-469f-b690-a977e72a921d';
     vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'listActiveForRouting').mockResolvedValue([{
@@ -1712,6 +1759,61 @@ describe('proxy token-mode route behavior', () => {
       escalationThreshold: 10,
       reason: 'upstream_429_consecutive_rate_limit'
     }));
+    expect(runtimeModule.runtime.services.metering.recordUsage).not.toHaveBeenCalled();
+    upstreamSpy.mockRestore();
+  });
+
+  it('does not meter token-mode non-stream upstream 400 responses', async () => {
+    process.env.TOKEN_MODE_ENABLED_ORGS = '818d0cc7-7ed2-469f-b690-a977e72a921d';
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'listActiveForRouting').mockResolvedValue([{
+      id: 'dddd0000-0000-4000-8000-000000000000',
+      orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      provider: 'anthropic',
+      authScheme: 'bearer',
+      accessToken: 'sk-ant-oat01-test-token',
+      refreshToken: null,
+      expiresAt: new Date('2026-03-02T00:00:00Z'),
+      status: 'active',
+      rotationVersion: 1,
+      createdAt: new Date('2026-03-01T00:00:00Z'),
+      updatedAt: new Date('2026-03-01T00:00:00Z'),
+      revokedAt: null,
+      monthlyContributionLimitUnits: null,
+      monthlyContributionUsedUnits: 0,
+      monthlyWindowStartAt: new Date('2026-03-01T00:00:00Z'),
+      fiveHourReservePercent: 0,
+      sevenDayReservePercent: 0
+    } as any]);
+    const upstreamSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ error: { type: 'invalid_request_error', message: 'bad request' } }), {
+        status: 400,
+        headers: { 'content-type': 'application/json' }
+      })
+    );
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/proxy/v1/messages',
+      headers: {
+        authorization: 'Bearer in_test_token',
+        'content-type': 'application/json',
+        'idempotency-key': 'abcdefghijklmnopqrstuvwxyz123456',
+        'anthropic-version': '2023-06-01'
+      },
+      body: {
+        provider: 'anthropic',
+        model: 'claude-3-5-sonnet-latest',
+        streaming: false,
+        payload: { model: 'claude-3-5-sonnet-latest', max_tokens: 16, messages: [{ role: 'user', content: 'hi' }] }
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(handlers[0], req, res);
+    await invoke(handlers[1], req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(runtimeModule.runtime.services.metering.recordUsage).not.toHaveBeenCalled();
     upstreamSpy.mockRestore();
   });
 
@@ -2921,6 +3023,82 @@ describe('proxy token-mode route behavior', () => {
     upstreamSpy.mockRestore();
   });
 
+  it('does not meter native codex streaming requests when upstream returns 400', async () => {
+    process.env.TOKEN_MODE_ENABLED_ORGS = '818d0cc7-7ed2-469f-b690-a977e72a921d';
+    const oauthToken = createFakeOpenAiOauthToken({
+      accountId: 'acct_codex_stream_400',
+      clientId: 'app_codex_stream_400'
+    });
+
+    vi.spyOn(runtimeModule.runtime.repos.apiKeys, 'findActiveByHash').mockResolvedValue({
+      id: '11111111-1111-4111-8111-111111111111',
+      org_id: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      scope: 'buyer_proxy',
+      is_active: true,
+      expires_at: null,
+      preferred_provider: 'openai'
+    } as any);
+    vi.spyOn(runtimeModule.runtime.repos.modelCompatibility, 'findActive').mockResolvedValue({
+      provider: 'openai',
+      model: 'gpt-5.4',
+      supports_streaming: true
+    } as any);
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'listActiveForRouting').mockResolvedValue([{
+      id: 'dddd1113-4000-4000-8000-000000000000',
+      orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      provider: 'openai',
+      authScheme: 'bearer',
+      accessToken: oauthToken,
+      refreshToken: 'rt_codex_stream_400',
+      expiresAt: new Date('2026-03-02T00:00:00Z'),
+      status: 'active',
+      rotationVersion: 1,
+      createdAt: new Date('2026-03-01T00:00:00Z'),
+      updatedAt: new Date('2026-03-01T00:00:00Z'),
+      revokedAt: null,
+      monthlyContributionLimitUnits: null,
+      monthlyContributionUsedUnits: 0,
+      monthlyWindowStartAt: new Date('2026-03-01T00:00:00Z')
+    } as any]);
+    const upstreamSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({
+        error: {
+          type: 'invalid_request_error',
+          message: 'bad request'
+        }
+      }), {
+        status: 400,
+        headers: { 'content-type': 'application/json' }
+      })
+    );
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/proxy/v1/responses',
+      headers: {
+        authorization: 'Bearer in_test_token',
+        'content-type': 'application/json',
+        'idempotency-key': 'abcdefghijklmnopqrstuvwxyz123456',
+        'x-innies-provider-pin': 'true'
+      },
+      body: {
+        model: 'gpt-5.4',
+        stream: true,
+        instructions: 'Reply with one word only.',
+        input: [{ type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hello' }] }]
+      }
+    });
+    const res = createStreamingMockRes();
+
+    await invoke(handlers[0], req, res);
+    await invoke(handlers[1], req, res);
+
+    expect(res.statusCode).toBeGreaterThanOrEqual(400);
+    expect(runtimeModule.runtime.services.metering.recordUsage).not.toHaveBeenCalled();
+    expect(runtimeModule.runtime.repos.tokenCredentials.addMonthlyContributionUsage).not.toHaveBeenCalled();
+    upstreamSpy.mockRestore();
+  });
+
   it('translates mislabelled upstream codex SSE bodies into anthropic SSE for compat streaming requests', async () => {
     process.env.TOKEN_MODE_ENABLED_ORGS = '818d0cc7-7ed2-469f-b690-a977e72a921d';
     const oauthToken = createFakeOpenAiOauthToken({
@@ -3031,6 +3209,96 @@ describe('proxy token-mode route behavior', () => {
 
     upstreamSpy.mockRestore();
     streamLatencySpy.mockRestore();
+  });
+
+  it('does not meter translated compat streaming requests when upstream returns 400', async () => {
+    process.env.TOKEN_MODE_ENABLED_ORGS = '818d0cc7-7ed2-469f-b690-a977e72a921d';
+    process.env.COMPAT_CODEX_DEFAULT_MODEL = 'gpt-5.4';
+    const oauthToken = createFakeOpenAiOauthToken({
+      accountId: 'acct_codex_stream_compat_400',
+      clientId: 'app_codex_stream_compat_400'
+    });
+
+    vi.spyOn(runtimeModule.runtime.repos.apiKeys, 'findActiveByHash').mockResolvedValue({
+      id: '11111111-1111-4111-8111-111111111111',
+      org_id: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      scope: 'buyer_proxy',
+      is_active: true,
+      expires_at: null,
+      preferred_provider: 'openai'
+    } as any);
+    vi.spyOn(runtimeModule.runtime.repos.modelCompatibility, 'findActive').mockImplementation(async (provider: string, model: string) => {
+      if (provider === 'openai' && model === 'gpt-5.4') {
+        return { provider: 'openai', model: 'gpt-5.4', supports_streaming: true } as any;
+      }
+      if (provider === 'anthropic' && model === 'claude-opus-4-6') {
+        return { provider: 'anthropic', model: 'claude-opus-4-6', supports_streaming: true } as any;
+      }
+      return null as any;
+    });
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'listActiveForRouting').mockImplementation(async (_orgId: string, provider: string) => {
+      if (provider !== 'openai') return [];
+      return [{
+        id: 'dddd1113-compat-4000-8000-000000000000',
+        orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+        provider: 'openai',
+        authScheme: 'bearer',
+        accessToken: oauthToken,
+        refreshToken: 'rt_codex_stream_compat_400',
+        expiresAt: new Date('2026-03-02T00:00:00Z'),
+        status: 'active',
+        rotationVersion: 1,
+        createdAt: new Date('2026-03-01T00:00:00Z'),
+        updatedAt: new Date('2026-03-01T00:00:00Z'),
+        revokedAt: null,
+        monthlyContributionLimitUnits: null,
+        monthlyContributionUsedUnits: 0,
+        monthlyWindowStartAt: new Date('2026-03-01T00:00:00Z')
+      } as any];
+    });
+    const upstreamSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({
+        error: {
+          message: 'bad request',
+          type: 'invalid_request_error'
+        }
+      }), {
+        status: 400,
+        headers: { 'content-type': 'application/json' }
+      })
+    );
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/proxy/v1/messages',
+      headers: {
+        authorization: 'Bearer in_test_token',
+        'content-type': 'application/json',
+        'idempotency-key': 'abcdefghijklmnopqrstuvwxyz123456',
+        'anthropic-version': '2023-06-01'
+      },
+      body: {
+        provider: 'anthropic',
+        model: 'claude-opus-4-6',
+        streaming: true,
+        payload: {
+          model: 'claude-opus-4-6',
+          stream: true,
+          max_tokens: 64,
+          messages: [{ role: 'user', content: 'hi' }]
+        }
+      }
+    });
+    (req as any).inniesCompatMode = true;
+    const res = createStreamingMockRes();
+
+    await invoke(handlers[0], req, res);
+    await invoke(handlers[1], req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(runtimeModule.runtime.services.metering.recordUsage).not.toHaveBeenCalled();
+    expect(runtimeModule.runtime.repos.tokenCredentials.addMonthlyContributionUsage).not.toHaveBeenCalled();
+    upstreamSpy.mockRestore();
   });
 
   it('falls back to anthropic when translated openai compat non-stream responses report response.failed inside a 200 SSE body', async () => {

--- a/api/tests/proxy.tokenMode.route.test.ts
+++ b/api/tests/proxy.tokenMode.route.test.ts
@@ -418,7 +418,22 @@ describe('proxy token-mode route behavior', () => {
     } as any);
     vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'clearRateLimitBackoff').mockResolvedValue(false);
     vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'setProviderUsageWarning').mockResolvedValue(false);
-    vi.spyOn(runtimeModule.runtime.repos.tokenCredentialProviderUsage, 'listByTokenCredentialIds').mockResolvedValue([]);
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentialProviderUsage, 'listByTokenCredentialIds').mockImplementation(async (ids: string[]) => (
+      ids.map((id) => ({
+        tokenCredentialId: id,
+        orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+        provider: 'anthropic',
+        usageSource: 'anthropic_oauth_usage',
+        fiveHourUtilizationRatio: 0.2,
+        fiveHourResetsAt: new Date(Date.now() + (60 * 60 * 1000)),
+        sevenDayUtilizationRatio: 0.1,
+        sevenDayResetsAt: new Date(Date.now() + (24 * 60 * 60 * 1000)),
+        rawPayload: {},
+        fetchedAt: new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date()
+      } as any))
+    ));
     vi.spyOn(runtimeModule.runtime.repos.tokenCredentialProviderUsage, 'upsertSnapshot').mockImplementation(async (input: any) => ({
       tokenCredentialId: input.tokenCredentialId,
       orgId: input.orgId,
@@ -582,6 +597,60 @@ describe('proxy token-mode route behavior', () => {
     expect(upstreamSpy).not.toHaveBeenCalled();
   });
 
+  it('excludes zero-reserve Claude oauth tokens until the first provider-usage snapshot lands', async () => {
+    process.env.TOKEN_MODE_ENABLED_ORGS = '818d0cc7-7ed2-469f-b690-a977e72a921d';
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'listActiveForRouting').mockResolvedValue([{
+      id: '11112223-2222-4222-8222-222222222223',
+      orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      provider: 'anthropic',
+      authScheme: 'bearer',
+      accessToken: 'sk-ant-oat01-zero-reserve-missing',
+      refreshToken: null,
+      expiresAt: new Date('2026-03-02T00:00:00Z'),
+      status: 'active',
+      rotationVersion: 1,
+      createdAt: new Date('2026-03-01T00:00:00Z'),
+      updatedAt: new Date('2026-03-01T00:00:00Z'),
+      revokedAt: null,
+      monthlyContributionLimitUnits: null,
+      monthlyContributionUsedUnits: 0,
+      monthlyWindowStartAt: new Date('2026-03-01T00:00:00Z'),
+      fiveHourReservePercent: 0,
+      sevenDayReservePercent: 0
+    } as any]);
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentialProviderUsage, 'listByTokenCredentialIds').mockResolvedValue([]);
+    const upstreamSpy = vi.spyOn(globalThis, 'fetch');
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/proxy/v1/messages',
+      headers: {
+        authorization: 'Bearer in_test_token',
+        'content-type': 'application/json',
+        'idempotency-key': 'abcdefghijklmnopqrstuvwxyz123456',
+        'anthropic-version': '2023-06-01',
+        'x-innies-provider-pin': 'true'
+      },
+      body: {
+        provider: 'anthropic',
+        model: 'claude-3-5-sonnet-latest',
+        streaming: false,
+        payload: { model: 'claude-3-5-sonnet-latest', max_tokens: 16, messages: [{ role: 'user', content: 'hi' }] }
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(handlers[0], req, res);
+    await invoke(handlers[1], req, res);
+
+    expect(res.statusCode).toBe(429);
+    expect((res.body as any).code).toBe('capacity_unavailable');
+    expect((res.body as any).details?.providerUsageExcludedReasonCounts).toEqual({
+      provider_usage_snapshot_missing: 1
+    });
+    expect(upstreamSpy).not.toHaveBeenCalled();
+  });
+
   it('excludes reserve-enabled Claude oauth tokens when the provider-usage snapshot is hard stale', async () => {
     process.env.TOKEN_MODE_ENABLED_ORGS = '818d0cc7-7ed2-469f-b690-a977e72a921d';
     vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'listActiveForRouting').mockResolvedValue([{
@@ -605,6 +674,73 @@ describe('proxy token-mode route behavior', () => {
     } as any]);
     vi.spyOn(runtimeModule.runtime.repos.tokenCredentialProviderUsage, 'listByTokenCredentialIds').mockResolvedValue([{
       tokenCredentialId: '11113333-3333-4333-8333-333333333333',
+      orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      provider: 'anthropic',
+      usageSource: 'anthropic_oauth_usage',
+      fiveHourUtilizationRatio: 0.2,
+      fiveHourResetsAt: new Date('2026-03-01T05:00:00Z'),
+      sevenDayUtilizationRatio: 0.1,
+      sevenDayResetsAt: new Date('2026-03-08T00:00:00Z'),
+      rawPayload: {},
+      fetchedAt: new Date(Date.now() - (11 * 60 * 1000)),
+      createdAt: new Date('2026-03-01T00:00:00Z'),
+      updatedAt: new Date('2026-03-01T00:00:00Z')
+    } as any]);
+    const upstreamSpy = vi.spyOn(globalThis, 'fetch');
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/proxy/v1/messages',
+      headers: {
+        authorization: 'Bearer in_test_token',
+        'content-type': 'application/json',
+        'idempotency-key': 'abcdefghijklmnopqrstuvwxyz123456',
+        'anthropic-version': '2023-06-01',
+        'x-innies-provider-pin': 'true'
+      },
+      body: {
+        provider: 'anthropic',
+        model: 'claude-3-5-sonnet-latest',
+        streaming: false,
+        payload: { model: 'claude-3-5-sonnet-latest', max_tokens: 16, messages: [{ role: 'user', content: 'hi' }] }
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(handlers[0], req, res);
+    await invoke(handlers[1], req, res);
+
+    expect(res.statusCode).toBe(429);
+    expect((res.body as any).code).toBe('capacity_unavailable');
+    expect((res.body as any).details?.providerUsageExcludedReasonCounts).toEqual({
+      provider_usage_snapshot_hard_stale: 1
+    });
+    expect(upstreamSpy).not.toHaveBeenCalled();
+  });
+
+  it('excludes zero-reserve Claude oauth tokens when the provider-usage snapshot is hard stale', async () => {
+    process.env.TOKEN_MODE_ENABLED_ORGS = '818d0cc7-7ed2-469f-b690-a977e72a921d';
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'listActiveForRouting').mockResolvedValue([{
+      id: '11113336-3333-4333-8333-333333333336',
+      orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      provider: 'anthropic',
+      authScheme: 'bearer',
+      accessToken: 'sk-ant-oat01-zero-reserve-stale',
+      refreshToken: null,
+      expiresAt: new Date('2026-03-02T00:00:00Z'),
+      status: 'active',
+      rotationVersion: 1,
+      createdAt: new Date('2026-03-01T00:00:00Z'),
+      updatedAt: new Date('2026-03-01T00:00:00Z'),
+      revokedAt: null,
+      monthlyContributionLimitUnits: null,
+      monthlyContributionUsedUnits: 0,
+      monthlyWindowStartAt: new Date('2026-03-01T00:00:00Z'),
+      fiveHourReservePercent: 0,
+      sevenDayReservePercent: 0
+    } as any]);
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentialProviderUsage, 'listByTokenCredentialIds').mockResolvedValue([{
+      tokenCredentialId: '11113336-3333-4333-8333-333333333336',
       orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
       provider: 'anthropic',
       usageSource: 'anthropic_oauth_usage',
@@ -904,6 +1040,20 @@ describe('proxy token-mode route behavior', () => {
     ]);
     vi.spyOn(runtimeModule.runtime.repos.tokenCredentialProviderUsage, 'listByTokenCredentialIds').mockResolvedValue([
       {
+        tokenCredentialId: '21114444-4444-4444-8444-444444444444',
+        orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+        provider: 'anthropic',
+        usageSource: 'anthropic_oauth_usage',
+        fiveHourUtilizationRatio: 0.2,
+        fiveHourResetsAt: new Date('2026-03-01T05:00:00Z'),
+        sevenDayUtilizationRatio: 0.1,
+        sevenDayResetsAt: new Date('2026-03-08T00:00:00Z'),
+        rawPayload: {},
+        fetchedAt: new Date(),
+        createdAt: new Date('2026-03-01T00:00:00Z'),
+        updatedAt: new Date('2026-03-01T00:00:00Z')
+      } as any,
+      {
         tokenCredentialId: '31114444-4444-4444-8444-444444444444',
         orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
         provider: 'anthropic',
@@ -1110,7 +1260,14 @@ describe('proxy token-mode route behavior', () => {
     expect(res.statusCode).toBe(429);
     expect((res.body as any).code).toBe('capacity_unavailable');
     expect((res.body as any).details?.providerUsageExcludedReasonCounts).toEqual({
-      claude_repeated_429_local_backoff: 1
+      provider_usage_snapshot_soft_stale: 1
+    });
+    expect((res.body as any).details?.providerUsageExcludedRouteMeta).toMatchObject({
+      '11115555-5555-4555-8555-555555555555': {
+        claudeRepeated429LocalBackoffActive: true,
+        claudeRepeated429RecoveryBlockedBy: 'provider_usage_snapshot_soft_stale',
+        providerUsageSnapshotState: 'soft_stale'
+      }
     });
     expect(upstreamSpy).not.toHaveBeenCalled();
   });
@@ -2362,6 +2519,73 @@ describe('proxy token-mode route behavior', () => {
     expect(upstreamSpy).not.toHaveBeenCalled();
   });
 
+  it('excludes zero-reserve Codex credentials until the first provider-usage snapshot lands', async () => {
+    process.env.TOKEN_MODE_ENABLED_ORGS = '818d0cc7-7ed2-469f-b690-a977e72a921d';
+    const oauthToken = createFakeOpenAiOauthToken({ accountId: 'acct_codex_zero_reserve_missing' });
+    vi.spyOn(runtimeModule.runtime.repos.apiKeys, 'findActiveByHash').mockResolvedValue({
+      id: '11111111-1111-4111-8111-111111111111',
+      org_id: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      scope: 'buyer_proxy',
+      is_active: true,
+      expires_at: null,
+      preferred_provider: 'openai'
+    } as any);
+    vi.spyOn(runtimeModule.runtime.repos.modelCompatibility, 'findActive').mockResolvedValue({
+      provider: 'openai',
+      model: 'gpt-5.4',
+      supports_streaming: false
+    } as any);
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'listActiveForRouting').mockResolvedValue([{
+      id: 'dddd2226-0000-4000-8000-000000000000',
+      orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      provider: 'openai',
+      authScheme: 'bearer',
+      accessToken: oauthToken,
+      refreshToken: 'rt_codex_zero_reserve_missing',
+      expiresAt: new Date('2026-03-20T00:00:00Z'),
+      status: 'active',
+      rotationVersion: 1,
+      createdAt: new Date('2026-03-01T00:00:00Z'),
+      updatedAt: new Date('2026-03-01T00:00:00Z'),
+      revokedAt: null,
+      monthlyContributionLimitUnits: null,
+      monthlyContributionUsedUnits: 0,
+      monthlyWindowStartAt: new Date('2026-03-01T00:00:00Z'),
+      fiveHourReservePercent: 0,
+      sevenDayReservePercent: 0
+    } as any]);
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentialProviderUsage, 'listByTokenCredentialIds').mockResolvedValue([]);
+    const upstreamSpy = vi.spyOn(globalThis, 'fetch');
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/proxy/v1/responses',
+      headers: {
+        authorization: 'Bearer in_test_token',
+        'content-type': 'application/json',
+        'idempotency-key': 'abcdefghijklmnopqrstuvwxyz123456',
+        'x-innies-provider-pin': 'true'
+      },
+      body: {
+        provider: 'codex',
+        model: 'gpt-5.4',
+        streaming: false,
+        payload: { model: 'gpt-5.4', input: 'hello' }
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(handlers[0], req, res);
+    await invoke(handlers[1], req, res);
+
+    expect(res.statusCode).toBe(429);
+    expect((res.body as any).code).toBe('capacity_unavailable');
+    expect((res.body as any).details?.providerUsageExcludedReasonCounts).toEqual({
+      provider_usage_snapshot_missing: 1
+    });
+    expect(upstreamSpy).not.toHaveBeenCalled();
+  });
+
   it('excludes reserve-enabled Codex credentials when the provider-usage snapshot is hard stale', async () => {
     process.env.TOKEN_MODE_ENABLED_ORGS = '818d0cc7-7ed2-469f-b690-a977e72a921d';
     const oauthToken = createFakeOpenAiOauthToken({ accountId: 'acct_codex_reserved_stale' });
@@ -2399,6 +2623,89 @@ describe('proxy token-mode route behavior', () => {
     } as any]);
     vi.spyOn(runtimeModule.runtime.repos.tokenCredentialProviderUsage, 'listByTokenCredentialIds').mockResolvedValue([{
       tokenCredentialId: 'dddd2224-0000-4000-8000-000000000000',
+      orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      provider: 'openai',
+      usageSource: 'openai_chatgpt_usage',
+      fiveHourUtilizationRatio: 0.2,
+      fiveHourResetsAt: new Date('2026-03-19T01:00:00.000Z'),
+      sevenDayUtilizationRatio: 0.1,
+      sevenDayResetsAt: new Date('2026-03-22T00:00:00.000Z'),
+      rawPayload: {
+        five_hour: { utilization: 0.2, resets_at: '2026-03-19T01:00:00.000Z' },
+        seven_day: { utilization: 0.1, resets_at: '2026-03-22T00:00:00.000Z' }
+      },
+      fetchedAt: new Date(Date.now() - (11 * 60 * 1000)),
+      createdAt: new Date('2026-03-18T22:31:00.000Z'),
+      updatedAt: new Date('2026-03-18T22:31:00.000Z')
+    } as any]);
+    const upstreamSpy = vi.spyOn(globalThis, 'fetch');
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/proxy/v1/responses',
+      headers: {
+        authorization: 'Bearer in_test_token',
+        'content-type': 'application/json',
+        'idempotency-key': 'abcdefghijklmnopqrstuvwxyz123456',
+        'x-innies-provider-pin': 'true'
+      },
+      body: {
+        provider: 'codex',
+        model: 'gpt-5.4',
+        streaming: false,
+        payload: { model: 'gpt-5.4', input: 'hello' }
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(handlers[0], req, res);
+    await invoke(handlers[1], req, res);
+
+    expect(res.statusCode).toBe(429);
+    expect((res.body as any).code).toBe('capacity_unavailable');
+    expect((res.body as any).details?.providerUsageExcludedReasonCounts).toEqual({
+      provider_usage_snapshot_hard_stale: 1
+    });
+    expect(upstreamSpy).not.toHaveBeenCalled();
+  });
+
+  it('excludes zero-reserve Codex credentials when the provider-usage snapshot is hard stale', async () => {
+    process.env.TOKEN_MODE_ENABLED_ORGS = '818d0cc7-7ed2-469f-b690-a977e72a921d';
+    const oauthToken = createFakeOpenAiOauthToken({ accountId: 'acct_codex_zero_reserve_stale' });
+    vi.spyOn(runtimeModule.runtime.repos.apiKeys, 'findActiveByHash').mockResolvedValue({
+      id: '11111111-1111-4111-8111-111111111111',
+      org_id: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      scope: 'buyer_proxy',
+      is_active: true,
+      expires_at: null,
+      preferred_provider: 'openai'
+    } as any);
+    vi.spyOn(runtimeModule.runtime.repos.modelCompatibility, 'findActive').mockResolvedValue({
+      provider: 'openai',
+      model: 'gpt-5.4',
+      supports_streaming: false
+    } as any);
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'listActiveForRouting').mockResolvedValue([{
+      id: 'dddd2227-0000-4000-8000-000000000000',
+      orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      provider: 'openai',
+      authScheme: 'bearer',
+      accessToken: oauthToken,
+      refreshToken: 'rt_codex_zero_reserve_stale',
+      expiresAt: new Date('2026-03-20T00:00:00Z'),
+      status: 'active',
+      rotationVersion: 1,
+      createdAt: new Date('2026-03-01T00:00:00Z'),
+      updatedAt: new Date('2026-03-01T00:00:00Z'),
+      revokedAt: null,
+      monthlyContributionLimitUnits: null,
+      monthlyContributionUsedUnits: 0,
+      monthlyWindowStartAt: new Date('2026-03-01T00:00:00Z'),
+      fiveHourReservePercent: 0,
+      sevenDayReservePercent: 0
+    } as any]);
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentialProviderUsage, 'listByTokenCredentialIds').mockResolvedValue([{
+      tokenCredentialId: 'dddd2227-0000-4000-8000-000000000000',
       orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
       provider: 'openai',
       usageSource: 'openai_chatgpt_usage',

--- a/api/tests/proxy.tokenMode.route.test.ts
+++ b/api/tests/proxy.tokenMode.route.test.ts
@@ -2137,7 +2137,7 @@ describe('proxy token-mode route behavior', () => {
     const oauthToken = createFakeOpenAiOauthToken({ accountId: 'acct_codex_exhausted' });
     const exhaustedUntil = new Date(Date.now() + (60 * 60 * 1000));
     const sevenDayResetAt = new Date(Date.now() + (72 * 60 * 60 * 1000));
-    const fetchedAt = new Date(Date.now() - (15 * 60 * 1000));
+    const fetchedAt = new Date(Date.now() - (60 * 1000));
     vi.spyOn(runtimeModule.runtime.repos.apiKeys, 'findActiveByHash').mockResolvedValue({
       id: '11111111-1111-4111-8111-111111111111',
       org_id: '818d0cc7-7ed2-469f-b690-a977e72a921d',
@@ -2228,6 +2228,156 @@ describe('proxy token-mode route behavior', () => {
     expect(upstreamSpy).not.toHaveBeenCalled();
   });
 
+  it('excludes reserve-enabled Codex credentials until the first provider-usage snapshot lands', async () => {
+    process.env.TOKEN_MODE_ENABLED_ORGS = '818d0cc7-7ed2-469f-b690-a977e72a921d';
+    const oauthToken = createFakeOpenAiOauthToken({ accountId: 'acct_codex_reserved_missing' });
+    vi.spyOn(runtimeModule.runtime.repos.apiKeys, 'findActiveByHash').mockResolvedValue({
+      id: '11111111-1111-4111-8111-111111111111',
+      org_id: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      scope: 'buyer_proxy',
+      is_active: true,
+      expires_at: null,
+      preferred_provider: 'openai'
+    } as any);
+    vi.spyOn(runtimeModule.runtime.repos.modelCompatibility, 'findActive').mockResolvedValue({
+      provider: 'openai',
+      model: 'gpt-5.4',
+      supports_streaming: false
+    } as any);
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'listActiveForRouting').mockResolvedValue([{
+      id: 'dddd2223-0000-4000-8000-000000000000',
+      orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      provider: 'openai',
+      authScheme: 'bearer',
+      accessToken: oauthToken,
+      refreshToken: 'rt_codex_reserved_missing',
+      expiresAt: new Date('2026-03-20T00:00:00Z'),
+      status: 'active',
+      rotationVersion: 1,
+      createdAt: new Date('2026-03-01T00:00:00Z'),
+      updatedAt: new Date('2026-03-01T00:00:00Z'),
+      revokedAt: null,
+      monthlyContributionLimitUnits: null,
+      monthlyContributionUsedUnits: 0,
+      monthlyWindowStartAt: new Date('2026-03-01T00:00:00Z'),
+      fiveHourReservePercent: 20,
+      sevenDayReservePercent: 0
+    } as any]);
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentialProviderUsage, 'listByTokenCredentialIds').mockResolvedValue([]);
+    const upstreamSpy = vi.spyOn(globalThis, 'fetch');
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/proxy/v1/responses',
+      headers: {
+        authorization: 'Bearer in_test_token',
+        'content-type': 'application/json',
+        'idempotency-key': 'abcdefghijklmnopqrstuvwxyz123456',
+        'x-innies-provider-pin': 'true'
+      },
+      body: {
+        provider: 'codex',
+        model: 'gpt-5.4',
+        streaming: false,
+        payload: { model: 'gpt-5.4', input: 'hello' }
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(handlers[0], req, res);
+    await invoke(handlers[1], req, res);
+
+    expect(res.statusCode).toBe(429);
+    expect((res.body as any).code).toBe('capacity_unavailable');
+    expect((res.body as any).details?.providerUsageExcludedReasonCounts).toEqual({
+      provider_usage_snapshot_missing: 1
+    });
+    expect(upstreamSpy).not.toHaveBeenCalled();
+  });
+
+  it('excludes reserve-enabled Codex credentials when the provider-usage snapshot is hard stale', async () => {
+    process.env.TOKEN_MODE_ENABLED_ORGS = '818d0cc7-7ed2-469f-b690-a977e72a921d';
+    const oauthToken = createFakeOpenAiOauthToken({ accountId: 'acct_codex_reserved_stale' });
+    vi.spyOn(runtimeModule.runtime.repos.apiKeys, 'findActiveByHash').mockResolvedValue({
+      id: '11111111-1111-4111-8111-111111111111',
+      org_id: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      scope: 'buyer_proxy',
+      is_active: true,
+      expires_at: null,
+      preferred_provider: 'openai'
+    } as any);
+    vi.spyOn(runtimeModule.runtime.repos.modelCompatibility, 'findActive').mockResolvedValue({
+      provider: 'openai',
+      model: 'gpt-5.4',
+      supports_streaming: false
+    } as any);
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'listActiveForRouting').mockResolvedValue([{
+      id: 'dddd2224-0000-4000-8000-000000000000',
+      orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      provider: 'openai',
+      authScheme: 'bearer',
+      accessToken: oauthToken,
+      refreshToken: 'rt_codex_reserved_stale',
+      expiresAt: new Date('2026-03-20T00:00:00Z'),
+      status: 'active',
+      rotationVersion: 1,
+      createdAt: new Date('2026-03-01T00:00:00Z'),
+      updatedAt: new Date('2026-03-01T00:00:00Z'),
+      revokedAt: null,
+      monthlyContributionLimitUnits: null,
+      monthlyContributionUsedUnits: 0,
+      monthlyWindowStartAt: new Date('2026-03-01T00:00:00Z'),
+      fiveHourReservePercent: 20,
+      sevenDayReservePercent: 0
+    } as any]);
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentialProviderUsage, 'listByTokenCredentialIds').mockResolvedValue([{
+      tokenCredentialId: 'dddd2224-0000-4000-8000-000000000000',
+      orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      provider: 'openai',
+      usageSource: 'openai_chatgpt_usage',
+      fiveHourUtilizationRatio: 0.2,
+      fiveHourResetsAt: new Date('2026-03-19T01:00:00.000Z'),
+      sevenDayUtilizationRatio: 0.1,
+      sevenDayResetsAt: new Date('2026-03-22T00:00:00.000Z'),
+      rawPayload: {
+        five_hour: { utilization: 0.2, resets_at: '2026-03-19T01:00:00.000Z' },
+        seven_day: { utilization: 0.1, resets_at: '2026-03-22T00:00:00.000Z' }
+      },
+      fetchedAt: new Date(Date.now() - (11 * 60 * 1000)),
+      createdAt: new Date('2026-03-18T22:31:00.000Z'),
+      updatedAt: new Date('2026-03-18T22:31:00.000Z')
+    } as any]);
+    const upstreamSpy = vi.spyOn(globalThis, 'fetch');
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/proxy/v1/responses',
+      headers: {
+        authorization: 'Bearer in_test_token',
+        'content-type': 'application/json',
+        'idempotency-key': 'abcdefghijklmnopqrstuvwxyz123456',
+        'x-innies-provider-pin': 'true'
+      },
+      body: {
+        provider: 'codex',
+        model: 'gpt-5.4',
+        streaming: false,
+        payload: { model: 'gpt-5.4', input: 'hello' }
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(handlers[0], req, res);
+    await invoke(handlers[1], req, res);
+
+    expect(res.statusCode).toBe(429);
+    expect((res.body as any).code).toBe('capacity_unavailable');
+    expect((res.body as any).details?.providerUsageExcludedReasonCounts).toEqual({
+      provider_usage_snapshot_hard_stale: 1
+    });
+    expect(upstreamSpy).not.toHaveBeenCalled();
+  });
+
   it('keeps healthy Codex credentials routable and records provider-usage routing metadata', async () => {
     process.env.TOKEN_MODE_ENABLED_ORGS = '818d0cc7-7ed2-469f-b690-a977e72a921d';
     const oauthToken = createFakeOpenAiOauthToken({ accountId: 'acct_codex_healthy' });
@@ -2274,7 +2424,7 @@ describe('proxy token-mode route behavior', () => {
         five_hour: { utilization: 0.62, resets_at: '2026-03-19T01:00:00.000Z' },
         seven_day: { utilization: 0.14, resets_at: '2026-03-22T00:00:00.000Z' }
       },
-      fetchedAt: new Date('2026-03-18T22:31:00.000Z'),
+      fetchedAt: new Date(Date.now() - (60 * 1000)),
       createdAt: new Date('2026-03-18T22:31:00.000Z'),
       updatedAt: new Date('2026-03-18T22:31:00.000Z')
     } as any]);
@@ -2530,7 +2680,7 @@ describe('proxy token-mode route behavior', () => {
           secondary_window: { used_percent: 12, reset_at: 1760256000 }
         }
       },
-      fetchedAt: new Date('2026-03-18T22:31:00.000Z'),
+      fetchedAt: new Date(Date.now() - (60 * 1000)),
       createdAt: new Date('2026-03-18T22:31:00.000Z'),
       updatedAt: new Date('2026-03-18T22:31:00.000Z')
     } as any]);
@@ -2586,7 +2736,7 @@ describe('proxy token-mode route behavior', () => {
     const oauthToken = createFakeOpenAiOauthToken({ accountId: 'acct_native_codex_exhausted' });
     const exhaustedUntil = new Date(Date.now() + (60 * 60 * 1000));
     const sevenDayResetAt = new Date(Date.now() + (72 * 60 * 60 * 1000));
-    const fetchedAt = new Date(Date.now() - (15 * 60 * 1000));
+    const fetchedAt = new Date(Date.now() - (60 * 1000));
     vi.spyOn(runtimeModule.runtime.repos.apiKeys, 'findActiveByHash').mockResolvedValue({
       id: '11111111-1111-4111-8111-111111111111',
       org_id: '818d0cc7-7ed2-469f-b690-a977e72a921d',
@@ -2673,6 +2823,102 @@ describe('proxy token-mode route behavior', () => {
         providerUsageExhaustionReason: 'usage_exhausted_5h',
         providerUsageExhaustionHoldActive: true,
         providerUsageExhaustionHoldUntil: exhaustedUntil.toISOString()
+      })
+    );
+    expect(upstreamSpy).not.toHaveBeenCalled();
+  });
+
+  it('benches reserve-constrained legacy codex credentials on native openai responses requests', async () => {
+    process.env.TOKEN_MODE_ENABLED_ORGS = '818d0cc7-7ed2-469f-b690-a977e72a921d';
+    const oauthToken = createFakeOpenAiOauthToken({ accountId: 'acct_native_codex_capped' });
+    const fetchedAt = new Date(Date.now() - (60 * 1000));
+    vi.spyOn(runtimeModule.runtime.repos.apiKeys, 'findActiveByHash').mockResolvedValue({
+      id: '11111111-1111-4111-8111-111111111111',
+      org_id: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      scope: 'buyer_proxy',
+      is_active: true,
+      expires_at: null,
+      preferred_provider: 'openai'
+    } as any);
+    vi.spyOn(runtimeModule.runtime.repos.modelCompatibility, 'findActive').mockResolvedValue({
+      provider: 'openai',
+      model: 'gpt-5.4',
+      supports_streaming: false
+    } as any);
+    const listSpy = vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'listActiveForRouting').mockResolvedValue([{
+      id: 'dddd0004-0000-4000-8000-000000000000',
+      orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      provider: 'codex',
+      authScheme: 'bearer',
+      accessToken: oauthToken,
+      refreshToken: 'rt_native_codex_capped',
+      expiresAt: new Date('2026-03-20T00:00:00Z'),
+      status: 'active',
+      rotationVersion: 1,
+      createdAt: new Date('2026-03-01T00:00:00Z'),
+      updatedAt: new Date('2026-03-01T00:00:00Z'),
+      revokedAt: null,
+      monthlyContributionLimitUnits: null,
+      monthlyContributionUsedUnits: 0,
+      monthlyWindowStartAt: new Date('2026-03-01T00:00:00Z'),
+      fiveHourReservePercent: 20,
+      sevenDayReservePercent: 0
+    } as any]);
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentialProviderUsage, 'listByTokenCredentialIds').mockResolvedValue([{
+      tokenCredentialId: 'dddd0004-0000-4000-8000-000000000000',
+      orgId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      provider: 'codex',
+      usageSource: 'openai_wham_usage',
+      fiveHourUtilizationRatio: 0.8,
+      fiveHourResetsAt: new Date('2026-03-19T01:00:00.000Z'),
+      sevenDayUtilizationRatio: 0.12,
+      sevenDayResetsAt: new Date('2026-03-22T00:00:00.000Z'),
+      rawPayload: {
+        rate_limit: {
+          primary_window: { used_percent: 80, reset_at: 1760000400 },
+          secondary_window: { used_percent: 12, reset_at: 1760256000 }
+        }
+      },
+      fetchedAt,
+      createdAt: fetchedAt,
+      updatedAt: fetchedAt
+    } as any]);
+    const upstreamSpy = vi.spyOn(globalThis, 'fetch');
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/proxy/v1/responses',
+      headers: {
+        authorization: 'Bearer in_test_token',
+        'content-type': 'application/json',
+        'idempotency-key': 'abcdefghijklmnopqrstuvwxyz123456',
+        'x-innies-provider-pin': 'true'
+      },
+      body: {
+        model: 'gpt-5.4',
+        input: 'hello from native openai',
+        stream: false
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(handlers[0], req, res);
+    await invoke(handlers[1], req, res);
+
+    expect(res.statusCode).toBe(429);
+    expect((res.body as any).code).toBe('capacity_unavailable');
+    expect(listSpy).toHaveBeenCalledWith('818d0cc7-7ed2-469f-b690-a977e72a921d', 'openai');
+    expect((res.body as any).details?.providerUsageExcludedReasonCounts).toEqual({
+      contribution_cap_exhausted_5h: 1
+    });
+    expect((res.body as any).details?.providerUsageExcludedRouteMeta?.['dddd0004-0000-4000-8000-000000000000']).toEqual(
+      expect.objectContaining({
+        openaiProviderUsageInScope: true,
+        fiveHourReservePercent: 20,
+        sevenDayReservePercent: 0,
+        fiveHourSharedThresholdPercent: 80,
+        fiveHourContributionCapExhausted: true,
+        providerUsageSnapshotState: 'fresh'
       })
     );
     expect(upstreamSpy).not.toHaveBeenCalled();

--- a/api/tests/rateCardRepository.test.ts
+++ b/api/tests/rateCardRepository.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { RateCardRepository } from '../src/repos/rateCardRepository.js';
+import { MockSqlClient } from './testHelpers.js';
+
+describe('RateCardRepository', () => {
+  it('writes version and line-item rows', async () => {
+    const db = new MockSqlClient({
+      rows: [{ id: 'rate_1', version_key: 'pilot-v1' }],
+      rowCount: 1
+    });
+    const repo = new RateCardRepository(db, () => 'rate_1');
+
+    await repo.createVersion({
+      versionKey: 'pilot-v1',
+      effectiveAt: new Date('2026-03-20T00:00:00.000Z')
+    });
+
+    expect(db.queries[0].sql).toContain('insert into in_rate_card_versions');
+    expect(db.queries[0].params).toContain('pilot-v1');
+  });
+
+  it('resolves the active rate card with exact-model preference over wildcard', async () => {
+    const db = new MockSqlClient({
+      rows: [{
+        rate_card_version_id: 'rate_1',
+        version_key: 'pilot-v1',
+        provider: 'anthropic',
+        model_pattern: 'claude-opus-4-6',
+        routing_mode: 'paid-team-capacity',
+        buyer_debit_minor_per_unit: 3,
+        contributor_earnings_minor_per_unit: 0,
+        currency: 'USD'
+      }],
+      rowCount: 1
+    });
+    const repo = new RateCardRepository(db, () => 'line_1');
+
+    const applied = await repo.resolveAppliedRate({
+      provider: 'anthropic',
+      model: 'claude-opus-4-6',
+      routingMode: 'paid-team-capacity'
+    });
+
+    expect(applied).toEqual({
+      rateCardVersionId: 'rate_1',
+      versionKey: 'pilot-v1',
+      provider: 'anthropic',
+      modelPattern: 'claude-opus-4-6',
+      routingMode: 'paid-team-capacity',
+      buyerDebitMinorPerUnit: 3,
+      contributorEarningsMinorPerUnit: 0,
+      currency: 'USD'
+    });
+    expect(db.queries[0].sql).toContain('join in_rate_card_line_items');
+    expect(db.queries[0].sql).toContain('model_pattern = $4 or i.model_pattern = \'*\'');
+  });
+
+  it('creates versions and line items in one transaction', async () => {
+    const events: string[] = [];
+    const db = new MockSqlClient({ rows: [{ id: 'rate_1' }], rowCount: 1 });
+    db.transaction = async (run) => {
+      events.push('begin');
+      const result = await run({
+        query: async (sql, params) => {
+          events.push(sql.includes('in_rate_card_versions') ? 'version' : 'line_item');
+          return db.query(sql, params);
+        }
+      });
+      events.push('commit');
+      return result;
+    };
+    const repo = new RateCardRepository(db, () => 'rate_1');
+
+    await repo.createVersionWithLineItems({
+      versionKey: 'pilot-v1',
+      effectiveAt: new Date('2026-03-20T00:00:00.000Z'),
+      lineItems: [{
+        provider: 'anthropic',
+        modelPattern: '*',
+        routingMode: 'paid-team-capacity',
+        buyerDebitMinorPerUnit: 3,
+        contributorEarningsMinorPerUnit: 0,
+        currency: 'USD'
+      }]
+    });
+
+    expect(events).toEqual(['begin', 'version', 'line_item', 'commit']);
+  });
+});

--- a/api/tests/routingAttributionRepository.test.ts
+++ b/api/tests/routingAttributionRepository.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { MockSqlClient } from './testHelpers.js';
+import { RoutingAttributionRepository } from '../src/repos/routingAttributionRepository.js';
+
+describe('RoutingAttributionRepository', () => {
+  it('filters org request history to post-cutover rows when requested', async () => {
+    const db = new MockSqlClient({
+      rows: [{
+        request_id: 'req_1',
+        attempt_no: 1,
+        session_id: 'sess_1',
+        admission_org_id: 'org_fnf',
+        admission_cutover_id: 'cut_1',
+        admission_routing_mode: 'self-free',
+        consumer_org_id: 'org_fnf',
+        buyer_key_id: 'buyer_1',
+        serving_org_id: 'org_fnf',
+        provider_account_id: 'acct_1',
+        token_credential_id: 'cred_1',
+        capacity_owner_user_id: 'user_1',
+        provider: 'anthropic',
+        model: 'claude-opus-4-6',
+        rate_card_version_id: 'rate_1',
+        input_tokens: 10,
+        output_tokens: 20,
+        usage_units: 30,
+        buyer_debit_minor: 0,
+        contributor_earnings_minor: 0,
+        currency: 'USD',
+        metadata: { source: 'test' },
+        created_at: '2026-03-20T10:00:00Z',
+        prompt_preview: 'hello',
+        response_preview: 'world',
+        route_decision: { reason: 'preferred_provider_selected' },
+        projector_states: []
+      }],
+      rowCount: 1
+    });
+    const repo = new RoutingAttributionRepository(db);
+
+    const rows = await repo.listOrgRequestHistory({
+      orgId: 'org_fnf',
+      limit: 20,
+      historyScope: 'post_cutover'
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].admission_routing_mode).toBe('self-free');
+    expect(db.queries[0].sql).toContain('cm.admission_cutover_id is not null');
+    expect(db.queries[0].sql).toContain('left join in_routing_events');
+  });
+
+  it('applies cursor filtering using the full sort key', async () => {
+    const db = new MockSqlClient({ rows: [], rowCount: 0 });
+    const repo = new RoutingAttributionRepository(db);
+
+    await repo.listOrgRequestHistory({
+      orgId: 'org_fnf',
+      limit: 20,
+      historyScope: 'post_cutover',
+      cursor: {
+        createdAt: '2026-03-20T10:00:00Z',
+        requestId: 'req_9',
+        attemptNo: 3
+      }
+    });
+
+    expect(db.queries[0].sql).toContain('cm.created_at < $2');
+    expect(db.queries[0].sql).toContain('cm.created_at = $2 and cm.request_id < $3');
+    expect(db.queries[0].sql).toContain('cm.request_id = $3 and cm.attempt_no < $4');
+  });
+
+  it('lists financially unfinalized requests by joining routing events to canonical metering', async () => {
+    const db = new MockSqlClient({
+      rows: [{
+        request_id: 'req_missing',
+        attempt_no: 2,
+        org_id: 'org_fnf',
+        provider: 'openai',
+        model: 'gpt-5-codex',
+        upstream_status: 200,
+        created_at: '2026-03-20T12:00:00Z',
+        route_decision: { reason: 'cli_provider_pinned' }
+      }],
+      rowCount: 1
+    });
+    const repo = new RoutingAttributionRepository(db);
+
+    const rows = await repo.listFinanciallyUnfinalizedRequests(10);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].request_id).toBe('req_missing');
+    expect(db.queries[0].sql).toContain('left join in_canonical_metering_events');
+    expect(db.queries[0].sql).toContain('cm.id is null');
+    expect(db.queries[0].sql).toContain('re.upstream_status < 300');
+  });
+});

--- a/api/tests/runtime.pilotCutoverService.test.ts
+++ b/api/tests/runtime.pilotCutoverService.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 type RuntimeModule = typeof import('../src/services/runtime.js');
 
@@ -11,20 +11,32 @@ describe('runtime pilot cutover service', () => {
     runtimeModule = await import('../src/services/runtime.js');
   });
 
-  it('fails closed when reserve-floor migration is not configured yet', async () => {
-    const adapter = (runtimeModule.runtime.services.pilotCutovers as any).reserveFloorMigration;
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
 
-    await expect(adapter.migrateReserveFloors({
+  it('routes reserve-floor migration through the token credential repository adapter', async () => {
+    const adapter = (runtimeModule.runtime.services.pilotCutovers as any).reserveFloorMigration;
+    const migrate = vi.spyOn(runtimeModule.runtime.repos.tokenCredentials, 'migrateReserveFloors').mockResolvedValue({
+      migratedCount: 1
+    });
+
+    await adapter.migrateReserveFloors({
       db: {},
       fromOrgId: 'org_innies',
       toOrgId: 'org_fnf',
       targetUserId: 'user_darryn',
       cutoverId: 'cut_1',
       actorUserId: null
-    })).rejects.toMatchObject({
-      code: 'service_unavailable',
-      status: 503,
-      message: 'Pilot cutover unavailable until reserve-floor migration adapter is configured'
+    });
+
+    expect(migrate).toHaveBeenCalledWith({
+      db: {},
+      fromOrgId: 'org_innies',
+      toOrgId: 'org_fnf',
+      targetUserId: 'user_darryn',
+      cutoverId: 'cut_1',
+      actorUserId: null
     });
   });
 });

--- a/api/tests/tokenCredentialRepository.test.ts
+++ b/api/tests/tokenCredentialRepository.test.ts
@@ -475,7 +475,7 @@ describe('tokenCredentialRepository', () => {
     expect(db.queries[0].sql).toContain('five_hour_reserve_percent');
     expect(db.queries[0].sql).toContain('seven_day_reserve_percent');
     expect(db.queries[0].sql).toContain('updated_at = now()');
-    expect(db.queries[0].sql).toContain("and provider in ('anthropic', 'openai')");
+    expect(db.queries[0].sql).toContain("and provider in ('anthropic', 'openai', 'codex')");
   });
 
   it('updates reserve fields for OpenAI token credentials without touching other token state', async () => {
@@ -506,7 +506,38 @@ describe('tokenCredentialRepository', () => {
     expect(db.queries[0].sql).toContain('five_hour_reserve_percent');
     expect(db.queries[0].sql).toContain('seven_day_reserve_percent');
     expect(db.queries[0].sql).toContain('updated_at = now()');
-    expect(db.queries[0].sql).toContain("and provider in ('anthropic', 'openai')");
+    expect(db.queries[0].sql).toContain("and provider in ('anthropic', 'openai', 'codex')");
+  });
+
+  it('updates reserve fields for Codex token credentials without touching other token state', async () => {
+    const db = new SequenceSqlClient([{
+      rows: [{
+        id: 'cred_codex_1',
+        org_id: '00000000-0000-0000-0000-000000000001',
+        provider: 'codex',
+        five_hour_reserve_percent: 15,
+        seven_day_reserve_percent: 5
+      }],
+      rowCount: 1
+    }]);
+    const repo = new TokenCredentialRepository(db);
+
+    const updated = await repo.updateContributionCap('cred_codex_1', {
+      fiveHourReservePercent: 15,
+      sevenDayReservePercent: 5
+    });
+
+    expect(updated).toEqual({
+      id: 'cred_codex_1',
+      orgId: '00000000-0000-0000-0000-000000000001',
+      provider: 'codex',
+      fiveHourReservePercent: 15,
+      sevenDayReservePercent: 5
+    });
+    expect(db.queries[0].sql).toContain('five_hour_reserve_percent');
+    expect(db.queries[0].sql).toContain('seven_day_reserve_percent');
+    expect(db.queries[0].sql).toContain('updated_at = now()');
+    expect(db.queries[0].sql).toContain("and provider in ('anthropic', 'openai', 'codex')");
   });
 
   it('updates debug_label without rotating or reviving revoked credentials', async () => {

--- a/api/tests/tokenCredentialRepository.test.ts
+++ b/api/tests/tokenCredentialRepository.test.ts
@@ -475,7 +475,38 @@ describe('tokenCredentialRepository', () => {
     expect(db.queries[0].sql).toContain('five_hour_reserve_percent');
     expect(db.queries[0].sql).toContain('seven_day_reserve_percent');
     expect(db.queries[0].sql).toContain('updated_at = now()');
-    expect(db.queries[0].sql).toContain("and provider = 'anthropic'");
+    expect(db.queries[0].sql).toContain("and provider in ('anthropic', 'openai')");
+  });
+
+  it('updates reserve fields for OpenAI token credentials without touching other token state', async () => {
+    const db = new SequenceSqlClient([{
+      rows: [{
+        id: 'cred_openai_1',
+        org_id: '00000000-0000-0000-0000-000000000001',
+        provider: 'openai',
+        five_hour_reserve_percent: 20,
+        seven_day_reserve_percent: 5
+      }],
+      rowCount: 1
+    }]);
+    const repo = new TokenCredentialRepository(db);
+
+    const updated = await repo.updateContributionCap('cred_openai_1', {
+      fiveHourReservePercent: 20,
+      sevenDayReservePercent: 5
+    });
+
+    expect(updated).toEqual({
+      id: 'cred_openai_1',
+      orgId: '00000000-0000-0000-0000-000000000001',
+      provider: 'openai',
+      fiveHourReservePercent: 20,
+      sevenDayReservePercent: 5
+    });
+    expect(db.queries[0].sql).toContain('five_hour_reserve_percent');
+    expect(db.queries[0].sql).toContain('seven_day_reserve_percent');
+    expect(db.queries[0].sql).toContain('updated_at = now()');
+    expect(db.queries[0].sql).toContain("and provider in ('anthropic', 'openai')");
   });
 
   it('updates debug_label without rotating or reviving revoked credentials', async () => {

--- a/api/tests/tokenCredentialService.test.ts
+++ b/api/tests/tokenCredentialService.test.ts
@@ -105,12 +105,12 @@ describe('tokenCredentialService', () => {
     }));
   });
 
-  it('rejects contribution-cap updates for non-Claude credentials', async () => {
+  it('rejects contribution-cap updates for unsupported credentials', async () => {
     const repo = {
       getById: vi.fn(async () => ({
         id: 'cred_1',
         orgId: 'org_1',
-        provider: 'openai'
+        provider: 'google'
       })),
       updateContributionCap: vi.fn()
     };
@@ -122,10 +122,52 @@ describe('tokenCredentialService', () => {
     })).rejects.toMatchObject<AppError>({
       code: 'invalid_request',
       status: 400,
-      message: 'Contribution caps are only supported for Claude token credentials'
+      message: 'Contribution caps are only supported for Claude and OpenAI token credentials'
     });
     expect(repo.updateContributionCap).not.toHaveBeenCalled();
     expect(createEvent).not.toHaveBeenCalled();
+  });
+
+  it('writes an audit event for OpenAI reserve-floor updates', async () => {
+    const repo = {
+      getById: vi.fn(async () => ({
+        id: 'cred_openai_1',
+        orgId: 'org_1',
+        provider: 'openai'
+      })),
+      updateContributionCap: vi.fn(async () => ({
+        id: 'cred_openai_1',
+        orgId: 'org_1',
+        provider: 'openai',
+        fiveHourReservePercent: 20,
+        sevenDayReservePercent: 5
+      }))
+    };
+    const createEvent = vi.fn(async () => ({ id: 'audit_1' }));
+    const service = new TokenCredentialService(repo as any, { createEvent } as any);
+
+    const updated = await service.updateContributionCap('cred_openai_1', {
+      fiveHourReservePercent: 20,
+      sevenDayReservePercent: 5
+    });
+
+    expect(updated).toEqual({
+      id: 'cred_openai_1',
+      orgId: 'org_1',
+      provider: 'openai',
+      fiveHourReservePercent: 20,
+      sevenDayReservePercent: 5
+    });
+    expect(repo.getById).toHaveBeenCalledWith('cred_openai_1');
+    expect(repo.updateContributionCap).toHaveBeenCalledWith('cred_openai_1', {
+      fiveHourReservePercent: 20,
+      sevenDayReservePercent: 5
+    });
+    expect(createEvent).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'token_credential.update_contribution_cap',
+      targetId: 'cred_openai_1',
+      orgId: 'org_1'
+    }));
   });
 
   it('updates a token credential debug label and writes an audit event', async () => {

--- a/api/tests/tokenCredentialService.test.ts
+++ b/api/tests/tokenCredentialService.test.ts
@@ -122,7 +122,7 @@ describe('tokenCredentialService', () => {
     })).rejects.toMatchObject<AppError>({
       code: 'invalid_request',
       status: 400,
-      message: 'Contribution caps are only supported for Claude and OpenAI token credentials'
+      message: 'Contribution caps are only supported for Claude, OpenAI, and Codex token credentials'
     });
     expect(repo.updateContributionCap).not.toHaveBeenCalled();
     expect(createEvent).not.toHaveBeenCalled();
@@ -166,6 +166,48 @@ describe('tokenCredentialService', () => {
     expect(createEvent).toHaveBeenCalledWith(expect.objectContaining({
       action: 'token_credential.update_contribution_cap',
       targetId: 'cred_openai_1',
+      orgId: 'org_1'
+    }));
+  });
+
+  it('writes an audit event for Codex reserve-floor updates', async () => {
+    const repo = {
+      getById: vi.fn(async () => ({
+        id: 'cred_codex_1',
+        orgId: 'org_1',
+        provider: 'codex'
+      })),
+      updateContributionCap: vi.fn(async () => ({
+        id: 'cred_codex_1',
+        orgId: 'org_1',
+        provider: 'codex',
+        fiveHourReservePercent: 15,
+        sevenDayReservePercent: 5
+      }))
+    };
+    const createEvent = vi.fn(async () => ({ id: 'audit_1' }));
+    const service = new TokenCredentialService(repo as any, { createEvent } as any);
+
+    const updated = await service.updateContributionCap('cred_codex_1', {
+      fiveHourReservePercent: 15,
+      sevenDayReservePercent: 5
+    });
+
+    expect(updated).toEqual({
+      id: 'cred_codex_1',
+      orgId: 'org_1',
+      provider: 'codex',
+      fiveHourReservePercent: 15,
+      sevenDayReservePercent: 5
+    });
+    expect(repo.getById).toHaveBeenCalledWith('cred_codex_1');
+    expect(repo.updateContributionCap).toHaveBeenCalledWith('cred_codex_1', {
+      fiveHourReservePercent: 15,
+      sevenDayReservePercent: 5
+    });
+    expect(createEvent).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'token_credential.update_contribution_cap',
+      targetId: 'cred_codex_1',
       orgId: 'org_1'
     }));
   });

--- a/api/tests/usage.route.test.ts
+++ b/api/tests/usage.route.test.ts
@@ -1,0 +1,270 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { AppError } from '../src/utils/errors.js';
+
+type RuntimeModule = typeof import('../src/services/runtime.js');
+type UsageRouteModule = typeof import('../src/routes/usage.js');
+
+type MockReq = {
+  method: string;
+  path: string;
+  originalUrl: string;
+  body: unknown;
+  params: Record<string, string>;
+  query?: Record<string, string>;
+  auth?: {
+    apiKeyId: string;
+    orgId: string | null;
+    scope: 'buyer_proxy' | 'admin';
+  };
+  header: (name: string) => string | undefined;
+};
+
+type MockRes = {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: unknown;
+  headersSent: boolean;
+  writableEnded: boolean;
+  setHeader: (name: string, value: string) => void;
+  status: (code: number) => MockRes;
+  json: (payload: unknown) => void;
+  send: (payload: unknown) => void;
+};
+
+function createMockReq(input: {
+  method: string;
+  path: string;
+  headers?: Record<string, string>;
+  params?: Record<string, string>;
+  query?: Record<string, string>;
+}): MockReq {
+  const lower = Object.fromEntries(
+    Object.entries(input.headers ?? {}).map(([key, value]) => [key.toLowerCase(), value])
+  );
+  return {
+    method: input.method.toUpperCase(),
+    path: input.path,
+    originalUrl: input.path,
+    body: {},
+    params: input.params ?? {},
+    query: input.query ?? {},
+    header: (name: string) => lower[name.toLowerCase()]
+  };
+}
+
+function createMockRes(): MockRes {
+  return {
+    statusCode: 200,
+    headers: {},
+    body: undefined,
+    headersSent: false,
+    writableEnded: false,
+    setHeader(name: string, value: string) {
+      this.headers[name.toLowerCase()] = value;
+    },
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      this.headersSent = true;
+      this.writableEnded = true;
+    },
+    send(payload: unknown) {
+      this.body = payload;
+      this.headersSent = true;
+      this.writableEnded = true;
+    }
+  };
+}
+
+function applyError(err: unknown, res: MockRes): void {
+  if (err instanceof z.ZodError) {
+    res.status(400).json({ code: 'invalid_request', message: 'Invalid request', issues: err.issues });
+    return;
+  }
+  if (err instanceof AppError) {
+    res.status(err.status).json({ code: err.code, message: err.message, details: err.details });
+    return;
+  }
+  const message = err instanceof Error ? err.message : 'Unexpected error';
+  res.status(500).json({ code: 'internal_error', message });
+}
+
+async function invoke(handle: (req: any, res: any, next: (error?: unknown) => void) => unknown, req: MockReq, res: MockRes): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    let nextCalled = false;
+    const next = (error?: unknown) => {
+      nextCalled = true;
+      if (error) applyError(error, res);
+      resolve();
+    };
+
+    Promise.resolve(handle(req, res, next))
+      .then(() => {
+        if (!nextCalled) resolve();
+      })
+      .catch(reject);
+  });
+}
+
+function getRouteHandlers(router: any, routePath: string, method: 'get'): Array<(req: any, res: any, next: (error?: unknown) => void) => unknown> {
+  const layer = router.stack.find((entry: any) => entry?.route?.path === routePath && entry?.route?.methods?.[method]);
+  if (!layer) throw new Error(`route not found: ${routePath}`);
+  return layer.route.stack.map((entry: any) => entry.handle);
+}
+
+describe('usage routes', () => {
+  let runtimeModule: RuntimeModule;
+  let requestHistoryHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+
+  beforeAll(async () => {
+    process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgres://postgres:postgres@127.0.0.1:5432/innies_test';
+    process.env.SELLER_SECRET_ENC_KEY_B64 = process.env.SELLER_SECRET_ENC_KEY_B64 || Buffer.alloc(32, 7).toString('base64');
+    runtimeModule = await import('../src/services/runtime.js');
+    const mod = await import('../src/routes/usage.js') as UsageRouteModule;
+    requestHistoryHandlers = getRouteHandlers(mod.default as any, '/v1/usage/me/requests', 'get');
+  });
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(runtimeModule.runtime.repos.apiKeys, 'findActiveByHash').mockResolvedValue({
+      id: '11111111-1111-4111-8111-111111111111',
+      org_id: 'org_fnf',
+      scope: 'buyer_proxy',
+      is_active: true,
+      expires_at: null
+    } as any);
+    vi.spyOn(runtimeModule.runtime.repos.apiKeys, 'touchLastUsed').mockResolvedValue(undefined);
+    vi.spyOn(runtimeModule.runtime.repos.routingAttribution, 'listOrgRequestHistory').mockResolvedValue([{
+      request_id: 'req_1',
+      attempt_no: 1,
+      session_id: 'sess_1',
+      admission_org_id: 'org_fnf',
+      admission_cutover_id: 'cut_1',
+      admission_routing_mode: 'self-free',
+      consumer_org_id: 'org_fnf',
+      buyer_key_id: 'buyer_1',
+      serving_org_id: 'org_fnf',
+      provider_account_id: 'acct_1',
+      token_credential_id: 'cred_1',
+      capacity_owner_user_id: 'user_1',
+      provider: 'anthropic',
+      model: 'claude-opus-4-6',
+      rate_card_version_id: 'rate_1',
+      input_tokens: 11,
+      output_tokens: 22,
+      usage_units: 33,
+      buyer_debit_minor: 0,
+      contributor_earnings_minor: 0,
+      currency: 'USD',
+      metadata: null,
+      created_at: '2026-03-20T10:00:00.000Z',
+      prompt_preview: 'hello',
+      response_preview: 'world',
+      route_decision: { reason: 'cli_provider_pinned' },
+      projector_states: []
+    }] as any);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns post-cutover request history for the caller org', async () => {
+    const req = createMockReq({
+      method: 'GET',
+      path: '/v1/usage/me/requests',
+      headers: {
+        authorization: 'Bearer in_buyer_token'
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(requestHistoryHandlers[0], req, res);
+    await invoke(requestHistoryHandlers[1], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(expect.objectContaining({
+      orgId: 'org_fnf',
+      requests: [expect.objectContaining({ request_id: 'req_1' })],
+      nextCursor: null
+    }));
+    expect(runtimeModule.runtime.repos.routingAttribution.listOrgRequestHistory).toHaveBeenCalledWith({
+      orgId: 'org_fnf',
+      limit: 20,
+      cursor: null,
+      historyScope: 'post_cutover'
+    });
+  });
+
+  it('accepts and emits full request-history cursors', async () => {
+    const decodedCursor = {
+      createdAt: '2026-03-19T09:00:00.000Z',
+      requestId: 'req_8',
+      attemptNo: 2
+    };
+    const encodedCursor = Buffer.from(JSON.stringify(decodedCursor), 'utf8').toString('base64url');
+    vi.spyOn(runtimeModule.runtime.repos.routingAttribution, 'listOrgRequestHistory').mockResolvedValue([{
+      request_id: 'req_9',
+      attempt_no: 3,
+      session_id: 'sess_1',
+      admission_org_id: 'org_fnf',
+      admission_cutover_id: 'cut_1',
+      admission_routing_mode: 'self-free',
+      consumer_org_id: 'org_fnf',
+      buyer_key_id: 'buyer_1',
+      serving_org_id: 'org_fnf',
+      provider_account_id: 'acct_1',
+      token_credential_id: 'cred_1',
+      capacity_owner_user_id: 'user_1',
+      provider: 'anthropic',
+      model: 'claude-opus-4-6',
+      rate_card_version_id: 'rate_1',
+      input_tokens: 11,
+      output_tokens: 22,
+      usage_units: 33,
+      buyer_debit_minor: 0,
+      contributor_earnings_minor: 0,
+      currency: 'USD',
+      metadata: null,
+      created_at: '2026-03-20T10:00:00.000Z',
+      prompt_preview: 'hello',
+      response_preview: 'world',
+      route_decision: { reason: 'cli_provider_pinned' },
+      projector_states: []
+    }] as any);
+
+    const req = createMockReq({
+      method: 'GET',
+      path: '/v1/usage/me/requests',
+      headers: {
+        authorization: 'Bearer in_buyer_token'
+      },
+      query: {
+        limit: '1',
+        cursor: encodedCursor
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(requestHistoryHandlers[0], req, res);
+    await invoke(requestHistoryHandlers[1], req, res);
+
+    expect(runtimeModule.runtime.repos.routingAttribution.listOrgRequestHistory).toHaveBeenCalledWith({
+      orgId: 'org_fnf',
+      limit: 1,
+      cursor: decodedCursor,
+      historyScope: 'post_cutover'
+    });
+    expect(res.body).toEqual(expect.objectContaining({
+      nextCursor: Buffer.from(JSON.stringify({
+        createdAt: '2026-03-20T10:00:00.000Z',
+        requestId: 'req_9',
+        attemptNo: 3
+      }), 'utf8').toString('base64url')
+    }));
+  });
+});

--- a/api/tests/usageMeteringWriter.test.ts
+++ b/api/tests/usageMeteringWriter.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from 'vitest';
+import { CanonicalMeteringRepository } from '../src/repos/canonicalMeteringRepository.js';
+import { MeteringProjectorStateRepository } from '../src/repos/meteringProjectorStateRepository.js';
+import { RateCardRepository } from '../src/repos/rateCardRepository.js';
 import { UsageLedgerRepository } from '../src/repos/usageLedgerRepository.js';
 import { UsageMeteringWriter } from '../src/services/metering/usageMeteringWriter.js';
 import { MockSqlClient } from './testHelpers.js';
@@ -21,7 +24,7 @@ describe('UsageMeteringWriter', () => {
   it('writes primary usage rows', async () => {
     const db = new MockSqlClient({ rows: [{ id: 'usage_1' }], rowCount: 1 });
     const repo = new UsageLedgerRepository(db);
-    const writer = new UsageMeteringWriter(repo);
+    const writer = new UsageMeteringWriter({ usageLedgerRepo: repo });
 
     await writer.recordUsage(sampleEvent);
 
@@ -33,7 +36,7 @@ describe('UsageMeteringWriter', () => {
   it('writes correction and reversal rows with source_event_id', async () => {
     const db = new MockSqlClient({ rows: [{ id: 'usage_2' }], rowCount: 1 });
     const repo = new UsageLedgerRepository(db);
-    const writer = new UsageMeteringWriter(repo);
+    const writer = new UsageMeteringWriter({ usageLedgerRepo: repo });
 
     await writer.recordCorrection('orig_1', sampleEvent, 'meter correction');
     await writer.recordReversal('orig_1', sampleEvent, 'full reversal');
@@ -43,5 +46,40 @@ describe('UsageMeteringWriter', () => {
     expect(db.queries[0].params?.[14]).toBe('orig_1');
     expect(db.queries[1].params?.[1]).toBe('reversal');
     expect(db.queries[1].params?.[14]).toBe('orig_1');
+  });
+
+  it('dual-writes canonical metering when routing mode and rate card are known', async () => {
+    const usageDb = new MockSqlClient({ rows: [{ id: 'usage_3', entry_type: 'usage' }], rowCount: 1 });
+    const canonicalDb = new MockSqlClient({ rows: [{ id: 'meter_1' }], rowCount: 1 });
+    const projectorDb = new MockSqlClient({ rows: [{ metering_event_id: 'meter_1', projector: 'wallet' }], rowCount: 1 });
+    const writer = new UsageMeteringWriter({
+      usageLedgerRepo: new UsageLedgerRepository(usageDb),
+      canonicalMeteringRepo: new CanonicalMeteringRepository(canonicalDb, () => 'meter_1'),
+      meteringProjectorStateRepo: new MeteringProjectorStateRepository(projectorDb),
+      rateCardRepo: {
+        resolveAppliedRate: async () => ({
+          rateCardVersionId: 'rate_1',
+          versionKey: 'pilot-v1',
+          provider: 'anthropic',
+          modelPattern: 'claude-sonnet',
+          routingMode: 'paid-team-capacity',
+          buyerDebitMinorPerUnit: 2,
+          contributorEarningsMinorPerUnit: 0,
+          currency: 'USD'
+        })
+      } as unknown as RateCardRepository
+    });
+
+    await writer.recordUsage({
+      ...sampleEvent,
+      admissionRoutingMode: 'paid-team-capacity'
+    });
+
+    expect(canonicalDb.queries).toHaveLength(1);
+    expect(canonicalDb.queries[0].sql).toContain('insert into in_canonical_metering_events');
+    expect(canonicalDb.queries[0].params).toContain('paid-team-capacity');
+    expect(canonicalDb.queries[0].params).toContain('rate_1');
+    expect(projectorDb.queries).toHaveLength(1);
+    expect(projectorDb.queries[0].params).toContain('wallet');
   });
 });

--- a/docs/migrations/019_darryn_routing_metering.sql
+++ b/docs/migrations/019_darryn_routing_metering.sql
@@ -1,0 +1,51 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS in_rate_card_line_items (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  rate_card_version_id uuid NOT NULL REFERENCES in_rate_card_versions(id) ON DELETE CASCADE,
+  provider text NOT NULL,
+  model_pattern text NOT NULL,
+  routing_mode in_routing_mode NOT NULL,
+  buyer_debit_minor_per_unit bigint NOT NULL DEFAULT 0,
+  contributor_earnings_minor_per_unit bigint NOT NULL DEFAULT 0,
+  currency char(3) NOT NULL DEFAULT 'USD',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (rate_card_version_id, provider, model_pattern, routing_mode)
+);
+
+CREATE INDEX IF NOT EXISTS idx_in_rate_card_line_items_lookup
+  ON in_rate_card_line_items (rate_card_version_id, provider, routing_mode, model_pattern);
+
+INSERT INTO in_rate_card_versions (
+  id,
+  version_key,
+  effective_at,
+  created_at
+) VALUES (
+  '01901901-9019-4019-8019-019019019019',
+  'phase2-bootstrap',
+  '2026-03-20T00:00:00Z',
+  now()
+)
+ON CONFLICT (version_key) DO NOTHING;
+
+INSERT INTO in_rate_card_line_items (
+  id,
+  rate_card_version_id,
+  provider,
+  model_pattern,
+  routing_mode,
+  buyer_debit_minor_per_unit,
+  contributor_earnings_minor_per_unit,
+  currency,
+  created_at
+) VALUES
+  ('01901911-9019-4019-8019-019019019011', '01901901-9019-4019-8019-019019019019', 'anthropic', '*', 'self-free', 0, 0, 'USD', now()),
+  ('01901912-9019-4019-8019-019019019012', '01901901-9019-4019-8019-019019019019', 'anthropic', '*', 'paid-team-capacity', 0, 0, 'USD', now()),
+  ('01901913-9019-4019-8019-019019019013', '01901901-9019-4019-8019-019019019019', 'anthropic', '*', 'team-overflow-on-contributor-capacity', 0, 0, 'USD', now()),
+  ('01901921-9019-4019-8019-019019019021', '01901901-9019-4019-8019-019019019019', 'openai', '*', 'self-free', 0, 0, 'USD', now()),
+  ('01901922-9019-4019-8019-019019019022', '01901901-9019-4019-8019-019019019019', 'openai', '*', 'paid-team-capacity', 0, 0, 'USD', now()),
+  ('01901923-9019-4019-8019-019019019023', '01901901-9019-4019-8019-019019019019', 'openai', '*', 'team-overflow-on-contributor-capacity', 0, 0, 'USD', now())
+ON CONFLICT (rate_card_version_id, provider, model_pattern, routing_mode) DO NOTHING;
+
+COMMIT;

--- a/docs/migrations/019_darryn_routing_metering_no_extensions.sql
+++ b/docs/migrations/019_darryn_routing_metering_no_extensions.sql
@@ -1,0 +1,51 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS in_rate_card_line_items (
+  id uuid PRIMARY KEY,
+  rate_card_version_id uuid NOT NULL REFERENCES in_rate_card_versions(id) ON DELETE CASCADE,
+  provider text NOT NULL,
+  model_pattern text NOT NULL,
+  routing_mode in_routing_mode NOT NULL,
+  buyer_debit_minor_per_unit bigint NOT NULL DEFAULT 0,
+  contributor_earnings_minor_per_unit bigint NOT NULL DEFAULT 0,
+  currency char(3) NOT NULL DEFAULT 'USD',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (rate_card_version_id, provider, model_pattern, routing_mode)
+);
+
+CREATE INDEX IF NOT EXISTS idx_in_rate_card_line_items_lookup
+  ON in_rate_card_line_items (rate_card_version_id, provider, routing_mode, model_pattern);
+
+INSERT INTO in_rate_card_versions (
+  id,
+  version_key,
+  effective_at,
+  created_at
+) VALUES (
+  '01901901-9019-4019-8019-019019019019',
+  'phase2-bootstrap',
+  '2026-03-20T00:00:00Z',
+  now()
+)
+ON CONFLICT (version_key) DO NOTHING;
+
+INSERT INTO in_rate_card_line_items (
+  id,
+  rate_card_version_id,
+  provider,
+  model_pattern,
+  routing_mode,
+  buyer_debit_minor_per_unit,
+  contributor_earnings_minor_per_unit,
+  currency,
+  created_at
+) VALUES
+  ('01901911-9019-4019-8019-019019019011', '01901901-9019-4019-8019-019019019019', 'anthropic', '*', 'self-free', 0, 0, 'USD', now()),
+  ('01901912-9019-4019-8019-019019019012', '01901901-9019-4019-8019-019019019019', 'anthropic', '*', 'paid-team-capacity', 0, 0, 'USD', now()),
+  ('01901913-9019-4019-8019-019019019013', '01901901-9019-4019-8019-019019019019', 'anthropic', '*', 'team-overflow-on-contributor-capacity', 0, 0, 'USD', now()),
+  ('01901921-9019-4019-8019-019019019021', '01901901-9019-4019-8019-019019019019', 'openai', '*', 'self-free', 0, 0, 'USD', now()),
+  ('01901922-9019-4019-8019-019019019022', '01901901-9019-4019-8019-019019019019', 'openai', '*', 'paid-team-capacity', 0, 0, 'USD', now()),
+  ('01901923-9019-4019-8019-019019019023', '01901901-9019-4019-8019-019019019019', 'openai', '*', 'team-overflow-on-contributor-capacity', 0, 0, 'USD', now())
+ON CONFLICT (rate_card_version_id, provider, model_pattern, routing_mode) DO NOTHING;
+
+COMMIT;

--- a/docs/superpowers/plans/2026-03-20-darryn-phase2-routing-metering-implementation.md
+++ b/docs/superpowers/plans/2026-03-20-darryn-phase2-routing-metering-implementation.md
@@ -1,0 +1,332 @@
+# Routing And Canonical Metering Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the Darryn Phase 2 routing-and-canonical-metering workstream without touching pilot auth, cutover routes, or the merged cutover/access migration slice.
+
+**Architecture:** Keep the cutover/access seam intact and replace the current raw `usageLedger` request-finalization writes with canonical metering finalization that persists routing mode, admission-time attribution, applied rate-card version, and derived financial amounts per finalized request. Expose routing/metering reads through existing `admin.ts` and `usage.ts` route seams, keep reserve-floor storage on token credentials, and wire the cutover reserve-floor migration helper only through `runtime.ts`.
+
+**Tech Stack:** TypeScript, Express, Postgres repositories, Vitest, npm build
+
+---
+
+## Locked Interfaces
+
+### Request-history APIs
+
+- `GET /v1/usage/me/requests?limit=<1-100>&cursor=<opaque>`
+  - Auth: `buyer_proxy` or `admin`
+  - Scope: caller org only
+  - Darryn-facing visibility: post-cutover requests only
+  - Returns: request id, attempt no, admitted at/finalized at, session id, provider, model, `admission_routing_mode`, serving org, token credential id, rate-card version id, buyer debit minor, contributor earnings minor, request preview metadata, routing explanation summary
+
+- `GET /v1/admin/requests?consumerOrgId=<uuid>&limit=<1-100>&cursor=<opaque>&historyScope=<post_cutover|all>`
+  - Auth: `admin`
+  - Scope: admin support view
+  - `historyScope=post_cutover` matches Darryn-facing slice
+  - `historyScope=all` may include pre-cutover internal history for admin-only troubleshooting
+
+- `GET /v1/admin/requests/:requestId/explanation`
+  - Auth: `admin`
+  - Returns: canonical metering row, routing event metadata, reserve-floor/provider-usage exclusion reasons when present, why the request was `self-free` vs `paid-team-capacity` vs `team-overflow-on-contributor-capacity`, and whether wallet/earnings projections remain financially unfinalized
+
+- `POST /v1/admin/metering/corrections`
+  - Auth: `admin`
+  - Purpose: operator correction intake for financially unfinalized or mis-finalized requests
+  - Payload supports `served_request_retry`, `correction`, and `reversal` actions with actor/reason metadata
+
+### Reserve-floor contract
+
+- Storage remains on `in_token_credentials.five_hour_reserve_percent` and `in_token_credentials.seven_day_reserve_percent`
+- Routing enforcement remains provider-aware and fail-closed for sold contributor work when provider-usage signals are missing, stale, or below the configured floor
+- Read API:
+  - `GET /v1/admin/token-credentials/:id/contribution-cap`
+- Write API:
+  - existing `PATCH /v1/admin/token-credentials/:id/contribution-cap`
+- Cutover helper:
+  - `tokenCredentialRepository.migrateReserveFloors({ fromOrgId, toOrgId, cutoverId })`
+  - wired into `PilotCutoverService` only through the existing `runtime.ts` adapter
+
+### Rate-card contract
+
+- Add admin-managed immutable rate-card line items keyed by `(rate_card_version_id, provider, model_pattern, routing_mode)`
+- Canonical metering finalization must persist:
+  - `rate_card_version_id`
+  - derived `buyer_debit_minor`
+  - derived `contributor_earnings_minor`
+- `self-free` requests still write canonical metering with zero debit and zero earnings
+
+### File map
+
+- Modify: `api/src/routes/admin.ts`
+- Modify: `api/src/routes/proxy.ts`
+- Modify: `api/src/routes/usage.ts`
+- Modify: `api/src/services/runtime.ts`
+- Modify: `api/src/services/routingService.ts`
+- Modify: `api/src/services/routerEngine.ts`
+- Modify: `api/src/services/metering/usageMeteringWriter.ts`
+- Modify: `api/src/repos/canonicalMeteringRepository.ts`
+- Modify: `api/src/repos/meteringProjectorStateRepository.ts`
+- Modify: `api/src/repos/requestLogRepository.ts`
+- Modify: `api/src/repos/routingEventsRepository.ts`
+- Modify: `api/src/repos/tableNames.ts`
+- Modify: `api/src/repos/tokenCredentialRepository.ts`
+- Modify: `api/src/types/phase2Contracts.ts`
+- Create: `api/src/repos/rateCardRepository.ts`
+- Create: `api/src/repos/routingAttributionRepository.ts`
+- Create: `api/tests/rateCardRepository.test.ts`
+- Create: `api/tests/routingAttributionRepository.test.ts`
+- Create: `api/tests/usage.route.test.ts`
+- Modify: `api/tests/admin.pilot.route.test.ts`
+- Modify: `api/tests/canonicalMeteringRepository.test.ts`
+- Modify: `api/tests/routingService.test.ts`
+- Modify: `api/tests/proxy.sellerMode.route.test.ts`
+- Modify: `api/tests/proxy.tokenMode.route.test.ts`
+- Create: `docs/migrations/019_darryn_routing_metering.sql`
+- Create: `docs/migrations/019_darryn_routing_metering_no_extensions.sql`
+
+## Chunk 1: Persistence Contracts
+
+### Task 1: Add routing/metering schema and repository coverage
+
+**Files:**
+- Create: `docs/migrations/019_darryn_routing_metering.sql`
+- Create: `docs/migrations/019_darryn_routing_metering_no_extensions.sql`
+- Modify: `api/src/repos/tableNames.ts`
+- Modify: `api/src/repos/canonicalMeteringRepository.ts`
+- Modify: `api/src/repos/meteringProjectorStateRepository.ts`
+- Create: `api/src/repos/rateCardRepository.ts`
+- Create: `api/src/repos/routingAttributionRepository.ts`
+- Modify: `api/src/repos/requestLogRepository.ts`
+- Modify: `api/src/repos/routingEventsRepository.ts`
+- Test: `api/tests/canonicalMeteringRepository.test.ts`
+- Test: `api/tests/meteringProjectorStateRepository.test.ts`
+- Test: `api/tests/rateCardRepository.test.ts`
+- Test: `api/tests/routingAttributionRepository.test.ts`
+
+- [ ] **Step 1: Write the failing repository tests**
+
+Add tests for:
+- canonical metering query/list methods that drive request history and explanation reads
+- rate-card version activation and line-item lookup
+- financially unfinalized request detection when a successful routed request lacks canonical metering
+- admin/post-cutover filtering in request-history queries
+
+- [ ] **Step 2: Run the targeted failing tests**
+
+Run:
+```bash
+cd api && npm test -- canonicalMeteringRepository.test.ts meteringProjectorStateRepository.test.ts rateCardRepository.test.ts routingAttributionRepository.test.ts
+```
+
+Expected: FAIL with missing tables, missing repository methods, or missing query behavior
+
+- [ ] **Step 3: Add the migration and minimal repository implementation**
+
+Implement:
+- rate-card line-item tables and indexes
+- retry bookkeeping table/index support needed for missing-metering scans if existing projector-state columns are insufficient
+- repository methods to:
+  - read active rate-card version and line items
+  - persist/read canonical metering history by org/request
+  - list financially unfinalized finalized requests
+  - join canonical metering + routing events + request previews for admin explanations
+
+- [ ] **Step 4: Re-run the targeted repository tests**
+
+Run:
+```bash
+cd api && npm test -- canonicalMeteringRepository.test.ts meteringProjectorStateRepository.test.ts rateCardRepository.test.ts routingAttributionRepository.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/migrations/019_darryn_routing_metering.sql docs/migrations/019_darryn_routing_metering_no_extensions.sql api/src/repos/tableNames.ts api/src/repos/canonicalMeteringRepository.ts api/src/repos/meteringProjectorStateRepository.ts api/src/repos/requestLogRepository.ts api/src/repos/routingEventsRepository.ts api/src/repos/rateCardRepository.ts api/src/repos/routingAttributionRepository.ts api/tests/canonicalMeteringRepository.test.ts api/tests/meteringProjectorStateRepository.test.ts api/tests/rateCardRepository.test.ts api/tests/routingAttributionRepository.test.ts
+git commit -m "feat: add routing metering persistence"
+```
+
+## Chunk 2: Finalization And Routing Classification
+
+### Task 2: Convert finalized requests to canonical metering
+
+**Files:**
+- Modify: `api/src/services/metering/usageMeteringWriter.ts`
+- Modify: `api/src/services/runtime.ts`
+- Modify: `api/src/services/routingService.ts`
+- Modify: `api/src/services/routerEngine.ts`
+- Modify: `api/src/routes/proxy.ts`
+- Modify: `api/src/types/phase2Contracts.ts`
+- Modify: `api/src/repos/tokenCredentialRepository.ts`
+- Test: `api/tests/usageMeteringWriter.test.ts`
+- Test: `api/tests/routingService.test.ts`
+- Test: `api/tests/proxy.sellerMode.route.test.ts`
+- Test: `api/tests/proxy.tokenMode.route.test.ts`
+
+- [ ] **Step 1: Write the failing behavior tests**
+
+Add tests for:
+- `self-free` canonical metering on user-owned token-credential traffic
+- `paid-team-capacity` canonical metering on team-capacity admissions
+- `team-overflow-on-contributor-capacity` canonical metering on internal traffic served by user-contributed capacity
+- lane isolation: `innies claude` never spills into OpenAI/Codex, `innies codex` never spills into Claude
+- missing/stale reserve-floor provider signals failing closed for sold contributor capacity
+- reserve-floor migration helper moving contribution-cap values during cutover adapter invocation
+
+- [ ] **Step 2: Run the failing behavior tests**
+
+Run:
+```bash
+cd api && npm test -- usageMeteringWriter.test.ts routingService.test.ts proxy.sellerMode.route.test.ts proxy.tokenMode.route.test.ts
+```
+
+Expected: FAIL because canonical metering finalization, route-mode classification, lane-isolation assertions, and reserve-floor migration helper are not implemented yet
+
+- [ ] **Step 3: Implement the minimal runtime seam**
+
+Implement:
+- `UsageMeteringWriter` as the canonical metering writer instead of the old `usageLedger` wrapper
+- request-finalization input carrying:
+  - `admission_org_id`
+  - `admission_cutover_id`
+  - `admission_routing_mode`
+  - serving org/credential attribution
+  - applied `rate_card_version_id`
+  - derived debit/earnings amounts
+- `proxy.ts` updates so every finalized pilot-mode request writes exactly one canonical metering event
+- `runtime.ts` wiring for:
+  - rate-card repo
+  - routing attribution repo
+  - reserve-floor migration adapter for cutover service
+- narrow `routingService.ts` / `routerEngine.ts` changes only where needed to expose the locked routing modes and lane-isolation reasons
+
+- [ ] **Step 4: Re-run the behavior tests**
+
+Run:
+```bash
+cd api && npm test -- usageMeteringWriter.test.ts routingService.test.ts proxy.sellerMode.route.test.ts proxy.tokenMode.route.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/src/services/metering/usageMeteringWriter.ts api/src/services/runtime.ts api/src/services/routingService.ts api/src/services/routerEngine.ts api/src/routes/proxy.ts api/src/types/phase2Contracts.ts api/src/repos/tokenCredentialRepository.ts api/tests/usageMeteringWriter.test.ts api/tests/routingService.test.ts api/tests/proxy.sellerMode.route.test.ts api/tests/proxy.tokenMode.route.test.ts
+git commit -m "feat: finalize canonical routing metering"
+```
+
+## Chunk 3: Read APIs, Corrections, And Reserve-Floor Reads
+
+### Task 3: Expose request history, admin explanations, and operator correction intake
+
+**Files:**
+- Modify: `api/src/routes/admin.ts`
+- Modify: `api/src/routes/usage.ts`
+- Modify: `api/src/services/runtime.ts`
+- Modify: `api/src/repos/routingAttributionRepository.ts`
+- Modify: `api/src/repos/rateCardRepository.ts`
+- Test: `api/tests/admin.pilot.route.test.ts`
+- Test: `api/tests/admin.tokenCredentials.route.test.ts`
+- Test: `api/tests/usage.route.test.ts`
+
+- [ ] **Step 1: Write the failing route tests**
+
+Add tests for:
+- `GET /v1/usage/me/requests` returning only post-cutover caller-visible history
+- `GET /v1/admin/requests` supporting `historyScope=post_cutover|all`
+- `GET /v1/admin/requests/:requestId/explanation` returning routing + metering + projector-state explanation
+- `GET /v1/admin/token-credentials/:id/contribution-cap` returning current reserve floors
+- `POST /v1/admin/metering/corrections` enforcing reason metadata and action-specific validation
+
+- [ ] **Step 2: Run the failing route tests**
+
+Run:
+```bash
+cd api && npm test -- admin.pilot.route.test.ts admin.tokenCredentials.route.test.ts usage.route.test.ts
+```
+
+Expected: FAIL with missing endpoints or missing response fields
+
+- [ ] **Step 3: Implement the route handlers**
+
+Implement:
+- request-history pagination and filtering in `usage.ts`
+- admin history/explanation/correction endpoints in `admin.ts`
+- reserve-floor read endpoint in `admin.ts`
+- runtime wiring for any new repositories/services these handlers need
+
+- [ ] **Step 4: Re-run the route tests**
+
+Run:
+```bash
+cd api && npm test -- admin.pilot.route.test.ts admin.tokenCredentials.route.test.ts usage.route.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/src/routes/admin.ts api/src/routes/usage.ts api/src/services/runtime.ts api/src/repos/routingAttributionRepository.ts api/src/repos/rateCardRepository.ts api/tests/admin.pilot.route.test.ts api/tests/admin.tokenCredentials.route.test.ts api/tests/usage.route.test.ts
+git commit -m "feat: add routing history and explanations"
+```
+
+## Chunk 4: Retry, Verification, And Build
+
+### Task 4: Finish missing-metering retry flow and verify the slice
+
+**Files:**
+- Modify: `api/src/routes/admin.ts`
+- Modify: `api/src/repos/meteringProjectorStateRepository.ts`
+- Modify: `api/src/repos/routingAttributionRepository.ts`
+- Test: `api/tests/admin.pilot.route.test.ts`
+- Test: `api/tests/meteringProjectorStateRepository.test.ts`
+
+- [ ] **Step 1: Write the failing retry/correction tests**
+
+Add tests for:
+- financially unfinalized request detection returning requests missing canonical metering
+- retry endpoint re-finalizing a missing request idempotently
+- correction endpoint emitting `correction` and `reversal` events without mutating source rows
+
+- [ ] **Step 2: Run the failing tests**
+
+Run:
+```bash
+cd api && npm test -- admin.pilot.route.test.ts meteringProjectorStateRepository.test.ts
+```
+
+Expected: FAIL with missing retry orchestration or missing operator correction behavior
+
+- [ ] **Step 3: Implement the minimal retry/correction orchestration**
+
+Implement:
+- scan/query helpers for financially unfinalized requests
+- admin retry path that replays canonical metering finalization idempotently
+- correction/reversal writes that preserve source-event linkage and projector-state visibility
+
+- [ ] **Step 4: Run focused verification**
+
+Run:
+```bash
+cd api && npm test -- canonicalMeteringRepository.test.ts meteringProjectorStateRepository.test.ts rateCardRepository.test.ts routingAttributionRepository.test.ts usageMeteringWriter.test.ts routingService.test.ts proxy.sellerMode.route.test.ts proxy.tokenMode.route.test.ts admin.pilot.route.test.ts admin.tokenCredentials.route.test.ts usage.route.test.ts
+cd api && npm run build
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/src/routes/admin.ts api/src/repos/meteringProjectorStateRepository.ts api/src/repos/routingAttributionRepository.ts api/tests/admin.pilot.route.test.ts api/tests/meteringProjectorStateRepository.test.ts
+git commit -m "feat: add metering retry and correction flows"
+```
+
+## Remaining Dependency On Later Wallet Work
+
+- `paid-team-capacity` must persist the canonical `rate_card_version_id`, debit amount, and admission-time routing mode now, but wallet admission and wallet-ledger projection remain downstream consumers of that fact.
+- This workstream must not invent wallet balance rules, preauth behavior, or payment integration. It only exposes the seam that Workstream 4 consumes.
+- Admin explanations should surface when a request is financially finalized in canonical metering but still awaiting downstream wallet projection so later wallet work can reconcile without changing routing behavior.


### PR DESCRIPTION
## Summary
- add Darryn phase 2 routing and canonical metering repositories, routes, and runtime wiring
- persist admission routing attribution, request history, reserve-floor, rate-card, and canonical metering seams
- fix seller streaming metering so only successful 2xx streams create served canonical usage rows

## Test Plan
- cd api && npm test -- rateCardRepository.test.ts routingAttributionRepository.test.ts usageMeteringWriter.test.ts canonicalMeteringRepository.test.ts admin.pilot.route.test.ts admin.tokenCredentials.route.test.ts usage.route.test.ts runtime.pilotCutoverService.test.ts proxy.sellerMode.route.test.ts proxy.tokenMode.route.test.ts routingService.test.ts
- cd api && npm run build