### PR TITLE
feat: add wallet admission flow

### DIFF
--- a/api/src/jobs/registry.ts
+++ b/api/src/jobs/registry.ts
@@ -5,7 +5,11 @@ import { RequestLogRepository } from '../repos/requestLogRepository.js';
 import { SellerKeyRepository } from '../repos/sellerKeyRepository.js';
 import { TokenCredentialRepository } from '../repos/tokenCredentialRepository.js';
 import { TokenCredentialProviderUsageRepository } from '../repos/tokenCredentialProviderUsageRepository.js';
+import { WalletLedgerRepository } from '../repos/walletLedgerRepository.js';
+import { CanonicalMeteringRepository } from '../repos/canonicalMeteringRepository.js';
+import { MeteringProjectorStateRepository } from '../repos/meteringProjectorStateRepository.js';
 import type { SqlClient } from '../repos/sqlClient.js';
+import { WalletService } from '../services/wallet/walletService.js';
 import { C1ReconciliationDataSource } from './reconciliationDataSource.js';
 import {
   createDailyAggregatesCompactionJob,
@@ -16,6 +20,7 @@ import { createKeyHealthCheckJob } from './keyHealthJob.js';
 import { createRequestLogRetentionJob } from './requestLogRetentionJob.js';
 import { createTokenCredentialHealthJob } from './tokenCredentialHealthJob.js';
 import { createTokenCredentialProviderUsageJob } from './tokenCredentialProviderUsageJob.js';
+import { createWalletProjectorJob } from './walletProjectorJob.js';
 import { createReconciliationJob, type ReconciliationDataSource } from './reconciliationJob.js';
 import type { JobDefinition } from './types.js';
 
@@ -27,11 +32,24 @@ export function buildDefaultJobs(db: SqlClient, source: ReconciliationDataSource
   const sellerKeysRepo = new SellerKeyRepository(db);
   const tokenCredentialsRepo = new TokenCredentialRepository(db);
   const tokenCredentialProviderUsageRepo = new TokenCredentialProviderUsageRepository(db);
+  const walletLedgerRepo = new WalletLedgerRepository(db);
+  const canonicalMeteringRepo = new CanonicalMeteringRepository(db);
+  const meteringProjectorStateRepo = new MeteringProjectorStateRepository(db);
+  const walletService = new WalletService({
+    sql: db,
+    walletLedgerRepo,
+    canonicalMeteringRepo,
+    meteringProjectorStateRepo
+  });
 
   return [
     createIdempotencyPurgeJob(idempotencyRepo),
     createKeyHealthCheckJob(sellerKeysRepo),
     createTokenCredentialProviderUsageJob(tokenCredentialsRepo, tokenCredentialProviderUsageRepo),
+    createWalletProjectorJob({
+      walletService,
+      meteringProjectorStateRepo
+    }),
     createTokenCredentialHealthJob(tokenCredentialsRepo),
     createDailyAggregatesIncrementalJob(aggregatesRepo),
     createDailyAggregatesCompactionJob(aggregatesRepo),

--- a/api/src/jobs/walletProjectorJob.ts
+++ b/api/src/jobs/walletProjectorJob.ts
@@ -1,0 +1,84 @@
+import type { MeteringProjectorStateRepository } from '../repos/meteringProjectorStateRepository.js';
+import type { WalletService } from '../services/wallet/walletService.js';
+import type { JobDefinition } from './types.js';
+
+const DEFAULT_SCHEDULE_MS = 30_000;
+const DEFAULT_RETRY_DELAY_MS = 60_000;
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_BATCH_SIZE = 50;
+
+function readIntEnv(name: string, fallback: number): number {
+  const value = process.env[name];
+  if (!value) return fallback;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return Math.floor(parsed);
+}
+
+export function createWalletProjectorJob(input: {
+  walletService: Pick<WalletService, 'projectMeteringEvent'>;
+  meteringProjectorStateRepo: Pick<
+    MeteringProjectorStateRepository,
+    'listDueForProjector' | 'markPendingRetry' | 'markNeedsOperatorCorrection'
+  >;
+  retryDelayMs?: number;
+  maxRetries?: number;
+}): JobDefinition {
+  const retryDelayMs = input.retryDelayMs ?? readIntEnv('WALLET_PROJECTOR_RETRY_DELAY_MS', DEFAULT_RETRY_DELAY_MS);
+  const maxRetries = input.maxRetries ?? readIntEnv('WALLET_PROJECTOR_MAX_RETRIES', DEFAULT_MAX_RETRIES);
+
+  return {
+    name: 'wallet-projector',
+    scheduleMs: readIntEnv('WALLET_PROJECTOR_SCHEDULE_MS', DEFAULT_SCHEDULE_MS),
+    runOnStart: true,
+    async run(ctx) {
+      const rows = await input.meteringProjectorStateRepo.listDueForProjector({
+        projector: 'wallet',
+        now: ctx.now,
+        limit: DEFAULT_BATCH_SIZE
+      });
+
+      for (const row of rows) {
+        try {
+          await input.walletService.projectMeteringEvent(row.metering_event_id);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : 'unknown error';
+          const retryCount = row.retry_count + 1;
+
+          if (retryCount >= maxRetries) {
+            await input.meteringProjectorStateRepo.markNeedsOperatorCorrection({
+              meteringEventId: row.metering_event_id,
+              projector: 'wallet',
+              retryCount,
+              lastAttemptAt: ctx.now,
+              nextRetryAt: null,
+              lastErrorCode: 'wallet_projection_failed',
+              lastErrorMessage: message
+            });
+            ctx.logger.error('wallet projection requires operator correction', {
+              meteringEventId: row.metering_event_id,
+              retryCount,
+              errorMessage: message
+            });
+            continue;
+          }
+
+          await input.meteringProjectorStateRepo.markPendingRetry({
+            meteringEventId: row.metering_event_id,
+            projector: 'wallet',
+            retryCount,
+            lastAttemptAt: ctx.now,
+            nextRetryAt: new Date(ctx.now.getTime() + retryDelayMs),
+            lastErrorCode: 'wallet_projection_failed',
+            lastErrorMessage: message
+          });
+          ctx.logger.info('wallet projection retry scheduled', {
+            meteringEventId: row.metering_event_id,
+            retryCount,
+            retryDelayMs
+          });
+        }
+      }
+    }
+  };
+}

--- a/api/src/repos/canonicalMeteringRepository.ts
+++ b/api/src/repos/canonicalMeteringRepository.ts
@@ -190,6 +190,17 @@ export class CanonicalMeteringRepository {
     throw new Error('expected one canonical metering row');
   }
 
+  async findById(id: string): Promise<CanonicalMeteringEventRow | null> {
+    const sql = `
+      select *
+      from ${TABLES.canonicalMeteringEvents}
+      where id = $1
+      limit 1
+    `;
+    const result = await this.db.query<CanonicalMeteringEventRow>(sql, [id]);
+    return result.rowCount === 1 ? result.rows[0] : null;
+  }
+
   private async findExistingEvent(input: Pick<CanonicalMeteringEventInput, 'requestId' | 'attemptNo' | 'finalizationKind'>): Promise<CanonicalMeteringEventRow | null> {
     const sql = `
       select *

--- a/api/src/repos/meteringProjectorStateRepository.ts
+++ b/api/src/repos/meteringProjectorStateRepository.ts
@@ -134,6 +134,103 @@ export class MeteringProjectorStateRepository {
     return this.db.query<MeteringProjectorStateRow>(sql, [input.projector, input.state]).then((result) => result.rows);
   }
 
+  listDueForProjector(input: {
+    projector: Projector;
+    now: Date;
+    limit: number;
+  }): Promise<MeteringProjectorStateRow[]> {
+    const sql = `
+      select *
+      from ${TABLES.meteringProjectorStates}
+      where projector = $1
+        and state = 'pending_projection'
+        and (next_retry_at is null or next_retry_at <= $2)
+      order by updated_at asc, metering_event_id asc
+      limit $3
+    `;
+    return this.db.query<MeteringProjectorStateRow>(sql, [
+      input.projector,
+      input.now,
+      Math.max(1, Math.min(200, Math.floor(input.limit)))
+    ]).then((result) => result.rows);
+  }
+
+  async markPendingRetry(input: {
+    meteringEventId: string;
+    projector: Projector;
+    retryCount: number;
+    lastAttemptAt: Date;
+    nextRetryAt: Date;
+    lastErrorCode: string;
+    lastErrorMessage: string;
+  }): Promise<MeteringProjectorStateRow> {
+    const sql = `
+      update ${TABLES.meteringProjectorStates}
+      set
+        state = $3,
+        retry_count = $4,
+        last_attempt_at = $5,
+        next_retry_at = $6,
+        last_error_code = $7,
+        last_error_message = $8,
+        updated_at = now()
+      where metering_event_id = $1
+        and projector = $2
+      returning *
+    `;
+    return this.expectOne(sql, [
+      input.meteringEventId,
+      input.projector,
+      'pending_projection',
+      input.retryCount,
+      input.lastAttemptAt,
+      input.nextRetryAt,
+      input.lastErrorCode,
+      input.lastErrorMessage
+    ]);
+  }
+
+  async requeueForRetry(input: {
+    meteringEventId: string;
+    projector: Projector;
+  }): Promise<MeteringProjectorStateRow> {
+    const sql = `
+      update ${TABLES.meteringProjectorStates}
+      set
+        state = $3,
+        next_retry_at = null,
+        last_error_code = null,
+        last_error_message = null,
+        updated_at = now()
+      where metering_event_id = $1
+        and projector = $2
+      returning *
+    `;
+    return this.expectOne(sql, [
+      input.meteringEventId,
+      input.projector,
+      'pending_projection'
+    ]);
+  }
+
+  listOutstandingByProjector(input: {
+    projector: Projector;
+    limit?: number;
+  }): Promise<MeteringProjectorStateRow[]> {
+    const sql = `
+      select *
+      from ${TABLES.meteringProjectorStates}
+      where projector = $1
+        and state <> 'projected'
+      order by updated_at asc, metering_event_id asc
+      limit $2
+    `;
+    return this.db.query<MeteringProjectorStateRow>(sql, [
+      input.projector,
+      Math.max(1, Math.min(200, Math.floor(input.limit ?? 100)))
+    ]).then((result) => result.rows);
+  }
+
   private async expectOne(sql: string, params: SqlValue[]): Promise<MeteringProjectorStateRow> {
     const result = await this.db.query<MeteringProjectorStateRow>(sql, params);
     if (result.rowCount !== 1) {

--- a/api/src/repos/walletLedgerRepository.ts
+++ b/api/src/repos/walletLedgerRepository.ts
@@ -1,10 +1,11 @@
-import type { SqlClient, SqlValue } from './sqlClient.js';
+import type { SqlClient, SqlValue, TransactionContext } from './sqlClient.js';
 import { type IdFactory, uuidV4 } from './idFactory.js';
 import { TABLES } from './tableNames.js';
 import { assertIdempotentReplayMatches } from './idempotentReplay.js';
 import type { WalletEffectType } from '../types/phase2Contracts.js';
 
 export type WalletLedgerEntryInput = {
+  entryId?: string;
   walletId: string;
   ownerOrgId: string;
   buyerKeyId?: string | null;
@@ -13,6 +14,7 @@ export type WalletLedgerEntryInput = {
   amountMinor: number;
   currency?: string;
   actorUserId?: string | null;
+  actorApiKeyId?: string | null;
   reason?: string | null;
   processorEffectId?: string | null;
   metadata?: Record<string, unknown>;
@@ -34,6 +36,16 @@ export type WalletLedgerRow = {
   created_at: string;
 };
 
+export type WalletLedgerCursor = {
+  createdAt: string;
+  id: string;
+};
+
+export type WalletBalanceRow = {
+  wallet_id: string;
+  balance_minor: number;
+};
+
 const MANUAL_WALLET_EFFECT_TYPES = new Set<WalletEffectType>([
   'manual_credit',
   'manual_debit'
@@ -51,8 +63,8 @@ export class WalletLedgerRepository {
   ) {}
 
   async appendEntry(input: WalletLedgerEntryInput): Promise<WalletLedgerRow> {
-    if (MANUAL_WALLET_EFFECT_TYPES.has(input.effectType) && (!input.actorUserId || !input.reason)) {
-      throw new Error('manual wallet entries require actorUserId and reason');
+    if (MANUAL_WALLET_EFFECT_TYPES.has(input.effectType) && (!hasManualActorMetadata(input) || !input.reason)) {
+      throw new Error('manual wallet entries require actor metadata and reason');
     }
 
     if (PAYMENT_WALLET_EFFECT_TYPES.has(input.effectType) && !input.processorEffectId) {
@@ -67,6 +79,7 @@ export class WalletLedgerRepository {
       throw new Error('metering-derived wallet entries require meteringEventId');
     }
 
+    const metadata = manualWalletMetadata(input);
     const sql = `
       insert into ${TABLES.walletLedger} (
         id,
@@ -89,7 +102,7 @@ export class WalletLedgerRepository {
     `;
 
     const params: SqlValue[] = [
-      this.createId(),
+      input.entryId ?? this.createId(),
       input.walletId,
       input.ownerOrgId,
       input.buyerKeyId ?? null,
@@ -100,7 +113,7 @@ export class WalletLedgerRepository {
       input.actorUserId ?? null,
       input.reason ?? null,
       input.processorEffectId ?? null,
-      input.metadata ? JSON.stringify(input.metadata) : null
+      metadata ? JSON.stringify(metadata) : null
     ];
 
     const result = await this.db.query<WalletLedgerRow>(sql, params);
@@ -137,7 +150,79 @@ export class WalletLedgerRepository {
     return this.db.query<WalletLedgerRow>(sql, [meteringEventId]).then((result) => result.rows);
   }
 
+  async readBalance(
+    walletId: string,
+    db: Pick<TransactionContext, 'query'> = this.db
+  ): Promise<{
+    walletId: string;
+    balanceMinor: number;
+  }> {
+    const sql = `
+      select
+        $1::text as wallet_id,
+        coalesce(sum(case
+          when effect_type in ('manual_credit', 'payment_credit') then amount_minor
+          when effect_type in ('buyer_debit', 'buyer_correction', 'buyer_reversal', 'manual_debit', 'payment_reversal') then amount_minor * -1
+          else 0
+        end), 0)::bigint as balance_minor
+      from ${TABLES.walletLedger}
+      where wallet_id = $1
+    `;
+    const result = await db.query<WalletBalanceRow>(sql, [walletId]);
+    const row = result.rows[0] ?? {
+      wallet_id: walletId,
+      balance_minor: 0
+    };
+
+    return {
+      walletId: row.wallet_id,
+      balanceMinor: Number(row.balance_minor)
+    };
+  }
+
+  async listPageByWalletId(input: {
+    walletId: string;
+    limit: number;
+    cursor?: WalletLedgerCursor | null;
+  }): Promise<WalletLedgerRow[]> {
+    const params: SqlValue[] = [input.walletId];
+    const where: string[] = ['wallet_id = $1'];
+
+    if (input.cursor) {
+      params.push(input.cursor.createdAt);
+      const createdAtParam = params.length;
+      params.push(input.cursor.id);
+      const idParam = params.length;
+      where.push(`(
+        created_at < $${createdAtParam}
+        or (created_at = $${createdAtParam} and id < $${idParam})
+      )`);
+    }
+
+    params.push(Math.max(1, Math.min(100, Math.floor(input.limit))));
+    const sql = `
+      select *
+      from ${TABLES.walletLedger}
+      where ${where.join(' and ')}
+      order by created_at desc, id desc
+      limit $${params.length}
+    `;
+    const result = await this.db.query<WalletLedgerRow>(sql, params);
+    return result.rows;
+  }
+
   private async findExistingIdempotentEntry(input: WalletLedgerEntryInput): Promise<WalletLedgerRow | null> {
+    if (input.entryId) {
+      const sql = `
+        select *
+        from ${TABLES.walletLedger}
+        where id = $1
+        limit 1
+      `;
+      const result = await this.db.query<WalletLedgerRow>(sql, [input.entryId]);
+      return result.rowCount === 1 ? result.rows[0] : null;
+    }
+
     if (input.meteringEventId) {
       const sql = `
         select *
@@ -168,6 +253,7 @@ export class WalletLedgerRepository {
 
 function assertWalletLedgerReplayMatches(input: WalletLedgerEntryInput, row: WalletLedgerRow): void {
   assertIdempotentReplayMatches('wallet ledger', [
+    { field: 'entryId', expected: input.entryId ?? row.id, actual: row.id },
     { field: 'walletId', expected: input.walletId, actual: row.wallet_id },
     { field: 'ownerOrgId', expected: input.ownerOrgId, actual: row.owner_org_id },
     { field: 'buyerKeyId', expected: input.buyerKeyId ?? null, actual: row.buyer_key_id },
@@ -178,6 +264,21 @@ function assertWalletLedgerReplayMatches(input: WalletLedgerEntryInput, row: Wal
     { field: 'actorUserId', expected: input.actorUserId ?? null, actual: row.actor_user_id },
     { field: 'reason', expected: input.reason ?? null, actual: row.reason },
     { field: 'processorEffectId', expected: input.processorEffectId ?? null, actual: row.processor_effect_id },
-    { field: 'metadata', expected: input.metadata ?? null, actual: row.metadata }
+    { field: 'metadata', expected: manualWalletMetadata(input) ?? null, actual: row.metadata }
   ]);
+}
+
+function hasManualActorMetadata(input: WalletLedgerEntryInput): boolean {
+  return Boolean(input.actorUserId || input.actorApiKeyId);
+}
+
+function manualWalletMetadata(input: WalletLedgerEntryInput): Record<string, unknown> | undefined {
+  if (!input.actorApiKeyId) {
+    return input.metadata;
+  }
+
+  return {
+    ...(input.metadata ?? {}),
+    actorApiKeyId: input.actorApiKeyId
+  };
 }

--- a/api/src/routes/admin.ts
+++ b/api/src/routes/admin.ts
@@ -27,7 +27,7 @@ import {
 } from '../services/tokenCredentialProbe.js';
 import { deriveTokenCredentialAuthDiagnosis } from '../services/tokenCredentialAuthDiagnosis.js';
 import { AppError } from '../utils/errors.js';
-import { sha256Hex, stableJson } from '../utils/hash.js';
+import { sha256Hex, stableJson, stableUuid } from '../utils/hash.js';
 import { readAndValidateIdempotencyKey } from '../utils/idempotencyKey.js';
 import { logSensitiveAction } from '../utils/audit.js';
 import { resolveDefaultBuyerProvider } from '../utils/providerPreference.js';
@@ -205,6 +205,27 @@ const adminUnfinalizedRequestsQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(100).optional().default(20)
 });
 
+const walletLedgerQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).optional().default(20),
+  cursor: z.string().min(1).optional()
+});
+
+const walletLedgerCursorSchema = z.object({
+  createdAt: z.string().min(1),
+  id: z.string().uuid()
+});
+
+const walletAdjustmentSchema = z.object({
+  effectType: z.enum(['manual_credit', 'manual_debit']),
+  amountMinor: z.number().int().positive(),
+  reason: z.string().trim().min(3).max(500),
+  metadata: z.record(z.string(), z.unknown()).optional()
+});
+
+const walletProjectorQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(200).optional().default(100)
+});
+
 const requestHistoryCursorSchema = z.object({
   createdAt: z.string().min(1),
   requestId: z.string().min(1),
@@ -256,6 +277,20 @@ function decodeHistoryCursor(cursor: string | undefined): RequestHistoryCursor |
     return requestHistoryCursorSchema.parse(JSON.parse(decoded));
   } catch {
     throw new AppError('invalid_request', 400, 'Invalid request-history cursor');
+  }
+}
+
+function encodeWalletLedgerCursor(cursor: { createdAt: string; id: string }): string {
+  return Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url');
+}
+
+function decodeWalletLedgerCursor(cursor: string | undefined): { createdAt: string; id: string } | null {
+  if (!cursor) return null;
+  try {
+    const decoded = Buffer.from(cursor, 'base64url').toString('utf8');
+    return walletLedgerCursorSchema.parse(JSON.parse(decoded));
+  } catch {
+    throw new AppError('invalid_request', 400, 'Invalid wallet-ledger cursor');
   }
 }
 
@@ -669,6 +704,162 @@ router.get('/v1/admin/requests/unfinalized', requireApiKey(runtime.repos.apiKeys
     res.json({
       requests
     });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/v1/admin/wallets/:walletId', requireApiKey(runtime.repos.apiKeys, ['admin']), async (req, res, next) => {
+  try {
+    const walletId = z.string().min(1).parse(req.params.walletId);
+    const wallet = await runtime.services.wallets.getWalletSnapshot(walletId);
+    res.json({
+      ok: true,
+      wallet
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/v1/admin/wallets/:walletId/ledger', requireApiKey(runtime.repos.apiKeys, ['admin']), async (req, res, next) => {
+  try {
+    const walletId = z.string().min(1).parse(req.params.walletId);
+    const query = walletLedgerQuerySchema.parse(req.query);
+    const result = await runtime.services.wallets.listWalletLedger({
+      walletId,
+      limit: query.limit,
+      cursor: decodeWalletLedgerCursor(query.cursor)
+    });
+    res.json({
+      ok: true,
+      ledger: result.entries,
+      nextCursor: result.nextCursor ? encodeWalletLedgerCursor(result.nextCursor) : null
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/v1/admin/wallets/:walletId/adjustments', requireApiKey(runtime.repos.apiKeys, ['admin']), async (req, res, next) => {
+  try {
+    const walletId = z.string().min(1).parse(req.params.walletId);
+    const idempotencyKey = readAndValidateIdempotencyKey(req.header('idempotency-key') ?? undefined);
+    const parsed = walletAdjustmentSchema.parse(req.body);
+    const requestHash = sha256Hex(stableJson({
+      walletId,
+      body: parsed,
+      apiKeyId: req.auth?.apiKeyId
+    }));
+    const tenantScope = req.auth?.orgId ?? `admin:${req.auth?.apiKeyId}`;
+    const idemStart = await runtime.services.idempotency.start({
+      scope: 'admin_wallet_adjustment_v1',
+      tenantScope,
+      idempotencyKey,
+      requestHash
+    });
+
+    if (idemStart.replay) {
+      if (!idemStart.responseBody) {
+        throw new AppError('idempotency_replay_unavailable', 409, 'Idempotent replay not available for this request');
+      }
+      res.setHeader('x-idempotent-replay', 'true');
+      res.status(idemStart.responseCode).json(idemStart.responseBody);
+      return;
+    }
+
+    const saved = await runtime.services.wallets.recordManualAdjustment({
+      entryId: stableUuid(`admin_wallet_adjustment_v1:${tenantScope}:${idempotencyKey}`),
+      walletId,
+      ownerOrgId: walletId,
+      actorApiKeyId: req.auth?.apiKeyId ?? null,
+      effectType: parsed.effectType,
+      amountMinor: parsed.amountMinor,
+      reason: parsed.reason,
+      metadata: parsed.metadata
+    });
+
+    await logSensitiveAction(runtime.repos.auditLogs, req.auth, {
+      action: 'admin.wallet_adjustment.create',
+      targetType: 'wallet',
+      targetId: walletId,
+      metadata: {
+        walletLedgerEntryId: saved.id,
+        effectType: parsed.effectType,
+        amountMinor: parsed.amountMinor,
+        reason: parsed.reason
+      }
+    });
+
+    const responseBody = {
+      ok: true,
+      entry: saved
+    };
+
+    await runtime.services.idempotency.commit(idemStart, {
+      responseCode: 200,
+      responseBody,
+      responseDigest: sha256Hex(stableJson(responseBody)),
+      responseRef: saved.id
+    });
+
+    res.status(200).json(responseBody);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/v1/admin/metering/projectors/wallet', requireApiKey(runtime.repos.apiKeys, ['admin']), async (req, res, next) => {
+  try {
+    const query = walletProjectorQuerySchema.parse(req.query);
+    const rows = await runtime.services.wallets.listWalletProjectionBacklog(query.limit);
+    res.json({
+      rows
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/v1/admin/metering/projectors/wallet/:meteringEventId/retry', requireApiKey(runtime.repos.apiKeys, ['admin']), async (req, res, next) => {
+  try {
+    const meteringEventId = z.string().min(1).parse(req.params.meteringEventId);
+    const idempotencyKey = readAndValidateIdempotencyKey(req.header('idempotency-key') ?? undefined);
+    const requestHash = sha256Hex(stableJson({
+      meteringEventId,
+      apiKeyId: req.auth?.apiKeyId
+    }));
+    const tenantScope = req.auth?.orgId ?? `admin:${req.auth?.apiKeyId}`;
+    const idemStart = await runtime.services.idempotency.start({
+      scope: 'admin_wallet_projector_retry_v1',
+      tenantScope,
+      idempotencyKey,
+      requestHash
+    });
+
+    if (idemStart.replay) {
+      if (!idemStart.responseBody) {
+        throw new AppError('idempotency_replay_unavailable', 409, 'Idempotent replay not available for this request');
+      }
+      res.setHeader('x-idempotent-replay', 'true');
+      res.status(idemStart.responseCode).json(idemStart.responseBody);
+      return;
+    }
+
+    const row = await runtime.services.wallets.retryWalletProjection(meteringEventId);
+    const responseBody = {
+      ok: true,
+      row
+    };
+
+    await runtime.services.idempotency.commit(idemStart, {
+      responseCode: 200,
+      responseBody,
+      responseDigest: sha256Hex(stableJson(responseBody)),
+      responseRef: meteringEventId
+    });
+
+    res.status(200).json(responseBody);
   } catch (error) {
     next(error);
   }

--- a/api/src/routes/pilot.ts
+++ b/api/src/routes/pilot.ts
@@ -16,6 +16,16 @@ const pilotAuthCallbackQuerySchema = z.object({
   state: z.string().min(1)
 });
 
+const walletLedgerQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).optional().default(20),
+  cursor: z.string().min(1).optional()
+});
+
+const walletLedgerCursorSchema = z.object({
+  createdAt: z.string().min(1),
+  id: z.string().uuid()
+});
+
 function normalizePilotReturnTo(value: string | undefined | null): string | undefined {
   const normalized = value?.trim();
   if (!normalized) return undefined;
@@ -24,21 +34,77 @@ function normalizePilotReturnTo(value: string | undefined | null): string | unde
   return normalized;
 }
 
+function readPilotSession(req: {
+  header(name: string): string | undefined;
+}) {
+  const token = runtime.services.pilotSessions.readTokenFromRequest(req);
+  if (!token) {
+    throw new AppError('unauthorized', 401, 'Missing pilot session');
+  }
+
+  const session = runtime.services.pilotSessions.readSession(token);
+  if (!session) {
+    throw new AppError('unauthorized', 401, 'Invalid pilot session');
+  }
+
+  return session;
+}
+
+function decodeWalletLedgerCursor(cursor: string | undefined) {
+  if (!cursor) return null;
+  try {
+    const decoded = Buffer.from(cursor, 'base64url').toString('utf8');
+    return walletLedgerCursorSchema.parse(JSON.parse(decoded));
+  } catch {
+    throw new AppError('invalid_request', 400, 'Invalid wallet-ledger cursor');
+  }
+}
+
+function encodeWalletLedgerCursor(cursor: { createdAt: string; id: string }): string {
+  return Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url');
+}
+
 router.get('/v1/pilot/session', async (req, res, next) => {
   try {
-    const token = runtime.services.pilotSessions.readTokenFromRequest(req);
-    if (!token) {
-      throw new AppError('unauthorized', 401, 'Missing pilot session');
-    }
-
-    const session = runtime.services.pilotSessions.readSession(token);
-    if (!session) {
-      throw new AppError('unauthorized', 401, 'Invalid pilot session');
-    }
+    const session = readPilotSession(req);
 
     res.status(200).json({
       ok: true,
       session
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/v1/pilot/wallet', async (req, res, next) => {
+  try {
+    const session = readPilotSession(req);
+    const wallet = await runtime.services.wallets.getWalletSnapshot(
+      runtime.services.wallets.walletIdForOrgId(session.effectiveOrgId)
+    );
+    res.status(200).json({
+      ok: true,
+      wallet
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/v1/pilot/wallet/ledger', async (req, res, next) => {
+  try {
+    const session = readPilotSession(req);
+    const query = walletLedgerQuerySchema.parse(req.query ?? {});
+    const result = await runtime.services.wallets.listWalletLedger({
+      walletId: runtime.services.wallets.walletIdForOrgId(session.effectiveOrgId),
+      limit: query.limit,
+      cursor: decodeWalletLedgerCursor(query.cursor)
+    });
+    res.status(200).json({
+      ok: true,
+      ledger: result.entries,
+      nextCursor: result.nextCursor ? encodeWalletLedgerCursor(result.nextCursor) : null
     });
   } catch (error) {
     next(error);

--- a/api/src/routes/proxy.ts
+++ b/api/src/routes/proxy.ts
@@ -4638,6 +4638,13 @@ export async function proxyPostHandler(req: any, res: Response, next: any): Prom
       }
       const keys = await runtime.repos.sellerKeys.listActiveForRouting(requestProvider, parsed.model, parsed.streaming);
       runtime.services.keyPool.setKeys(keys);
+      const buyerOwnership = await runtime.repos.fnfOwnership.findBuyerKeyOwnership(auth.apiKeyId);
+      if (buyerOwnership?.owner_org_id === orgId) {
+        await runtime.services.wallets.ensurePaidAdmissionEligible({
+          walletId: runtime.services.wallets.walletIdForOrgId(orgId),
+          trigger: 'paid_team_capacity'
+        });
+      }
 
       const sellerResult = await runtime.services.routingService.execute({
         request: {

--- a/api/src/services/runtime.ts
+++ b/api/src/services/runtime.ts
@@ -15,6 +15,7 @@ import { UsageLedgerRepository } from '../repos/usageLedgerRepository.js';
 import { UsageQueryRepository } from '../repos/usageQueryRepository.js';
 import { TokenCredentialRepository } from '../repos/tokenCredentialRepository.js';
 import { TokenCredentialProviderUsageRepository } from '../repos/tokenCredentialProviderUsageRepository.js';
+import { WalletLedgerRepository } from '../repos/walletLedgerRepository.js';
 import { AnalyticsRepository } from '../repos/analyticsRepository.js';
 import { AnalyticsDashboardSnapshotRepository } from '../repos/analyticsDashboardSnapshotRepository.js';
 import { RequestLogRepository } from '../repos/requestLogRepository.js';
@@ -31,6 +32,7 @@ import { TokenCredentialService } from './tokenCredentialService.js';
 import { PilotSessionService } from './pilot/pilotSessionService.js';
 import { PilotGithubAuthService } from './pilot/pilotGithubAuthService.js';
 import { PilotCutoverService } from './pilot/pilotCutoverService.js';
+import { WalletService } from './wallet/walletService.js';
 import { assertRequiredEnv, readRequiredEnv } from '../utils/env.js';
 import { AppError } from '../utils/errors.js';
 
@@ -56,6 +58,7 @@ export const runtime = {
     usageQuery: new UsageQueryRepository(sql),
     tokenCredentials: new TokenCredentialRepository(sql),
     tokenCredentialProviderUsage: new TokenCredentialProviderUsageRepository(sql),
+    walletLedger: new WalletLedgerRepository(sql),
     analytics: new AnalyticsRepository(sql),
     analyticsDashboardSnapshots: new AnalyticsDashboardSnapshotRepository(sql),
     requestLog: new RequestLogRepository(sql),
@@ -72,7 +75,8 @@ export const runtime = {
     pilotSessions: undefined as unknown as PilotSessionService,
     routerEngine: new RouterEngine(),
     routingService: undefined as unknown as RoutingService,
-    tokenCredentials: undefined as unknown as TokenCredentialService
+    tokenCredentials: undefined as unknown as TokenCredentialService,
+    wallets: undefined as unknown as WalletService
   }
 };
 
@@ -125,6 +129,12 @@ runtime.services.tokenCredentials = new TokenCredentialService(
   runtime.repos.tokenCredentials,
   runtime.repos.auditLogs
 );
+runtime.services.wallets = new WalletService({
+  sql: runtime.sql,
+  walletLedgerRepo: runtime.repos.walletLedger,
+  canonicalMeteringRepo: runtime.repos.canonicalMetering,
+  meteringProjectorStateRepo: runtime.repos.meteringProjectorStates
+});
 
 export function startBackgroundJobs(): void {
   runtime.services.jobs.start(buildDefaultJobs(runtime.sql));

--- a/api/src/services/wallet/walletBalance.ts
+++ b/api/src/services/wallet/walletBalance.ts
@@ -1,0 +1,22 @@
+import type { WalletEffectType } from '../../types/phase2Contracts.js';
+
+export function walletIdForOrgId(orgId: string): string {
+  return orgId;
+}
+
+export function walletBalanceImpact(input: {
+  effectType: WalletEffectType;
+  amountMinor: number;
+}): number {
+  switch (input.effectType) {
+    case 'manual_credit':
+    case 'payment_credit':
+      return input.amountMinor;
+    case 'buyer_debit':
+    case 'buyer_correction':
+    case 'buyer_reversal':
+    case 'manual_debit':
+    case 'payment_reversal':
+      return input.amountMinor * -1;
+  }
+}

--- a/api/src/services/wallet/walletService.ts
+++ b/api/src/services/wallet/walletService.ts
@@ -1,0 +1,185 @@
+import { AppError } from '../../utils/errors.js';
+import type { SqlClient } from '../../repos/sqlClient.js';
+import type {
+  CanonicalMeteringEventRow,
+  CanonicalMeteringRepository
+} from '../../repos/canonicalMeteringRepository.js';
+import type {
+  MeteringProjectorStateRepository,
+  MeteringProjectorStateRow
+} from '../../repos/meteringProjectorStateRepository.js';
+import type {
+  WalletLedgerCursor,
+  WalletLedgerRepository,
+  WalletLedgerRow
+} from '../../repos/walletLedgerRepository.js';
+import { buildWalletProjectionEffects } from '../metering/ledgerProjectionContracts.js';
+import { walletIdForOrgId } from './walletBalance.js';
+import type { WalletEffectType } from '../../types/phase2Contracts.js';
+
+export type WalletAdmissionTrigger = 'paid_team_capacity';
+
+export class WalletService {
+  constructor(private readonly deps: {
+    sql: SqlClient;
+    walletLedgerRepo: WalletLedgerRepository;
+    canonicalMeteringRepo: CanonicalMeteringRepository;
+    meteringProjectorStateRepo: MeteringProjectorStateRepository;
+  }) {}
+
+  async getWalletSnapshot(walletId: string): Promise<{
+    walletId: string;
+    ownerOrgId: string;
+    balanceMinor: number;
+    currency: string;
+  }> {
+    const balance = await this.deps.walletLedgerRepo.readBalance(walletId);
+    return {
+      walletId,
+      ownerOrgId: walletId,
+      balanceMinor: balance.balanceMinor,
+      currency: 'USD'
+    };
+  }
+
+  async listWalletLedger(input: {
+    walletId: string;
+    limit?: number;
+    cursor?: WalletLedgerCursor | null;
+  }): Promise<{
+    entries: WalletLedgerRow[];
+    nextCursor: WalletLedgerCursor | null;
+  }> {
+    const limit = Math.max(1, Math.min(100, Math.floor(input.limit ?? 20)));
+    const entries = await this.deps.walletLedgerRepo.listPageByWalletId({
+      walletId: input.walletId,
+      limit,
+      cursor: input.cursor ?? null
+    });
+    const last = entries[entries.length - 1];
+    return {
+      entries,
+      nextCursor: entries.length === limit && last
+        ? {
+          createdAt: last.created_at,
+          id: last.id
+        }
+        : null
+    };
+  }
+
+  async ensurePaidAdmissionEligible(input: {
+    walletId: string;
+    trigger: WalletAdmissionTrigger;
+  }): Promise<{
+    walletId: string;
+    balanceMinor: number;
+    eligible: true;
+  }> {
+    return this.deps.sql.transaction(async (tx) => {
+      await tx.query('select pg_advisory_xact_lock(hashtext($1))', [input.walletId]);
+      const balance = await this.deps.walletLedgerRepo.readBalance(input.walletId, tx);
+      if (balance.balanceMinor <= 0) {
+        throw new AppError(
+          'wallet_admission_denied',
+          402,
+          'Paid admission requires a positive wallet balance',
+          {
+            walletId: input.walletId,
+            balanceMinor: balance.balanceMinor,
+            trigger: input.trigger
+          }
+        );
+      }
+
+      return {
+        walletId: input.walletId,
+        balanceMinor: balance.balanceMinor,
+        eligible: true as const
+      };
+    });
+  }
+
+  async projectMeteringEvent(meteringEventId: string): Promise<void> {
+    const event = await this.deps.canonicalMeteringRepo.findById(meteringEventId);
+    if (!event) {
+      throw new AppError('not_found', 404, 'Canonical metering event not found', {
+        meteringEventId
+      });
+    }
+
+    const effects = buildWalletProjectionEffects({
+      meteringEventId: event.id,
+      finalizationKind: event.finalization_kind,
+      buyerDebitMinor: event.buyer_debit_minor,
+      contributorEarningsMinor: event.contributor_earnings_minor
+    });
+
+    for (const effect of effects) {
+      await this.deps.walletLedgerRepo.appendEntry(buildWalletProjectionInput(event, effect.effectType, effect.amountMinor));
+    }
+
+    await this.deps.meteringProjectorStateRepo.markProjected({
+      meteringEventId,
+      projector: 'wallet'
+    });
+  }
+
+  recordManualAdjustment(input: {
+    entryId?: string;
+    walletId: string;
+    ownerOrgId: string;
+    actorUserId?: string | null;
+    actorApiKeyId?: string | null;
+    effectType: Extract<WalletEffectType, 'manual_credit' | 'manual_debit'>;
+    amountMinor: number;
+    reason: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<WalletLedgerRow> {
+    return this.deps.walletLedgerRepo.appendEntry({
+      entryId: input.entryId,
+      walletId: input.walletId,
+      ownerOrgId: input.ownerOrgId,
+      effectType: input.effectType,
+      amountMinor: input.amountMinor,
+      actorUserId: input.actorUserId ?? null,
+      actorApiKeyId: input.actorApiKeyId ?? null,
+      reason: input.reason,
+      metadata: input.metadata
+    });
+  }
+
+  listWalletProjectionBacklog(limit = 100): Promise<MeteringProjectorStateRow[]> {
+    return this.deps.meteringProjectorStateRepo.listOutstandingByProjector({
+      projector: 'wallet',
+      limit
+    });
+  }
+
+  retryWalletProjection(meteringEventId: string): Promise<MeteringProjectorStateRow> {
+    return this.deps.meteringProjectorStateRepo.requeueForRetry({
+      meteringEventId,
+      projector: 'wallet'
+    });
+  }
+
+  walletIdForOrgId(orgId: string): string {
+    return walletIdForOrgId(orgId);
+  }
+}
+
+function buildWalletProjectionInput(
+  event: CanonicalMeteringEventRow,
+  effectType: Extract<WalletEffectType, 'buyer_debit' | 'buyer_correction' | 'buyer_reversal'>,
+  amountMinor: number
+) {
+  return {
+    walletId: walletIdForOrgId(event.consumer_org_id),
+    ownerOrgId: event.consumer_org_id,
+    buyerKeyId: event.buyer_key_id,
+    meteringEventId: event.id,
+    effectType,
+    amountMinor,
+    currency: event.currency
+  };
+}

--- a/api/src/utils/hash.ts
+++ b/api/src/utils/hash.ts
@@ -16,3 +16,10 @@ export function stableJson(value: unknown): string {
   const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) => a.localeCompare(b));
   return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${stableJson(v)}`).join(',')}}`;
 }
+
+export function stableUuid(value: string): string {
+  const hex = sha256Hex(value).slice(0, 32).split('');
+  hex[12] = '5';
+  hex[16] = ((parseInt(hex[16], 16) & 0x3) | 0x8).toString(16);
+  return `${hex.slice(0, 8).join('')}-${hex.slice(8, 12).join('')}-${hex.slice(12, 16).join('')}-${hex.slice(16, 20).join('')}-${hex.slice(20, 32).join('')}`;
+}

--- a/api/tests/admin.pilot.route.test.ts
+++ b/api/tests/admin.pilot.route.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import { AppError } from '../src/utils/errors.js';
+import { stableUuid } from '../src/utils/hash.js';
 
 type RuntimeModule = typeof import('../src/services/runtime.js');
 type AdminRouteModule = typeof import('../src/routes/admin.js');
@@ -127,6 +128,11 @@ describe('admin pilot routes', () => {
   let requestHistoryHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
   let requestExplanationHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
   let unfinalizedRequestHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+  let walletHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+  let walletLedgerHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+  let walletAdjustmentHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+  let walletProjectorHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+  let walletProjectorRetryHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
   let rateCardListHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
   let rateCardCreateHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
   let meteringCorrectionHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
@@ -142,6 +148,11 @@ describe('admin pilot routes', () => {
     requestHistoryHandlers = getRouteHandlers(mod.default as any, '/v1/admin/requests', 'get');
     requestExplanationHandlers = getRouteHandlers(mod.default as any, '/v1/admin/requests/:requestId/explanation', 'get');
     unfinalizedRequestHandlers = getRouteHandlers(mod.default as any, '/v1/admin/requests/unfinalized', 'get');
+    walletHandlers = getRouteHandlers(mod.default as any, '/v1/admin/wallets/:walletId', 'get');
+    walletLedgerHandlers = getRouteHandlers(mod.default as any, '/v1/admin/wallets/:walletId/ledger', 'get');
+    walletAdjustmentHandlers = getRouteHandlers(mod.default as any, '/v1/admin/wallets/:walletId/adjustments', 'post');
+    walletProjectorHandlers = getRouteHandlers(mod.default as any, '/v1/admin/metering/projectors/wallet', 'get');
+    walletProjectorRetryHandlers = getRouteHandlers(mod.default as any, '/v1/admin/metering/projectors/wallet/:meteringEventId/retry', 'post');
     rateCardListHandlers = getRouteHandlers(mod.default as any, '/v1/admin/rate-cards', 'get');
     rateCardCreateHandlers = getRouteHandlers(mod.default as any, '/v1/admin/rate-cards', 'post');
     meteringCorrectionHandlers = getRouteHandlers(mod.default as any, '/v1/admin/metering/corrections', 'post');
@@ -162,6 +173,25 @@ describe('admin pilot routes', () => {
     vi.spyOn(runtimeModule.runtime.repos.routingAttribution, 'listAdminRequestHistory').mockResolvedValue([]);
     vi.spyOn(runtimeModule.runtime.repos.routingAttribution, 'getRequestExplanation').mockResolvedValue(null);
     vi.spyOn(runtimeModule.runtime.repos.routingAttribution, 'listFinanciallyUnfinalizedRequests').mockResolvedValue([]);
+    vi.spyOn(runtimeModule.runtime.services.wallets, 'getWalletSnapshot').mockResolvedValue({
+      walletId: 'org_fnf',
+      ownerOrgId: 'org_fnf',
+      balanceMinor: 0,
+      currency: 'USD'
+    } as any);
+    vi.spyOn(runtimeModule.runtime.services.wallets, 'listWalletLedger').mockResolvedValue({
+      entries: [],
+      nextCursor: null
+    } as any);
+    vi.spyOn(runtimeModule.runtime.services.wallets, 'recordManualAdjustment').mockResolvedValue({
+      id: 'wallet_entry_manual'
+    } as any);
+    vi.spyOn(runtimeModule.runtime.services.wallets, 'listWalletProjectionBacklog').mockResolvedValue([]);
+    vi.spyOn(runtimeModule.runtime.services.wallets, 'retryWalletProjection').mockResolvedValue({
+      metering_event_id: 'meter_1',
+      projector: 'wallet',
+      state: 'pending_projection'
+    } as any);
     vi.spyOn(runtimeModule.runtime.repos.rateCards, 'listVersions').mockResolvedValue([]);
     vi.spyOn(runtimeModule.runtime.repos.rateCards, 'createVersionWithLineItems').mockResolvedValue({
       version: {
@@ -490,6 +520,162 @@ describe('admin pilot routes', () => {
     expect(res.body).toEqual({
       requests: [expect.objectContaining({ request_id: 'req_missing' })]
     });
+  });
+
+  it('returns an admin wallet snapshot', async () => {
+    vi.spyOn(runtimeModule.runtime.services.wallets, 'getWalletSnapshot').mockResolvedValue({
+      walletId: 'org_fnf',
+      ownerOrgId: 'org_fnf',
+      balanceMinor: 1250,
+      currency: 'USD'
+    } as any);
+
+    const req = createMockReq({
+      method: 'GET',
+      path: '/v1/admin/wallets/org_fnf',
+      headers: {
+        authorization: 'Bearer in_admin_token'
+      },
+      params: {
+        walletId: 'org_fnf'
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(walletHandlers[0], req, res);
+    await invoke(walletHandlers[1], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(expect.objectContaining({
+      ok: true,
+      wallet: expect.objectContaining({
+        walletId: 'org_fnf',
+        balanceMinor: 1250
+      })
+    }));
+  });
+
+  it('returns admin wallet ledger history', async () => {
+    vi.spyOn(runtimeModule.runtime.services.wallets, 'listWalletLedger').mockResolvedValue({
+      entries: [{
+        id: 'wallet_entry_1',
+        wallet_id: 'org_fnf',
+        effect_type: 'manual_credit',
+        amount_minor: 5000
+      }],
+      nextCursor: null
+    } as any);
+
+    const req = createMockReq({
+      method: 'GET',
+      path: '/v1/admin/wallets/org_fnf/ledger',
+      headers: {
+        authorization: 'Bearer in_admin_token'
+      },
+      params: {
+        walletId: 'org_fnf'
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(walletLedgerHandlers[0], req, res);
+    await invoke(walletLedgerHandlers[1], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(expect.objectContaining({
+      ok: true,
+      ledger: [expect.objectContaining({ id: 'wallet_entry_1' })],
+      nextCursor: null
+    }));
+  });
+
+  it('records manual admin wallet adjustments with explicit reasons', async () => {
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/admin/wallets/org_fnf/adjustments',
+      headers: {
+        authorization: 'Bearer in_admin_token',
+        'content-type': 'application/json',
+        'idempotency-key': 'abcdefghijklmnopqrstuvwxyz765432'
+      },
+      params: {
+        walletId: 'org_fnf'
+      },
+      body: {
+        actorUserId: '11111111-1111-4111-8111-111111111111',
+        effectType: 'manual_credit',
+        amountMinor: 5000,
+        reason: 'usdc top-up',
+        metadata: {
+          source: 'admin_console'
+        }
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(walletAdjustmentHandlers[0], req, res);
+    await invoke(walletAdjustmentHandlers[1], req, res);
+
+    expect(res.statusCode).toBe(200);
+    const adjustmentCall = vi.mocked(runtimeModule.runtime.services.wallets.recordManualAdjustment).mock.calls[0]?.[0];
+    expect(adjustmentCall).toEqual(expect.objectContaining({
+      entryId: stableUuid('admin_wallet_adjustment_v1:org_innies:abcdefghijklmnopqrstuvwxyz765432'),
+      walletId: 'org_fnf',
+      ownerOrgId: 'org_fnf',
+      actorApiKeyId: '99999999-9999-4999-8999-999999999999',
+      effectType: 'manual_credit',
+      amountMinor: 5000,
+      reason: 'usdc top-up'
+    }));
+    expect(adjustmentCall?.actorUserId).toBeUndefined();
+  });
+
+  it('lists wallet projector backlog rows for operators', async () => {
+    vi.spyOn(runtimeModule.runtime.services.wallets, 'listWalletProjectionBacklog').mockResolvedValue([{
+      metering_event_id: 'meter_7',
+      projector: 'wallet',
+      state: 'needs_operator_correction'
+    }] as any);
+
+    const req = createMockReq({
+      method: 'GET',
+      path: '/v1/admin/metering/projectors/wallet',
+      headers: {
+        authorization: 'Bearer in_admin_token'
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(walletProjectorHandlers[0], req, res);
+    await invoke(walletProjectorHandlers[1], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      rows: [expect.objectContaining({ metering_event_id: 'meter_7' })]
+    });
+  });
+
+  it('requeues a stuck wallet projector row', async () => {
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/admin/metering/projectors/wallet/meter_7/retry',
+      headers: {
+        authorization: 'Bearer in_admin_token',
+        'content-type': 'application/json',
+        'idempotency-key': 'abcdefghijklmnopqrstuvwxyz765431'
+      },
+      params: {
+        meteringEventId: 'meter_7'
+      },
+      body: {}
+    });
+    const res = createMockRes();
+
+    await invoke(walletProjectorRetryHandlers[0], req, res);
+    await invoke(walletProjectorRetryHandlers[1], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(runtimeModule.runtime.services.wallets.retryWalletProjection).toHaveBeenCalledWith('meter_7');
   });
 
   it('lists rate-card versions', async () => {

--- a/api/tests/meteringProjectorStateRepository.test.ts
+++ b/api/tests/meteringProjectorStateRepository.test.ts
@@ -66,4 +66,74 @@ describe('MeteringProjectorStateRepository', () => {
     expect(db.queries[0].params).toContain('projection_failed');
     expect(db.queries[0].params).toContain('wallet projection mismatch');
   });
+
+  it('lists due pending projection rows for a projector', async () => {
+    const db = new MockSqlClient({
+      rows: [{
+        metering_event_id: 'meter_3',
+        projector: 'wallet',
+        state: 'pending_projection'
+      }],
+      rowCount: 1
+    });
+    const repo = new MeteringProjectorStateRepository(db);
+
+    const rows = await repo.listDueForProjector({
+      projector: 'wallet',
+      now: new Date('2026-03-20T12:00:00Z'),
+      limit: 25
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(db.queries[0].sql).toContain('next_retry_at is null or next_retry_at <= $2');
+    expect(db.queries[0].params).toEqual(['wallet', new Date('2026-03-20T12:00:00Z'), 25]);
+  });
+
+  it('schedules a retry while keeping the projector pending', async () => {
+    const db = new MockSqlClient({
+      rows: [{
+        metering_event_id: 'meter_4',
+        projector: 'wallet',
+        state: 'pending_projection',
+        retry_count: 2
+      }],
+      rowCount: 1
+    });
+    const repo = new MeteringProjectorStateRepository(db);
+
+    await repo.markPendingRetry({
+      meteringEventId: 'meter_4',
+      projector: 'wallet',
+      retryCount: 2,
+      lastAttemptAt: new Date('2026-03-20T12:05:00Z'),
+      nextRetryAt: new Date('2026-03-20T12:10:00Z'),
+      lastErrorCode: 'projection_retry',
+      lastErrorMessage: 'temporary failure'
+    });
+
+    expect(db.queries[0].sql).toContain('state = $3');
+    expect(db.queries[0].params).toContain('pending_projection');
+    expect(db.queries[0].params).toContain('projection_retry');
+  });
+
+  it('requeues a stuck wallet projector row for manual retry', async () => {
+    const db = new MockSqlClient({
+      rows: [{
+        metering_event_id: 'meter_5',
+        projector: 'wallet',
+        state: 'pending_projection',
+        retry_count: 0
+      }],
+      rowCount: 1
+    });
+    const repo = new MeteringProjectorStateRepository(db);
+
+    await repo.requeueForRetry({
+      meteringEventId: 'meter_5',
+      projector: 'wallet'
+    });
+
+    expect(db.queries[0].sql).toContain('last_error_code = null');
+    expect(db.queries[0].params).toContain('pending_projection');
+  });
 });

--- a/api/tests/pilot.route.test.ts
+++ b/api/tests/pilot.route.test.ts
@@ -128,6 +128,8 @@ function getRouteHandlers(router: any, routePath: string, method: 'get' | 'post'
 describe('pilot routes', () => {
   let runtimeModule: RuntimeModule;
   let sessionHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+  let walletHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+  let walletLedgerHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
   let authStartHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
   let authCallbackHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
   let logoutHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
@@ -138,6 +140,8 @@ describe('pilot routes', () => {
     runtimeModule = await import('../src/services/runtime.js');
     const mod = await import('../src/routes/pilot.js') as PilotRouteModule;
     sessionHandlers = getRouteHandlers(mod.default as any, '/v1/pilot/session', 'get');
+    walletHandlers = getRouteHandlers(mod.default as any, '/v1/pilot/wallet', 'get');
+    walletLedgerHandlers = getRouteHandlers(mod.default as any, '/v1/pilot/wallet/ledger', 'get');
     authStartHandlers = getRouteHandlers(mod.default as any, '/v1/pilot/auth/github/start', 'get');
     authCallbackHandlers = getRouteHandlers(mod.default as any, '/v1/pilot/auth/github/callback', 'get');
     logoutHandlers = getRouteHandlers(mod.default as any, '/v1/pilot/session/logout', 'post');
@@ -187,6 +191,97 @@ describe('pilot routes', () => {
         effectiveOrgId: 'org_fnf',
         githubLogin: 'darryn'
       })
+    }));
+  });
+
+  it('returns the pilot wallet balance for the effective org', async () => {
+    vi.spyOn(runtimeModule.runtime.services.pilotSessions, 'readTokenFromRequest').mockReturnValue('pilot-token');
+    vi.spyOn(runtimeModule.runtime.services.pilotSessions, 'readSession').mockReturnValue({
+      sessionKind: 'darryn_self',
+      actorUserId: 'user_darryn',
+      actorApiKeyId: null,
+      actorOrgId: 'org_fnf',
+      effectiveOrgId: 'org_fnf',
+      effectiveOrgSlug: 'fnf',
+      effectiveOrgName: 'Friends & Family',
+      githubLogin: 'darryn',
+      userEmail: 'darryn@example.com',
+      impersonatedUserId: null,
+      issuedAt: '2026-03-20T00:00:00Z',
+      expiresAt: '2026-03-20T01:00:00Z'
+    } as any);
+    vi.spyOn(runtimeModule.runtime.services.wallets, 'getWalletSnapshot').mockResolvedValue({
+      walletId: 'org_fnf',
+      ownerOrgId: 'org_fnf',
+      balanceMinor: 1250,
+      currency: 'USD'
+    } as any);
+
+    const req = createMockReq({
+      method: 'GET',
+      path: '/v1/pilot/wallet',
+      headers: {
+        authorization: 'Bearer pilot-token'
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(walletHandlers[0], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(expect.objectContaining({
+      ok: true,
+      wallet: expect.objectContaining({
+        walletId: 'org_fnf',
+        balanceMinor: 1250
+      })
+    }));
+  });
+
+  it('returns pilot wallet ledger history for the effective org', async () => {
+    vi.spyOn(runtimeModule.runtime.services.pilotSessions, 'readTokenFromRequest').mockReturnValue('pilot-token');
+    vi.spyOn(runtimeModule.runtime.services.pilotSessions, 'readSession').mockReturnValue({
+      sessionKind: 'darryn_self',
+      actorUserId: 'user_darryn',
+      actorApiKeyId: null,
+      actorOrgId: 'org_fnf',
+      effectiveOrgId: 'org_fnf',
+      effectiveOrgSlug: 'fnf',
+      effectiveOrgName: 'Friends & Family',
+      githubLogin: 'darryn',
+      userEmail: 'darryn@example.com',
+      impersonatedUserId: null,
+      issuedAt: '2026-03-20T00:00:00Z',
+      expiresAt: '2026-03-20T01:00:00Z'
+    } as any);
+    vi.spyOn(runtimeModule.runtime.services.wallets, 'listWalletLedger').mockResolvedValue({
+      entries: [{
+        id: 'wallet_entry_1',
+        wallet_id: 'org_fnf',
+        effect_type: 'manual_credit',
+        amount_minor: 5000
+      }],
+      nextCursor: null
+    } as any);
+
+    const req = createMockReq({
+      method: 'GET',
+      path: '/v1/pilot/wallet/ledger',
+      headers: {
+        authorization: 'Bearer pilot-token'
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(walletLedgerHandlers[0], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(expect.objectContaining({
+      ok: true,
+      ledger: [expect.objectContaining({
+        id: 'wallet_entry_1'
+      })],
+      nextCursor: null
     }));
   });
 

--- a/api/tests/proxy.sellerMode.route.test.ts
+++ b/api/tests/proxy.sellerMode.route.test.ts
@@ -182,6 +182,11 @@ describe('proxy seller-mode route behavior', () => {
       preferred_provider: null
     } as any);
     vi.spyOn(runtimeModule.runtime.repos.apiKeys, 'touchLastUsed').mockResolvedValue(undefined);
+    vi.spyOn(runtimeModule.runtime.repos.fnfOwnership, 'findBuyerKeyOwnership').mockResolvedValue({
+      api_key_id: '11111111-1111-4111-8111-111111111111',
+      owner_org_id: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      owner_user_id: '22222222-2222-4222-8222-222222222222'
+    } as any);
     vi.spyOn(runtimeModule.runtime.repos.killSwitch, 'isDisabled').mockResolvedValue(false);
     vi.spyOn(runtimeModule.runtime.repos.modelCompatibility, 'findActive').mockResolvedValue({
       provider: 'anthropic',
@@ -217,6 +222,11 @@ describe('proxy seller-mode route behavior', () => {
     vi.spyOn(runtimeModule.runtime.services.metering, 'recordUsage').mockResolvedValue({
       id: 'usage_1',
       entry_type: 'usage'
+    } as any);
+    vi.spyOn(runtimeModule.runtime.services.wallets, 'ensurePaidAdmissionEligible').mockResolvedValue({
+      walletId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      balanceMinor: 100,
+      eligible: true
     } as any);
   });
 
@@ -271,6 +281,88 @@ describe('proxy seller-mode route behavior', () => {
         openclaw_run_id: 'oc_run_123'
       })
     }));
+  });
+
+  it('checks wallet admission before paid-team-capacity routing', async () => {
+    vi.spyOn(runtimeModule.runtime.services.routingService, 'execute').mockResolvedValue({
+      requestId: 'req_wallet_ok',
+      keyId: 'seller-key-1',
+      attemptNo: 1,
+      upstreamStatus: 200,
+      usageUnits: 0,
+      contentType: 'application/json',
+      data: { ok: true },
+      routeDecision: { reason: 'weighted_round_robin' }
+    } as any);
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/proxy/v1/messages',
+      headers: {
+        authorization: 'Bearer in_test_token',
+        'content-type': 'application/json',
+        'idempotency-key': 'abcdefghijklmnopqrstuvwxyz123450',
+        'anthropic-version': '2023-06-01'
+      },
+      body: {
+        provider: 'anthropic',
+        model: 'claude-opus-4-6',
+        streaming: false,
+        payload: {
+          model: 'claude-opus-4-6',
+          max_tokens: 16,
+          messages: [{ role: 'user', content: 'hello' }]
+        }
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(handlers[0], req, res);
+    await invoke(handlers[1], req, res);
+
+    expect(runtimeModule.runtime.services.wallets.ensurePaidAdmissionEligible).toHaveBeenCalledWith({
+      walletId: '818d0cc7-7ed2-469f-b690-a977e72a921d',
+      trigger: 'paid_team_capacity'
+    });
+    expect(runtimeModule.runtime.services.routingService.execute).toHaveBeenCalled();
+  });
+
+  it('fails clearly when wallet admission denies paid-team-capacity routing', async () => {
+    vi.spyOn(runtimeModule.runtime.services.wallets, 'ensurePaidAdmissionEligible').mockRejectedValue(
+      new AppError('wallet_admission_denied', 402, 'Paid admission requires a positive wallet balance')
+    );
+    const executeSpy = vi.spyOn(runtimeModule.runtime.services.routingService, 'execute');
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/proxy/v1/messages',
+      headers: {
+        authorization: 'Bearer in_test_token',
+        'content-type': 'application/json',
+        'idempotency-key': 'abcdefghijklmnopqrstuvwxyz123451',
+        'anthropic-version': '2023-06-01'
+      },
+      body: {
+        provider: 'anthropic',
+        model: 'claude-opus-4-6',
+        streaming: false,
+        payload: {
+          model: 'claude-opus-4-6',
+          max_tokens: 16,
+          messages: [{ role: 'user', content: 'hello' }]
+        }
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(handlers[0], req, res);
+    await invoke(handlers[1], req, res);
+
+    expect(res.statusCode).toBe(402);
+    expect(res.body).toEqual(expect.objectContaining({
+      code: 'wallet_admission_denied'
+    }));
+    expect(executeSpy).not.toHaveBeenCalled();
   });
 
   it('records seller-mode streaming cli requests with pinned source metadata and ttfb', async () => {

--- a/api/tests/walletLedgerRepository.test.ts
+++ b/api/tests/walletLedgerRepository.test.ts
@@ -38,7 +38,7 @@ describe('WalletLedgerRepository', () => {
       ownerOrgId: 'org_fnf',
       effectType: 'manual_credit',
       amountMinor: 1000
-    })).rejects.toThrow('manual wallet entries require actorUserId and reason');
+    })).rejects.toThrow('manual wallet entries require actor metadata and reason');
   });
 
   it('accepts processor effect ids for payment-backed wallet rows without manual actor metadata', async () => {
@@ -131,5 +131,107 @@ describe('WalletLedgerRepository', () => {
       effectType: 'buyer_debit',
       amountMinor: 450
     })).rejects.toThrow('wallet ledger idempotent replay mismatch');
+  });
+
+  it('returns the existing manual row on duplicate deterministic entry ids', async () => {
+    const db = new SequenceSqlClient([
+      { rows: [], rowCount: 0 },
+      {
+        rows: [{
+          id: 'wallet_entry_manual',
+          wallet_id: 'wallet_1',
+          owner_org_id: 'org_fnf',
+          buyer_key_id: null,
+          metering_event_id: null,
+          effect_type: 'manual_credit',
+          amount_minor: 5000,
+          currency: 'USD',
+          actor_user_id: null,
+          reason: 'usdc top-up',
+          processor_effect_id: null,
+          metadata: { actorApiKeyId: 'admin_key_1', source: 'admin_console' },
+          created_at: '2026-03-20T03:00:00Z'
+        }],
+        rowCount: 1
+      }
+    ]);
+    const repo = new WalletLedgerRepository(db, () => 'wallet_entry_new');
+
+    const row = await repo.appendEntry({
+      entryId: 'wallet_entry_manual',
+      walletId: 'wallet_1',
+      ownerOrgId: 'org_fnf',
+      actorApiKeyId: 'admin_key_1',
+      effectType: 'manual_credit',
+      amountMinor: 5000,
+      reason: 'usdc top-up',
+      metadata: {
+        source: 'admin_console'
+      }
+    });
+
+    expect(row.id).toBe('wallet_entry_manual');
+    expect(db.queries[1].sql).toContain('where id = $1');
+  });
+
+  it('computes wallet balance from append-only ledger effects', async () => {
+    const db = new MockSqlClient({
+      rows: [{
+        wallet_id: 'wallet_1',
+        balance_minor: 725
+      }],
+      rowCount: 1
+    });
+    const repo = new WalletLedgerRepository(db, () => 'wallet_entry_balance');
+
+    const snapshot = await repo.readBalance('wallet_1');
+
+    expect(snapshot).toEqual({
+      walletId: 'wallet_1',
+      balanceMinor: 725
+    });
+    expect(db.queries[0].sql).toContain('sum(');
+    expect(db.queries[0].sql).toContain('from in_wallet_ledger');
+    expect(db.queries[0].params).toEqual(['wallet_1']);
+  });
+
+  it('lists wallet history pages in reverse chronological order', async () => {
+    const db = new MockSqlClient({
+      rows: [{
+        id: 'wallet_entry_9',
+        wallet_id: 'wallet_1',
+        owner_org_id: 'org_fnf',
+        buyer_key_id: 'buyer_1',
+        metering_event_id: 'meter_9',
+        effect_type: 'buyer_debit',
+        amount_minor: 450,
+        currency: 'USD',
+        actor_user_id: null,
+        reason: null,
+        processor_effect_id: null,
+        metadata: null,
+        created_at: '2026-03-20T03:00:00Z'
+      }],
+      rowCount: 1
+    });
+    const repo = new WalletLedgerRepository(db, () => 'wallet_entry_page');
+
+    const rows = await repo.listPageByWalletId({
+      walletId: 'wallet_1',
+      limit: 10,
+      cursor: {
+        createdAt: '2026-03-20T04:00:00Z',
+        id: 'wallet_entry_10'
+      }
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(db.queries[0].sql).toContain('order by created_at desc, id desc');
+    expect(db.queries[0].params).toEqual([
+      'wallet_1',
+      '2026-03-20T04:00:00Z',
+      'wallet_entry_10',
+      10
+    ]);
   });
 });

--- a/api/tests/walletProjectorJob.test.ts
+++ b/api/tests/walletProjectorJob.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createLoggerSpy } from './testHelpers.js';
+import { createWalletProjectorJob } from '../src/jobs/walletProjectorJob.js';
+
+describe('walletProjectorJob', () => {
+  it('projects due wallet events and leaves success rows marked projected by the service path', async () => {
+    const listDueForProjector = vi.fn().mockResolvedValue([
+      {
+        metering_event_id: 'meter_1',
+        projector: 'wallet',
+        state: 'pending_projection',
+        retry_count: 0
+      }
+    ]);
+    const walletService = {
+      projectMeteringEvent: vi.fn().mockResolvedValue(undefined)
+    };
+    const job = createWalletProjectorJob({
+      walletService: walletService as any,
+      meteringProjectorStateRepo: {
+        listDueForProjector
+      } as any
+    });
+    const { logger, errorCalls } = createLoggerSpy();
+
+    await job.run({
+      now: new Date('2026-03-20T12:00:00Z'),
+      logger
+    });
+
+    expect(listDueForProjector).toHaveBeenCalledWith({
+      projector: 'wallet',
+      now: new Date('2026-03-20T12:00:00Z'),
+      limit: 50
+    });
+    expect(walletService.projectMeteringEvent).toHaveBeenCalledWith('meter_1');
+    expect(errorCalls).toHaveLength(0);
+  });
+
+  it('schedules retries for transient wallet projection failures', async () => {
+    const markPendingRetry = vi.fn().mockResolvedValue(undefined);
+    const walletService = {
+      projectMeteringEvent: vi.fn().mockRejectedValue(new Error('temporary failure'))
+    };
+    const job = createWalletProjectorJob({
+      walletService: walletService as any,
+      meteringProjectorStateRepo: {
+        listDueForProjector: vi.fn().mockResolvedValue([{
+          metering_event_id: 'meter_2',
+          projector: 'wallet',
+          state: 'pending_projection',
+          retry_count: 1
+        }]),
+        markPendingRetry
+      } as any,
+      maxRetries: 3,
+      retryDelayMs: 60_000
+    });
+    const { logger } = createLoggerSpy();
+
+    await job.run({
+      now: new Date('2026-03-20T12:00:00Z'),
+      logger
+    });
+
+    expect(markPendingRetry).toHaveBeenCalledWith(expect.objectContaining({
+      meteringEventId: 'meter_2',
+      projector: 'wallet',
+      retryCount: 2,
+      lastErrorCode: 'wallet_projection_failed',
+      lastErrorMessage: 'temporary failure'
+    }));
+  });
+
+  it('escalates repeated failures to operator correction', async () => {
+    const markNeedsOperatorCorrection = vi.fn().mockResolvedValue(undefined);
+    const walletService = {
+      projectMeteringEvent: vi.fn().mockRejectedValue(new Error('permanent failure'))
+    };
+    const job = createWalletProjectorJob({
+      walletService: walletService as any,
+      meteringProjectorStateRepo: {
+        listDueForProjector: vi.fn().mockResolvedValue([{
+          metering_event_id: 'meter_3',
+          projector: 'wallet',
+          state: 'pending_projection',
+          retry_count: 2
+        }]),
+        markNeedsOperatorCorrection
+      } as any,
+      maxRetries: 3,
+      retryDelayMs: 60_000
+    });
+    const { logger } = createLoggerSpy();
+
+    await job.run({
+      now: new Date('2026-03-20T12:00:00Z'),
+      logger
+    });
+
+    expect(markNeedsOperatorCorrection).toHaveBeenCalledWith(expect.objectContaining({
+      meteringEventId: 'meter_3',
+      projector: 'wallet',
+      retryCount: 3,
+      lastErrorCode: 'wallet_projection_failed',
+      lastErrorMessage: 'permanent failure'
+    }));
+  });
+});

--- a/api/tests/walletService.test.ts
+++ b/api/tests/walletService.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AppError } from '../src/utils/errors.js';
+import { MockSqlClient } from './testHelpers.js';
+import { WalletService } from '../src/services/wallet/walletService.js';
+
+describe('WalletService', () => {
+  it('allows paid admission when the wallet balance is positive', async () => {
+    const sql = new MockSqlClient();
+    const walletLedgerRepo = {
+      readBalance: vi.fn().mockResolvedValue({
+        walletId: 'org_fnf',
+        balanceMinor: 125
+      })
+    };
+    const service = new WalletService({
+      sql,
+      walletLedgerRepo: walletLedgerRepo as any,
+      canonicalMeteringRepo: {} as any,
+      meteringProjectorStateRepo: {} as any
+    });
+
+    const result = await service.ensurePaidAdmissionEligible({
+      walletId: 'org_fnf',
+      trigger: 'paid_team_capacity'
+    });
+
+    expect(result).toEqual({
+      walletId: 'org_fnf',
+      balanceMinor: 125,
+      eligible: true
+    });
+    expect(sql.queries[0].sql).toContain('pg_advisory_xact_lock');
+    expect(walletLedgerRepo.readBalance).toHaveBeenCalledWith('org_fnf', expect.anything());
+  });
+
+  it('denies paid admission when the wallet balance is non-positive', async () => {
+    const sql = new MockSqlClient();
+    const service = new WalletService({
+      sql,
+      walletLedgerRepo: {
+        readBalance: vi.fn().mockResolvedValue({
+          walletId: 'org_fnf',
+          balanceMinor: 0
+        })
+      } as any,
+      canonicalMeteringRepo: {} as any,
+      meteringProjectorStateRepo: {} as any
+    });
+
+    await expect(service.ensurePaidAdmissionEligible({
+      walletId: 'org_fnf',
+      trigger: 'paid_team_capacity'
+    })).rejects.toMatchObject<AppError>({
+      code: 'wallet_admission_denied',
+      status: 402
+    });
+  });
+
+  it('projects committed paid metering into an idempotent wallet ledger entry', async () => {
+    const appendEntry = vi.fn().mockResolvedValue({ id: 'wallet_entry_1' });
+    const markProjected = vi.fn().mockResolvedValue({
+      metering_event_id: 'meter_1',
+      projector: 'wallet',
+      state: 'projected'
+    });
+    const service = new WalletService({
+      sql: new MockSqlClient(),
+      walletLedgerRepo: {
+        appendEntry
+      } as any,
+      canonicalMeteringRepo: {
+        findById: vi.fn().mockResolvedValue({
+          id: 'meter_1',
+          finalization_kind: 'served_request',
+          consumer_org_id: 'org_fnf',
+          buyer_key_id: 'buyer_1',
+          buyer_debit_minor: 450,
+          contributor_earnings_minor: 0,
+          currency: 'USD'
+        })
+      } as any,
+      meteringProjectorStateRepo: {
+        markProjected
+      } as any
+    });
+
+    await service.projectMeteringEvent('meter_1');
+
+    expect(appendEntry).toHaveBeenCalledWith(expect.objectContaining({
+      walletId: 'org_fnf',
+      ownerOrgId: 'org_fnf',
+      buyerKeyId: 'buyer_1',
+      meteringEventId: 'meter_1',
+      effectType: 'buyer_debit',
+      amountMinor: 450
+    }));
+    expect(markProjected).toHaveBeenCalledWith({
+      meteringEventId: 'meter_1',
+      projector: 'wallet'
+    });
+  });
+
+  it('records manual wallet adjustments as explicit ledger rows with actor and reason', async () => {
+    const appendEntry = vi.fn().mockResolvedValue({ id: 'wallet_entry_manual' });
+    const service = new WalletService({
+      sql: new MockSqlClient(),
+      walletLedgerRepo: {
+        appendEntry
+      } as any,
+      canonicalMeteringRepo: {} as any,
+      meteringProjectorStateRepo: {} as any
+    });
+
+    await service.recordManualAdjustment({
+      entryId: 'wallet_entry_manual',
+      walletId: 'org_fnf',
+      ownerOrgId: 'org_fnf',
+      actorApiKeyId: 'admin_key_1',
+      effectType: 'manual_credit',
+      amountMinor: 5000,
+      reason: 'usdc top-up',
+      metadata: {
+        source: 'admin_console'
+      }
+    });
+
+    expect(appendEntry).toHaveBeenCalledWith(expect.objectContaining({
+      entryId: 'wallet_entry_manual',
+      walletId: 'org_fnf',
+      ownerOrgId: 'org_fnf',
+      actorApiKeyId: 'admin_key_1',
+      effectType: 'manual_credit',
+      amountMinor: 5000,
+      reason: 'usdc top-up'
+    }));
+  });
+
+  it('allows already-admitted work to finalize below zero and blocks later paid admissions', async () => {
+    const sql = new MockSqlClient();
+    const appendEntry = vi.fn().mockResolvedValue({ id: 'wallet_entry_negative' });
+    const readBalance = vi.fn().mockResolvedValue({
+      walletId: 'org_fnf',
+      balanceMinor: -125
+    });
+    const service = new WalletService({
+      sql,
+      walletLedgerRepo: {
+        appendEntry,
+        readBalance
+      } as any,
+      canonicalMeteringRepo: {
+        findById: vi.fn().mockResolvedValue({
+          id: 'meter_negative',
+          finalization_kind: 'served_request',
+          consumer_org_id: 'org_fnf',
+          buyer_key_id: 'buyer_1',
+          buyer_debit_minor: 250,
+          contributor_earnings_minor: 0,
+          currency: 'USD'
+        })
+      } as any,
+      meteringProjectorStateRepo: {
+        markProjected: vi.fn().mockResolvedValue(undefined)
+      } as any
+    });
+
+    await service.projectMeteringEvent('meter_negative');
+
+    await expect(service.ensurePaidAdmissionEligible({
+      walletId: 'org_fnf',
+      trigger: 'paid_team_capacity'
+    })).rejects.toMatchObject<AppError>({
+      code: 'wallet_admission_denied',
+      status: 402
+    });
+    expect(appendEntry).toHaveBeenCalledWith(expect.objectContaining({
+      meteringEventId: 'meter_negative',
+      effectType: 'buyer_debit',
+      amountMinor: 250
+    }));
+  });
+});


### PR DESCRIPTION
## Summary
- add wallet ledger reads, projector retry handling, and manual admin wallet adjustment flows
- add pilot and admin wallet APIs plus stuck wallet projection visibility and retry endpoints
- gate paid-team-capacity admissions through the wallet service without changing upstream routing or metering ownership

## Verification
- [x] npm test -- walletLedgerRepository.test.ts meteringProjectorStateRepository.test.ts walletService.test.ts walletProjectorJob.test.ts pilot.route.test.ts admin.pilot.route.test.ts proxy.sellerMode.route.test.ts
- [x] npm run build
