### PR TITLE
Implement Darryn earnings and withdrawals

### DIFF
--- a/api/src/jobs/earningsProjectorJob.ts
+++ b/api/src/jobs/earningsProjectorJob.ts
@@ -1,0 +1,28 @@
+import type { EarningsProjectorService } from '../services/earnings/earningsProjectorService.js';
+import type { JobDefinition } from './types.js';
+
+const DEFAULT_EARNINGS_PROJECTOR_POLL_MS = 60_000;
+const DEFAULT_EARNINGS_PROJECTOR_BATCH_SIZE = 25;
+
+function readPositiveIntEnv(name: string, fallback: number): number {
+  const value = process.env[name];
+  if (!value) return fallback;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return Math.floor(parsed);
+}
+
+export function createEarningsProjectorJob(service: EarningsProjectorService): JobDefinition {
+  const batchSize = readPositiveIntEnv('EARNINGS_PROJECTOR_BATCH_SIZE', DEFAULT_EARNINGS_PROJECTOR_BATCH_SIZE);
+
+  return {
+    name: 'earnings-projector-minute',
+    scheduleMs: readPositiveIntEnv('EARNINGS_PROJECTOR_POLL_MS', DEFAULT_EARNINGS_PROJECTOR_POLL_MS),
+    async run(ctx) {
+      const result = await service.retryBacklog({ limit: batchSize });
+      ctx.logger.info('earnings projector batch processed', result);
+    }
+  };
+}

--- a/api/src/jobs/registry.ts
+++ b/api/src/jobs/registry.ts
@@ -11,6 +11,7 @@ import {
   createDailyAggregatesCompactionJob,
   createDailyAggregatesIncrementalJob
 } from './dailyAggregatesJob.js';
+import { createEarningsProjectorJob } from './earningsProjectorJob.js';
 import { createIdempotencyPurgeJob } from './idempotencyPurgeJob.js';
 import { createKeyHealthCheckJob } from './keyHealthJob.js';
 import { createRequestLogRetentionJob } from './requestLogRetentionJob.js';
@@ -18,18 +19,31 @@ import { createTokenCredentialHealthJob } from './tokenCredentialHealthJob.js';
 import { createTokenCredentialProviderUsageJob } from './tokenCredentialProviderUsageJob.js';
 import { createReconciliationJob, type ReconciliationDataSource } from './reconciliationJob.js';
 import type { JobDefinition } from './types.js';
+import { CanonicalMeteringRepository } from '../repos/canonicalMeteringRepository.js';
+import { EarningsLedgerRepository } from '../repos/earningsLedgerRepository.js';
+import { MeteringProjectorStateRepository } from '../repos/meteringProjectorStateRepository.js';
+import { EarningsProjectorService } from '../services/earnings/earningsProjectorService.js';
 
 export function buildDefaultJobs(db: SqlClient, source: ReconciliationDataSource = new C1ReconciliationDataSource(db)): JobDefinition[] {
   const idempotencyRepo = new IdempotencyRepository(db);
   const aggregatesRepo = new AggregatesRepository(db);
+  const canonicalMeteringRepo = new CanonicalMeteringRepository(db);
+  const earningsLedgerRepo = new EarningsLedgerRepository(db);
+  const meteringProjectorStateRepo = new MeteringProjectorStateRepository(db);
   const reconciliationRepo = new ReconciliationRepository(db);
   const requestLogRepo = new RequestLogRepository(db);
   const sellerKeysRepo = new SellerKeyRepository(db);
   const tokenCredentialsRepo = new TokenCredentialRepository(db);
   const tokenCredentialProviderUsageRepo = new TokenCredentialProviderUsageRepository(db);
+  const earningsProjector = new EarningsProjectorService({
+    canonicalMeteringRepo,
+    earningsLedgerRepo,
+    meteringProjectorStateRepo
+  });
 
   return [
     createIdempotencyPurgeJob(idempotencyRepo),
+    createEarningsProjectorJob(earningsProjector),
     createKeyHealthCheckJob(sellerKeysRepo),
     createTokenCredentialProviderUsageJob(tokenCredentialsRepo, tokenCredentialProviderUsageRepo),
     createTokenCredentialHealthJob(tokenCredentialsRepo),

--- a/api/src/repos/canonicalMeteringRepository.ts
+++ b/api/src/repos/canonicalMeteringRepository.ts
@@ -71,6 +71,17 @@ export class CanonicalMeteringRepository {
     private readonly createId: IdFactory = uuidV4
   ) {}
 
+  async findById(id: string): Promise<CanonicalMeteringEventRow | null> {
+    const sql = `
+      select *
+      from ${TABLES.canonicalMeteringEvents}
+      where id = $1
+      limit 1
+    `;
+    const result = await this.db.query<CanonicalMeteringEventRow>(sql, [id]);
+    return result.rowCount === 1 ? result.rows[0] : null;
+  }
+
   createServedRequest(
     input: Omit<CanonicalMeteringEventInput, 'finalizationKind'>
   ): Promise<CanonicalMeteringEventRow> {

--- a/api/src/repos/earningsLedgerRepository.ts
+++ b/api/src/repos/earningsLedgerRepository.ts
@@ -13,6 +13,7 @@ export type EarningsLedgerEntryInput = {
   amountMinor: number;
   currency?: string;
   actorUserId?: string | null;
+  actorApiKeyId?: string | null;
   reason?: string | null;
   withdrawalRequestId?: string | null;
   payoutReference?: string | null;
@@ -29,6 +30,7 @@ export type EarningsLedgerRow = {
   amount_minor: number;
   currency: string;
   actor_user_id: string | null;
+  actor_api_key_id: string | null;
   reason: string | null;
   withdrawal_request_id: string | null;
   payout_reference: string | null;
@@ -50,8 +52,16 @@ export class EarningsLedgerRepository {
   ) {}
 
   async appendEntry(input: EarningsLedgerEntryInput): Promise<EarningsLedgerRow> {
-    if (MANUAL_EARNINGS_EFFECT_TYPES.has(input.effectType) && (!input.actorUserId || !input.reason)) {
-      throw new Error('manual earnings entries require actorUserId and reason');
+    if (MANUAL_EARNINGS_EFFECT_TYPES.has(input.effectType) && !input.reason) {
+      throw new Error('manual earnings entries require reason');
+    }
+
+    if (
+      MANUAL_EARNINGS_EFFECT_TYPES.has(input.effectType)
+      && !input.actorUserId
+      && !input.actorApiKeyId
+    ) {
+      throw new Error('manual earnings entries require actor attribution');
     }
 
     if (!MANUAL_EARNINGS_EFFECT_TYPES.has(input.effectType) && !input.meteringEventId) {
@@ -69,12 +79,13 @@ export class EarningsLedgerRepository {
         amount_minor,
         currency,
         actor_user_id,
+        actor_api_key_id,
         reason,
         withdrawal_request_id,
         payout_reference,
         metadata
       ) values (
-        $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13
+        $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14
       )
       on conflict do nothing
       returning *
@@ -90,6 +101,7 @@ export class EarningsLedgerRepository {
       input.amountMinor,
       input.currency ?? 'USD',
       input.actorUserId ?? null,
+      input.actorApiKeyId ?? null,
       input.reason ?? null,
       input.withdrawalRequestId ?? null,
       input.payoutReference ?? null,
@@ -120,6 +132,20 @@ export class EarningsLedgerRepository {
       order by created_at asc, id asc
     `;
     return this.db.query<EarningsLedgerRow>(sql, [contributorUserId]).then((result) => result.rows);
+  }
+
+  listByOwnerOrgAndContributorUserId(input: {
+    ownerOrgId: string;
+    contributorUserId: string;
+  }): Promise<EarningsLedgerRow[]> {
+    const sql = `
+      select *
+      from ${TABLES.earningsLedger}
+      where owner_org_id = $1
+        and contributor_user_id = $2
+      order by created_at asc, id asc
+    `;
+    return this.db.query<EarningsLedgerRow>(sql, [input.ownerOrgId, input.contributorUserId]).then((result) => result.rows);
   }
 
   listByMeteringEventId(meteringEventId: string): Promise<EarningsLedgerRow[]> {
@@ -158,6 +184,7 @@ function assertEarningsLedgerReplayMatches(input: EarningsLedgerEntryInput, row:
     { field: 'amountMinor', expected: input.amountMinor, actual: row.amount_minor },
     { field: 'currency', expected: input.currency ?? 'USD', actual: row.currency },
     { field: 'actorUserId', expected: input.actorUserId ?? null, actual: row.actor_user_id },
+    { field: 'actorApiKeyId', expected: input.actorApiKeyId ?? null, actual: row.actor_api_key_id },
     { field: 'reason', expected: input.reason ?? null, actual: row.reason },
     { field: 'withdrawalRequestId', expected: input.withdrawalRequestId ?? null, actual: row.withdrawal_request_id },
     { field: 'payoutReference', expected: input.payoutReference ?? null, actual: row.payout_reference },

--- a/api/src/repos/withdrawalRequestRepository.ts
+++ b/api/src/repos/withdrawalRequestRepository.ts
@@ -26,6 +26,7 @@ export type WithdrawalRequestRow = {
   status: WithdrawalRequestStatus;
   requested_by_user_id: string;
   reviewed_by_user_id: string | null;
+  reviewed_by_api_key_id: string | null;
   note: string | null;
   settlement_reference: string | null;
   settlement_failure_reason: string | null;
@@ -77,7 +78,8 @@ export class WithdrawalRequestRepository {
   async transitionStatus(input: {
     id: string;
     nextStatus: WithdrawalRequestStatus;
-    actedByUserId: string;
+    actedByUserId: string | null;
+    actedByApiKeyId?: string | null;
     settlementReference?: string | null;
     settlementFailureReason?: string | null;
   }): Promise<WithdrawalRequestRow> {
@@ -95,8 +97,9 @@ export class WithdrawalRequestRepository {
       set
         status = $3,
         reviewed_by_user_id = $4,
-        settlement_reference = coalesce($5, settlement_reference),
-        settlement_failure_reason = $6,
+        reviewed_by_api_key_id = $5,
+        settlement_reference = coalesce($6, settlement_reference),
+        settlement_failure_reason = $7,
         updated_at = now()
       where id = $1
         and status = $2
@@ -107,6 +110,7 @@ export class WithdrawalRequestRepository {
       current.status,
       input.nextStatus,
       input.actedByUserId,
+      input.actedByApiKeyId ?? null,
       input.settlementReference ?? null,
       input.settlementFailureReason ?? null
     ];
@@ -137,6 +141,30 @@ export class WithdrawalRequestRepository {
       order by created_at desc
     `;
     return this.db.query<WithdrawalRequestRow>(sql, [contributorUserId]).then((result) => result.rows);
+  }
+
+  listByOwnerOrgAndContributorUserId(input: {
+    ownerOrgId: string;
+    contributorUserId: string;
+  }): Promise<WithdrawalRequestRow[]> {
+    const sql = `
+      select *
+      from ${TABLES.withdrawalRequests}
+      where owner_org_id = $1
+        and contributor_user_id = $2
+      order by created_at desc
+    `;
+    return this.db.query<WithdrawalRequestRow>(sql, [input.ownerOrgId, input.contributorUserId]).then((result) => result.rows);
+  }
+
+  listByOwnerOrgId(ownerOrgId: string): Promise<WithdrawalRequestRow[]> {
+    const sql = `
+      select *
+      from ${TABLES.withdrawalRequests}
+      where owner_org_id = $1
+      order by created_at desc
+    `;
+    return this.db.query<WithdrawalRequestRow>(sql, [ownerOrgId]).then((result) => result.rows);
   }
 
   private async expectOne(sql: string, params: SqlValue[]): Promise<WithdrawalRequestRow> {

--- a/api/src/routes/admin.ts
+++ b/api/src/routes/admin.ts
@@ -226,6 +226,37 @@ const createRateCardVersionSchema = z.object({
   lineItems: z.array(rateCardLineItemSchema).min(1)
 });
 
+const earningsProjectionListQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).optional().default(20)
+});
+
+const adminWithdrawalListQuerySchema = z.object({
+  ownerOrgId: z.string().min(1)
+});
+
+const adminWithdrawalActionSchema = z.discriminatedUnion('action', [
+  z.object({
+    action: z.literal('approve'),
+    reason: z.string().min(1).max(500).optional()
+  }),
+  z.object({
+    action: z.literal('reject'),
+    reason: z.string().min(1).max(500)
+  }),
+  z.object({
+    action: z.literal('mark_settled'),
+    settlementReference: z.string().min(1).max(500),
+    adjustmentMinor: z.number().int().optional(),
+    adjustmentReason: z.string().min(1).max(500).optional()
+  }),
+  z.object({
+    action: z.literal('mark_settlement_failed'),
+    settlementFailureReason: z.string().min(1).max(500),
+    adjustmentMinor: z.number().int().optional(),
+    adjustmentReason: z.string().min(1).max(500).optional()
+  })
+]);
+
 function isUniqueViolation(error: unknown): boolean {
   if (!error || typeof error !== 'object') return false;
   return (error as { code?: string }).code === '23505';
@@ -373,6 +404,101 @@ router.post('/v1/admin/pilot/rollback', requireApiKey(runtime.repos.apiKeys, ['a
     res.status(200).json({
       ok: true,
       rollbackId: result.rollbackRecord.id
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/v1/admin/pilot/earnings/projections', requireApiKey(runtime.repos.apiKeys, ['admin']), async (req, res, next) => {
+  try {
+    const query = earningsProjectionListQuerySchema.parse(req.query ?? {});
+    const projections = await runtime.services.earningsProjector.listProjectionBacklog({
+      limit: query.limit
+    });
+    res.status(200).json({
+      projections
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/v1/admin/pilot/earnings/projections/:meteringEventId/retry', requireApiKey(runtime.repos.apiKeys, ['admin']), async (req, res, next) => {
+  try {
+    const meteringEventId = z.string().min(1).parse(req.params.meteringEventId);
+    await runtime.services.earningsProjector.projectMeteringEvent(meteringEventId);
+    res.status(200).json({
+      ok: true,
+      meteringEventId
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/v1/admin/pilot/withdrawals', requireApiKey(runtime.repos.apiKeys, ['admin']), async (req, res, next) => {
+  try {
+    const query = adminWithdrawalListQuerySchema.parse(req.query ?? {});
+    const withdrawals = await runtime.services.withdrawals.listAdminWithdrawals(query.ownerOrgId);
+    res.status(200).json({
+      withdrawals
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/v1/admin/pilot/withdrawals/:withdrawalRequestId/actions', requireApiKey(runtime.repos.apiKeys, ['admin']), async (req, res, next) => {
+  try {
+    const withdrawalRequestId = z.string().min(1).parse(req.params.withdrawalRequestId);
+    const parsed = adminWithdrawalActionSchema.parse(req.body);
+    const actorUserId = null;
+    const actorApiKeyId = req.auth?.apiKeyId ?? null;
+
+    let withdrawal;
+    switch (parsed.action) {
+      case 'approve':
+        withdrawal = await runtime.services.withdrawals.approveWithdrawal({
+          withdrawalRequestId,
+          actorUserId,
+          actorApiKeyId,
+          reason: parsed.reason
+        });
+        break;
+      case 'reject':
+        withdrawal = await runtime.services.withdrawals.rejectWithdrawal({
+          withdrawalRequestId,
+          actorUserId,
+          actorApiKeyId,
+          reason: parsed.reason
+        });
+        break;
+      case 'mark_settled':
+        withdrawal = await runtime.services.withdrawals.markSettled({
+          withdrawalRequestId,
+          actorUserId,
+          actorApiKeyId,
+          settlementReference: parsed.settlementReference,
+          adjustmentMinor: parsed.adjustmentMinor,
+          adjustmentReason: parsed.adjustmentReason
+        });
+        break;
+      case 'mark_settlement_failed':
+        withdrawal = await runtime.services.withdrawals.markSettlementFailed({
+          withdrawalRequestId,
+          actorUserId,
+          actorApiKeyId,
+          settlementFailureReason: parsed.settlementFailureReason,
+          adjustmentMinor: parsed.adjustmentMinor,
+          adjustmentReason: parsed.adjustmentReason
+        });
+        break;
+    }
+
+    res.status(200).json({
+      ok: true,
+      withdrawal
     });
   } catch (error) {
     next(error);

--- a/api/src/routes/pilot.ts
+++ b/api/src/routes/pilot.ts
@@ -16,12 +16,45 @@ const pilotAuthCallbackQuerySchema = z.object({
   state: z.string().min(1)
 });
 
+const createWithdrawalSchema = z.object({
+  amountMinor: z.number().int().positive(),
+  destination: z.record(z.string(), z.unknown()),
+  note: z.string().trim().min(1).max(500).optional()
+});
+
 function normalizePilotReturnTo(value: string | undefined | null): string | undefined {
   const normalized = value?.trim();
   if (!normalized) return undefined;
   if (!normalized.startsWith('/')) return undefined;
   if (normalized.startsWith('//')) return undefined;
   return normalized;
+}
+
+function readPilotSessionContext(req: {
+  header(name: string): string | undefined;
+}): {
+  ownerOrgId: string;
+  contributorUserId: string;
+} {
+  const token = runtime.services.pilotSessions.readTokenFromRequest(req);
+  if (!token) {
+    throw new AppError('unauthorized', 401, 'Missing pilot session');
+  }
+
+  const session = runtime.services.pilotSessions.readSession(token);
+  if (!session) {
+    throw new AppError('unauthorized', 401, 'Invalid pilot session');
+  }
+
+  const contributorUserId = session.impersonatedUserId ?? session.actorUserId;
+  if (!contributorUserId) {
+    throw new AppError('forbidden', 403, 'Pilot session is not scoped to a contributor');
+  }
+
+  return {
+    ownerOrgId: session.effectiveOrgId,
+    contributorUserId
+  };
 }
 
 router.get('/v1/pilot/session', async (req, res, next) => {
@@ -76,6 +109,67 @@ router.post('/v1/pilot/session/logout', async (_req, res, next) => {
   try {
     res.setHeader('set-cookie', buildClearedPilotSessionCookie());
     res.status(200).json({ ok: true });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/v1/pilot/earnings/summary', async (req, res, next) => {
+  try {
+    const context = readPilotSessionContext(req);
+    const summary = await runtime.services.withdrawals.getContributorSummary(context);
+    res.status(200).json({
+      ok: true,
+      summary
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/v1/pilot/earnings/history', async (req, res, next) => {
+  try {
+    const context = readPilotSessionContext(req);
+    const entries = await runtime.services.withdrawals.listContributorHistory(context);
+    res.status(200).json({
+      ok: true,
+      entries
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/v1/pilot/withdrawals', async (req, res, next) => {
+  try {
+    const context = readPilotSessionContext(req);
+    const withdrawals = await runtime.services.withdrawals.listContributorWithdrawals(context);
+    res.status(200).json({
+      ok: true,
+      withdrawals
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/v1/pilot/withdrawals', async (req, res, next) => {
+  try {
+    const context = readPilotSessionContext(req);
+    const parsed = createWithdrawalSchema.parse(req.body);
+    const withdrawal = await runtime.services.withdrawals.createWithdrawalRequest({
+      ownerOrgId: context.ownerOrgId,
+      contributorUserId: context.contributorUserId,
+      requestedByUserId: context.contributorUserId,
+      amountMinor: parsed.amountMinor,
+      destination: parsed.destination,
+      note: parsed.note
+    });
+
+    res.status(200).json({
+      ok: true,
+      withdrawal
+    });
   } catch (error) {
     next(error);
   }

--- a/api/src/services/earnings/earningsProjectorService.ts
+++ b/api/src/services/earnings/earningsProjectorService.ts
@@ -1,0 +1,219 @@
+import type {
+  CanonicalMeteringEventRow,
+  CanonicalMeteringRepository
+} from '../../repos/canonicalMeteringRepository.js';
+import type {
+  EarningsLedgerRepository,
+  EarningsLedgerEntryInput
+} from '../../repos/earningsLedgerRepository.js';
+import type {
+  MeteringProjectorStateRepository,
+  MeteringProjectorStateRow
+} from '../../repos/meteringProjectorStateRepository.js';
+import { buildEarningsProjectionEffects } from '../metering/ledgerProjectionContracts.js';
+
+const DEFAULT_BACKLOG_LIMIT = 50;
+const DEFAULT_MAX_RETRIES = 5;
+const BASE_RETRY_DELAY_MS = 60_000;
+
+type EarningsProjectorDeps = {
+  canonicalMeteringRepo: Pick<CanonicalMeteringRepository, 'findById'>;
+  earningsLedgerRepo: Pick<EarningsLedgerRepository, 'appendEntry'>;
+  meteringProjectorStateRepo: Pick<
+    MeteringProjectorStateRepository,
+    'listByMeteringEventId' | 'markProjected' | 'markNeedsOperatorCorrection' | 'listByProjectorAndState'
+  >;
+  now?: () => Date;
+  maxRetries?: number;
+};
+
+export type EarningsProjectionBacklogItem = {
+  meteringEventId: string;
+  requestId: string | null;
+  contributorUserId: string | null;
+  ownerOrgId: string | null;
+  routingMode: string | null;
+  contributorEarningsMinor: number | null;
+  state: MeteringProjectorStateRow['state'];
+  retryCount: number;
+  nextRetryAt: string | null;
+  updatedAt: string;
+};
+
+export class EarningsProjectorService {
+  private readonly now: () => Date;
+  private readonly maxRetries: number;
+
+  constructor(private readonly deps: EarningsProjectorDeps) {
+    this.now = deps.now ?? (() => new Date());
+    this.maxRetries = Math.max(1, deps.maxRetries ?? DEFAULT_MAX_RETRIES);
+  }
+
+  async projectMeteringEvent(meteringEventId: string): Promise<void> {
+    const projectorState = await this.loadProjectorState(meteringEventId);
+
+    try {
+      const event = await this.requireMeteringEvent(meteringEventId);
+      this.assertProjectableEarningsEvent(event);
+
+      const drafts = buildEarningsProjectionEffects({
+        meteringEventId: event.id,
+        finalizationKind: event.finalization_kind,
+        buyerDebitMinor: event.buyer_debit_minor,
+        contributorEarningsMinor: event.contributor_earnings_minor
+      });
+
+      for (const draft of drafts) {
+        await this.deps.earningsLedgerRepo.appendEntry(this.buildLedgerEntry(event, draft));
+      }
+
+      await this.deps.meteringProjectorStateRepo.markProjected({
+        meteringEventId,
+        projector: 'earnings'
+      });
+    } catch (error) {
+      await this.deps.meteringProjectorStateRepo.markNeedsOperatorCorrection({
+        meteringEventId,
+        projector: 'earnings',
+        retryCount: (projectorState?.retry_count ?? 0) + 1,
+        lastAttemptAt: this.now(),
+        nextRetryAt: this.buildNextRetryAt((projectorState?.retry_count ?? 0) + 1),
+        lastErrorCode: 'projection_failed',
+        lastErrorMessage: error instanceof Error ? error.message : 'unknown projector failure'
+      });
+      throw error;
+    }
+  }
+
+  async retryBacklog(input?: { limit?: number }): Promise<{
+    processed: number;
+    projected: number;
+    failed: number;
+  }> {
+    const candidates = await this.listRetryCandidates(input?.limit ?? DEFAULT_BACKLOG_LIMIT);
+
+    let projected = 0;
+    let failed = 0;
+    for (const candidate of candidates) {
+      try {
+        await this.projectMeteringEvent(candidate.metering_event_id);
+        projected += 1;
+      } catch {
+        failed += 1;
+      }
+    }
+
+    return {
+      processed: candidates.length,
+      projected,
+      failed
+    };
+  }
+
+  async listProjectionBacklog(input?: { limit?: number }): Promise<EarningsProjectionBacklogItem[]> {
+    const candidates = await this.listBacklogCandidates(input?.limit ?? DEFAULT_BACKLOG_LIMIT);
+    const items: EarningsProjectionBacklogItem[] = [];
+
+    for (const candidate of candidates) {
+      const event = await this.deps.canonicalMeteringRepo.findById(candidate.metering_event_id);
+      items.push({
+        meteringEventId: candidate.metering_event_id,
+        requestId: event?.request_id ?? null,
+        contributorUserId: event?.capacity_owner_user_id ?? null,
+        ownerOrgId: event?.serving_org_id ?? null,
+        routingMode: event?.admission_routing_mode ?? null,
+        contributorEarningsMinor: event?.contributor_earnings_minor ?? null,
+        state: candidate.state,
+        retryCount: candidate.retry_count,
+        nextRetryAt: candidate.next_retry_at,
+        updatedAt: candidate.updated_at
+      });
+    }
+
+    return items;
+  }
+
+  private async listRetryCandidates(limit: number): Promise<MeteringProjectorStateRow[]> {
+    const backlog = await this.listBacklogCandidates(limit);
+    const now = this.now().getTime();
+    return backlog.filter((row) => (
+      row.state === 'pending_projection'
+      || (row.next_retry_at !== null && new Date(row.next_retry_at).getTime() <= now)
+    ));
+  }
+
+  private async listBacklogCandidates(limit: number): Promise<MeteringProjectorStateRow[]> {
+    const pending = await this.deps.meteringProjectorStateRepo.listByProjectorAndState({
+      projector: 'earnings',
+      state: 'pending_projection'
+    });
+    const needsOperatorCorrection = await this.deps.meteringProjectorStateRepo.listByProjectorAndState({
+      projector: 'earnings',
+      state: 'needs_operator_correction'
+    });
+    return [...pending, ...needsOperatorCorrection.filter((row) => (
+      row.state === 'needs_operator_correction'
+    ))]
+      .sort((left, right) => new Date(left.updated_at).getTime() - new Date(right.updated_at).getTime())
+      .slice(0, Math.max(1, limit));
+  }
+
+  private async loadProjectorState(meteringEventId: string): Promise<MeteringProjectorStateRow | null> {
+    const rows = await this.deps.meteringProjectorStateRepo.listByMeteringEventId(meteringEventId);
+    return rows.find((row) => row.projector === 'earnings') ?? null;
+  }
+
+  private async requireMeteringEvent(meteringEventId: string): Promise<CanonicalMeteringEventRow> {
+    const event = await this.deps.canonicalMeteringRepo.findById(meteringEventId);
+    if (!event) {
+      throw new Error(`canonical metering event not found: ${meteringEventId}`);
+    }
+    return event;
+  }
+
+  private assertProjectableEarningsEvent(event: CanonicalMeteringEventRow): void {
+    if (event.contributor_earnings_minor === 0) {
+      return;
+    }
+
+    if (event.admission_routing_mode !== 'team-overflow-on-contributor-capacity') {
+      throw new Error('contributor earnings are only allowed for team-overflow-on-contributor-capacity');
+    }
+
+    if (!event.capacity_owner_user_id) {
+      throw new Error('contributor earnings metering is missing capacity_owner_user_id');
+    }
+  }
+
+  private buildLedgerEntry(
+    event: CanonicalMeteringEventRow,
+    draft: ReturnType<typeof buildEarningsProjectionEffects>[number]
+  ): EarningsLedgerEntryInput {
+    return {
+      ownerOrgId: event.serving_org_id,
+      contributorUserId: event.capacity_owner_user_id ?? '',
+      meteringEventId: event.id,
+      effectType: draft.effectType,
+      balanceBucket: draft.effectType === 'contributor_accrual' ? 'withdrawable' : 'adjusted',
+      amountMinor: draft.amountMinor,
+      currency: event.currency,
+      metadata: {
+        requestId: event.request_id,
+        attemptNo: event.attempt_no,
+        routingMode: event.admission_routing_mode,
+        provider: event.provider,
+        model: event.model,
+        rateCardVersionId: event.rate_card_version_id
+      }
+    };
+  }
+
+  private buildNextRetryAt(retryCount: number): Date | null {
+    if (retryCount >= this.maxRetries) {
+      return null;
+    }
+
+    const multiplier = Math.max(1, retryCount);
+    return new Date(this.now().getTime() + BASE_RETRY_DELAY_MS * multiplier);
+  }
+}

--- a/api/src/services/earnings/withdrawalService.ts
+++ b/api/src/services/earnings/withdrawalService.ts
@@ -27,7 +27,7 @@ type WithdrawalServiceDeps = {
   meteringProjectorStateRepo: Pick<MeteringProjectorStateRepository, 'listByProjectorAndState'>;
   repoFactory?: {
     earningsLedger?: (tx: TransactionContext) => Pick<EarningsLedgerRepository, 'appendEntry' | 'listByOwnerOrgAndContributorUserId'>;
-    withdrawalRequests?: (tx: TransactionContext) => Pick<WithdrawalRequestRepository, 'create'>;
+    withdrawalRequests?: (tx: TransactionContext) => Pick<WithdrawalRequestRepository, 'create' | 'findById' | 'transitionStatus'>;
   };
 };
 
@@ -80,10 +80,7 @@ export class WithdrawalService {
         [input.ownerOrgId, input.contributorUserId]
       );
 
-      const txEarningsLedgerRepo = this.deps.repoFactory?.earningsLedger?.(tx)
-        ?? new EarningsLedgerRepositoryImpl(tx as unknown as SqlClient);
-      const txWithdrawalRequestRepo = this.deps.repoFactory?.withdrawalRequests?.(tx)
-        ?? new WithdrawalRequestRepositoryImpl(tx as unknown as SqlClient);
+      const { earningsLedgerRepo: txEarningsLedgerRepo, withdrawalRequestRepo: txWithdrawalRequestRepo } = this.buildTxRepos(tx);
 
       const ledgerEntries = await txEarningsLedgerRepo.listByOwnerOrgAndContributorUserId({
         ownerOrgId: input.ownerOrgId,
@@ -120,43 +117,46 @@ export class WithdrawalService {
     actorApiKeyId: string | null;
     reason?: string | null;
   }): Promise<WithdrawalRequestRow> {
-    const request = await this.requireWithdrawal(input.withdrawalRequestId);
+    return this.deps.sql.transaction(async (tx) => {
+      const { earningsLedgerRepo, withdrawalRequestRepo } = this.buildTxRepos(tx);
+      const request = await this.requireWithdrawal(withdrawalRequestRepo, input.withdrawalRequestId);
 
-    if (request.status === 'requested') {
-      await this.deps.withdrawalRequestRepo.transitionStatus({
-        id: request.id,
-        nextStatus: 'under_review',
-        actedByUserId: input.actorUserId,
-        actedByApiKeyId: input.actorApiKeyId
-      });
-      return this.deps.withdrawalRequestRepo.transitionStatus({
+      if (request.status === 'requested') {
+        await withdrawalRequestRepo.transitionStatus({
+          id: request.id,
+          nextStatus: 'under_review',
+          actedByUserId: input.actorUserId,
+          actedByApiKeyId: input.actorApiKeyId
+        });
+        return withdrawalRequestRepo.transitionStatus({
+          id: request.id,
+          nextStatus: 'approved',
+          actedByUserId: input.actorUserId,
+          actedByApiKeyId: input.actorApiKeyId
+        });
+      }
+
+      if (request.status === 'settlement_failed') {
+        await earningsLedgerRepo.appendEntry({
+          ownerOrgId: request.owner_org_id,
+          contributorUserId: request.contributor_user_id,
+          effectType: 'withdrawal_reserve',
+          balanceBucket: 'reserved_for_payout',
+          amountMinor: request.amount_minor,
+          currency: request.currency,
+          actorUserId: input.actorUserId,
+          actorApiKeyId: input.actorApiKeyId,
+          reason: input.reason ?? 'withdrawal re-approved after settlement failure',
+          withdrawalRequestId: request.id
+        });
+      }
+
+      return withdrawalRequestRepo.transitionStatus({
         id: request.id,
         nextStatus: 'approved',
         actedByUserId: input.actorUserId,
         actedByApiKeyId: input.actorApiKeyId
       });
-    }
-
-    if (request.status === 'settlement_failed') {
-      await this.deps.earningsLedgerRepo.appendEntry({
-        ownerOrgId: request.owner_org_id,
-        contributorUserId: request.contributor_user_id,
-        effectType: 'withdrawal_reserve',
-        balanceBucket: 'reserved_for_payout',
-        amountMinor: request.amount_minor,
-        currency: request.currency,
-        actorUserId: input.actorUserId,
-        actorApiKeyId: input.actorApiKeyId,
-        reason: input.reason ?? 'withdrawal re-approved after settlement failure',
-        withdrawalRequestId: request.id
-      });
-    }
-
-    return this.deps.withdrawalRequestRepo.transitionStatus({
-      id: request.id,
-      nextStatus: 'approved',
-      actedByUserId: input.actorUserId,
-      actedByApiKeyId: input.actorApiKeyId
     });
   }
 
@@ -166,40 +166,43 @@ export class WithdrawalService {
     actorApiKeyId: string | null;
     reason: string;
   }): Promise<WithdrawalRequestRow> {
-    const request = await this.requireWithdrawal(input.withdrawalRequestId);
+    return this.deps.sql.transaction(async (tx) => {
+      const { earningsLedgerRepo, withdrawalRequestRepo } = this.buildTxRepos(tx);
+      const request = await this.requireWithdrawal(withdrawalRequestRepo, input.withdrawalRequestId);
 
-    if (request.status === 'requested') {
-      await this.deps.withdrawalRequestRepo.transitionStatus({
+      if (request.status === 'requested') {
+        await withdrawalRequestRepo.transitionStatus({
+          id: request.id,
+          nextStatus: 'under_review',
+          actedByUserId: input.actorUserId,
+          actedByApiKeyId: input.actorApiKeyId
+        });
+      }
+
+      const rejected = await withdrawalRequestRepo.transitionStatus({
         id: request.id,
-        nextStatus: 'under_review',
+        nextStatus: 'rejected',
         actedByUserId: input.actorUserId,
         actedByApiKeyId: input.actorApiKeyId
       });
-    }
 
-    const rejected = await this.deps.withdrawalRequestRepo.transitionStatus({
-      id: request.id,
-      nextStatus: 'rejected',
-      actedByUserId: input.actorUserId,
-      actedByApiKeyId: input.actorApiKeyId
+      if (request.status !== 'settlement_failed') {
+        await earningsLedgerRepo.appendEntry({
+          ownerOrgId: request.owner_org_id,
+          contributorUserId: request.contributor_user_id,
+          effectType: 'withdrawal_release',
+          balanceBucket: 'withdrawable',
+          amountMinor: request.amount_minor,
+          currency: request.currency,
+          actorUserId: input.actorUserId,
+          actorApiKeyId: input.actorApiKeyId,
+          reason: input.reason,
+          withdrawalRequestId: request.id
+        });
+      }
+
+      return rejected;
     });
-
-    if (request.status !== 'settlement_failed') {
-      await this.deps.earningsLedgerRepo.appendEntry({
-        ownerOrgId: request.owner_org_id,
-        contributorUserId: request.contributor_user_id,
-        effectType: 'withdrawal_release',
-        balanceBucket: 'withdrawable',
-        amountMinor: request.amount_minor,
-        currency: request.currency,
-        actorUserId: input.actorUserId,
-        actorApiKeyId: input.actorApiKeyId,
-        reason: input.reason,
-        withdrawalRequestId: request.id
-      });
-    }
-
-    return rejected;
   }
 
   async markSettlementFailed(input: {
@@ -210,36 +213,39 @@ export class WithdrawalService {
     adjustmentMinor?: number;
     adjustmentReason?: string | null;
   }): Promise<WithdrawalRequestRow> {
-    const request = await this.requireWithdrawal(input.withdrawalRequestId);
-    const updated = await this.deps.withdrawalRequestRepo.transitionStatus({
-      id: request.id,
-      nextStatus: 'settlement_failed',
-      actedByUserId: input.actorUserId,
-      actedByApiKeyId: input.actorApiKeyId,
-      settlementFailureReason: input.settlementFailureReason
-    });
+    return this.deps.sql.transaction(async (tx) => {
+      const { earningsLedgerRepo, withdrawalRequestRepo } = this.buildTxRepos(tx);
+      const request = await this.requireWithdrawal(withdrawalRequestRepo, input.withdrawalRequestId);
+      const updated = await withdrawalRequestRepo.transitionStatus({
+        id: request.id,
+        nextStatus: 'settlement_failed',
+        actedByUserId: input.actorUserId,
+        actedByApiKeyId: input.actorApiKeyId,
+        settlementFailureReason: input.settlementFailureReason
+      });
 
-    await this.deps.earningsLedgerRepo.appendEntry({
-      ownerOrgId: request.owner_org_id,
-      contributorUserId: request.contributor_user_id,
-      effectType: 'withdrawal_release',
-      balanceBucket: 'withdrawable',
-      amountMinor: request.amount_minor,
-      currency: request.currency,
-      actorUserId: input.actorUserId,
-      actorApiKeyId: input.actorApiKeyId,
-      reason: input.settlementFailureReason,
-      withdrawalRequestId: request.id
-    });
+      await earningsLedgerRepo.appendEntry({
+        ownerOrgId: request.owner_org_id,
+        contributorUserId: request.contributor_user_id,
+        effectType: 'withdrawal_release',
+        balanceBucket: 'withdrawable',
+        amountMinor: request.amount_minor,
+        currency: request.currency,
+        actorUserId: input.actorUserId,
+        actorApiKeyId: input.actorApiKeyId,
+        reason: input.settlementFailureReason,
+        withdrawalRequestId: request.id
+      });
 
-    await this.appendAdjustmentIfNeeded(request, {
-      actorUserId: input.actorUserId,
-      actorApiKeyId: input.actorApiKeyId,
-      adjustmentMinor: input.adjustmentMinor,
-      adjustmentReason: input.adjustmentReason ?? input.settlementFailureReason
-    });
+      await this.appendAdjustmentIfNeeded(earningsLedgerRepo, request, {
+        actorUserId: input.actorUserId,
+        actorApiKeyId: input.actorApiKeyId,
+        adjustmentMinor: input.adjustmentMinor,
+        adjustmentReason: input.adjustmentReason ?? input.settlementFailureReason
+      });
 
-    return updated;
+      return updated;
+    });
   }
 
   async markSettled(input: {
@@ -250,37 +256,40 @@ export class WithdrawalService {
     adjustmentMinor?: number;
     adjustmentReason?: string | null;
   }): Promise<WithdrawalRequestRow> {
-    const request = await this.requireWithdrawal(input.withdrawalRequestId);
-    const updated = await this.deps.withdrawalRequestRepo.transitionStatus({
-      id: request.id,
-      nextStatus: 'settled',
-      actedByUserId: input.actorUserId,
-      actedByApiKeyId: input.actorApiKeyId,
-      settlementReference: input.settlementReference
-    });
+    return this.deps.sql.transaction(async (tx) => {
+      const { earningsLedgerRepo, withdrawalRequestRepo } = this.buildTxRepos(tx);
+      const request = await this.requireWithdrawal(withdrawalRequestRepo, input.withdrawalRequestId);
+      const updated = await withdrawalRequestRepo.transitionStatus({
+        id: request.id,
+        nextStatus: 'settled',
+        actedByUserId: input.actorUserId,
+        actedByApiKeyId: input.actorApiKeyId,
+        settlementReference: input.settlementReference
+      });
 
-    await this.deps.earningsLedgerRepo.appendEntry({
-      ownerOrgId: request.owner_org_id,
-      contributorUserId: request.contributor_user_id,
-      effectType: 'payout_settlement',
-      balanceBucket: 'settled',
-      amountMinor: request.amount_minor,
-      currency: request.currency,
-      actorUserId: input.actorUserId,
-      actorApiKeyId: input.actorApiKeyId,
-      reason: 'withdrawal settled',
-      withdrawalRequestId: request.id,
-      payoutReference: input.settlementReference
-    });
+      await earningsLedgerRepo.appendEntry({
+        ownerOrgId: request.owner_org_id,
+        contributorUserId: request.contributor_user_id,
+        effectType: 'payout_settlement',
+        balanceBucket: 'settled',
+        amountMinor: request.amount_minor,
+        currency: request.currency,
+        actorUserId: input.actorUserId,
+        actorApiKeyId: input.actorApiKeyId,
+        reason: 'withdrawal settled',
+        withdrawalRequestId: request.id,
+        payoutReference: input.settlementReference
+      });
 
-    await this.appendAdjustmentIfNeeded(request, {
-      actorUserId: input.actorUserId,
-      actorApiKeyId: input.actorApiKeyId,
-      adjustmentMinor: input.adjustmentMinor,
-      adjustmentReason: input.adjustmentReason ?? 'payout adjustment'
-    });
+      await this.appendAdjustmentIfNeeded(earningsLedgerRepo, request, {
+        actorUserId: input.actorUserId,
+        actorApiKeyId: input.actorApiKeyId,
+        adjustmentMinor: input.adjustmentMinor,
+        adjustmentReason: input.adjustmentReason ?? 'payout adjustment'
+      });
 
-    return updated;
+      return updated;
+    });
   }
 
   async listAdminWithdrawals(ownerOrgId: string): Promise<WithdrawalRequestRow[]> {
@@ -328,7 +337,20 @@ export class WithdrawalService {
     return event.contributor_earnings_minor;
   }
 
+  private buildTxRepos(tx: TransactionContext): {
+    earningsLedgerRepo: Pick<EarningsLedgerRepository, 'appendEntry' | 'listByOwnerOrgAndContributorUserId'>;
+    withdrawalRequestRepo: Pick<WithdrawalRequestRepository, 'create' | 'findById' | 'transitionStatus'>;
+  } {
+    return {
+      earningsLedgerRepo: this.deps.repoFactory?.earningsLedger?.(tx)
+        ?? new EarningsLedgerRepositoryImpl(tx as unknown as SqlClient),
+      withdrawalRequestRepo: this.deps.repoFactory?.withdrawalRequests?.(tx)
+        ?? new WithdrawalRequestRepositoryImpl(tx as unknown as SqlClient)
+    };
+  }
+
   private async appendAdjustmentIfNeeded(
+    earningsLedgerRepo: Pick<EarningsLedgerRepository, 'appendEntry'>,
     request: WithdrawalRequestRow,
     input: {
       actorUserId: string | null;
@@ -341,7 +363,7 @@ export class WithdrawalService {
       return;
     }
 
-    await this.deps.earningsLedgerRepo.appendEntry({
+    await earningsLedgerRepo.appendEntry({
       ownerOrgId: request.owner_org_id,
       contributorUserId: request.contributor_user_id,
       effectType: 'payout_adjustment',
@@ -356,8 +378,11 @@ export class WithdrawalService {
     });
   }
 
-  private async requireWithdrawal(id: string): Promise<WithdrawalRequestRow> {
-    const request = await this.deps.withdrawalRequestRepo.findById(id);
+  private async requireWithdrawal(
+    withdrawalRequestRepo: Pick<WithdrawalRequestRepository, 'findById'>,
+    id: string
+  ): Promise<WithdrawalRequestRow> {
+    const request = await withdrawalRequestRepo.findById(id);
     if (!request) {
       throw new Error(`withdrawal request not found: ${id}`);
     }

--- a/api/src/services/earnings/withdrawalService.ts
+++ b/api/src/services/earnings/withdrawalService.ts
@@ -237,7 +237,7 @@ export class WithdrawalService {
         withdrawalRequestId: request.id
       });
 
-      await this.appendAdjustmentIfNeeded(earningsLedgerRepo, request, {
+      await this.appendAdjustmentIfNeeded(earningsLedgerRepo, updated, {
         actorUserId: input.actorUserId,
         actorApiKeyId: input.actorApiKeyId,
         adjustmentMinor: input.adjustmentMinor,
@@ -281,7 +281,7 @@ export class WithdrawalService {
         payoutReference: input.settlementReference
       });
 
-      await this.appendAdjustmentIfNeeded(earningsLedgerRepo, request, {
+      await this.appendAdjustmentIfNeeded(earningsLedgerRepo, updated, {
         actorUserId: input.actorUserId,
         actorApiKeyId: input.actorApiKeyId,
         adjustmentMinor: input.adjustmentMinor,

--- a/api/src/services/earnings/withdrawalService.ts
+++ b/api/src/services/earnings/withdrawalService.ts
@@ -1,0 +1,401 @@
+import type { SqlClient, TransactionContext } from '../../repos/sqlClient.js';
+import type { CanonicalMeteringRepository } from '../../repos/canonicalMeteringRepository.js';
+import type {
+  EarningsLedgerRepository,
+  EarningsLedgerRow
+} from '../../repos/earningsLedgerRepository.js';
+import type {
+  MeteringProjectorStateRepository,
+  MeteringProjectorStateRow
+} from '../../repos/meteringProjectorStateRepository.js';
+import type {
+  CreateWithdrawalRequestInput,
+  WithdrawalRequestRepository,
+  WithdrawalRequestRow
+} from '../../repos/withdrawalRequestRepository.js';
+import { EarningsLedgerRepository as EarningsLedgerRepositoryImpl } from '../../repos/earningsLedgerRepository.js';
+import { WithdrawalRequestRepository as WithdrawalRequestRepositoryImpl } from '../../repos/withdrawalRequestRepository.js';
+
+type WithdrawalServiceDeps = {
+  sql: Pick<SqlClient, 'transaction'>;
+  earningsLedgerRepo: Pick<EarningsLedgerRepository, 'appendEntry' | 'listByOwnerOrgAndContributorUserId'>;
+  withdrawalRequestRepo: Pick<
+    WithdrawalRequestRepository,
+    'findById' | 'listByOwnerOrgAndContributorUserId' | 'listByOwnerOrgId' | 'transitionStatus'
+  >;
+  canonicalMeteringRepo: Pick<CanonicalMeteringRepository, 'findById'>;
+  meteringProjectorStateRepo: Pick<MeteringProjectorStateRepository, 'listByProjectorAndState'>;
+  repoFactory?: {
+    earningsLedger?: (tx: TransactionContext) => Pick<EarningsLedgerRepository, 'appendEntry' | 'listByOwnerOrgAndContributorUserId'>;
+    withdrawalRequests?: (tx: TransactionContext) => Pick<WithdrawalRequestRepository, 'create'>;
+  };
+};
+
+export type ContributorEarningsSummary = {
+  pendingMinor: number;
+  withdrawableMinor: number;
+  reservedForPayoutMinor: number;
+  settledMinor: number;
+  adjustedMinor: number;
+};
+
+export class WithdrawalService {
+  constructor(private readonly deps: WithdrawalServiceDeps) {}
+
+  async getContributorSummary(input: {
+    ownerOrgId: string;
+    contributorUserId: string;
+  }): Promise<ContributorEarningsSummary> {
+    const ledgerEntries = await this.deps.earningsLedgerRepo.listByOwnerOrgAndContributorUserId(input);
+    const pendingMinor = await this.computePendingMinor(input);
+    const posted = summarizePostedLedger(ledgerEntries);
+
+    return {
+      pendingMinor,
+      withdrawableMinor: posted.withdrawableMinor,
+      reservedForPayoutMinor: posted.reservedForPayoutMinor,
+      settledMinor: posted.settledMinor,
+      adjustedMinor: posted.adjustedMinor
+    };
+  }
+
+  async listContributorHistory(input: {
+    ownerOrgId: string;
+    contributorUserId: string;
+  }): Promise<EarningsLedgerRow[]> {
+    return this.deps.earningsLedgerRepo.listByOwnerOrgAndContributorUserId(input);
+  }
+
+  async listContributorWithdrawals(input: {
+    ownerOrgId: string;
+    contributorUserId: string;
+  }): Promise<WithdrawalRequestRow[]> {
+    return this.deps.withdrawalRequestRepo.listByOwnerOrgAndContributorUserId(input);
+  }
+
+  async createWithdrawalRequest(input: CreateWithdrawalRequestInput): Promise<WithdrawalRequestRow> {
+    return this.deps.sql.transaction(async (tx) => {
+      await tx.query(
+        'select pg_advisory_xact_lock(hashtext($1), hashtext($2))',
+        [input.ownerOrgId, input.contributorUserId]
+      );
+
+      const txEarningsLedgerRepo = this.deps.repoFactory?.earningsLedger?.(tx)
+        ?? new EarningsLedgerRepositoryImpl(tx as unknown as SqlClient);
+      const txWithdrawalRequestRepo = this.deps.repoFactory?.withdrawalRequests?.(tx)
+        ?? new WithdrawalRequestRepositoryImpl(tx as unknown as SqlClient);
+
+      const ledgerEntries = await txEarningsLedgerRepo.listByOwnerOrgAndContributorUserId({
+        ownerOrgId: input.ownerOrgId,
+        contributorUserId: input.contributorUserId
+      });
+      const posted = summarizePostedLedger(ledgerEntries);
+      if (input.amountMinor > Math.max(0, posted.withdrawableMinor)) {
+        throw new Error('withdrawal amount exceeds withdrawable earnings');
+      }
+
+      const created = await txWithdrawalRequestRepo.create(input);
+      await txEarningsLedgerRepo.appendEntry({
+        ownerOrgId: input.ownerOrgId,
+        contributorUserId: input.contributorUserId,
+        effectType: 'withdrawal_reserve',
+        balanceBucket: 'reserved_for_payout',
+        amountMinor: input.amountMinor,
+        currency: input.currency ?? 'USD',
+        actorUserId: input.requestedByUserId,
+        reason: input.note ?? 'withdrawal requested',
+        withdrawalRequestId: created.id,
+        metadata: {
+          destination: input.destination
+        }
+      });
+
+      return created;
+    });
+  }
+
+  async approveWithdrawal(input: {
+    withdrawalRequestId: string;
+    actorUserId: string | null;
+    actorApiKeyId: string | null;
+    reason?: string | null;
+  }): Promise<WithdrawalRequestRow> {
+    const request = await this.requireWithdrawal(input.withdrawalRequestId);
+
+    if (request.status === 'requested') {
+      await this.deps.withdrawalRequestRepo.transitionStatus({
+        id: request.id,
+        nextStatus: 'under_review',
+        actedByUserId: input.actorUserId,
+        actedByApiKeyId: input.actorApiKeyId
+      });
+      return this.deps.withdrawalRequestRepo.transitionStatus({
+        id: request.id,
+        nextStatus: 'approved',
+        actedByUserId: input.actorUserId,
+        actedByApiKeyId: input.actorApiKeyId
+      });
+    }
+
+    if (request.status === 'settlement_failed') {
+      await this.deps.earningsLedgerRepo.appendEntry({
+        ownerOrgId: request.owner_org_id,
+        contributorUserId: request.contributor_user_id,
+        effectType: 'withdrawal_reserve',
+        balanceBucket: 'reserved_for_payout',
+        amountMinor: request.amount_minor,
+        currency: request.currency,
+        actorUserId: input.actorUserId,
+        actorApiKeyId: input.actorApiKeyId,
+        reason: input.reason ?? 'withdrawal re-approved after settlement failure',
+        withdrawalRequestId: request.id
+      });
+    }
+
+    return this.deps.withdrawalRequestRepo.transitionStatus({
+      id: request.id,
+      nextStatus: 'approved',
+      actedByUserId: input.actorUserId,
+      actedByApiKeyId: input.actorApiKeyId
+    });
+  }
+
+  async rejectWithdrawal(input: {
+    withdrawalRequestId: string;
+    actorUserId: string | null;
+    actorApiKeyId: string | null;
+    reason: string;
+  }): Promise<WithdrawalRequestRow> {
+    const request = await this.requireWithdrawal(input.withdrawalRequestId);
+
+    if (request.status === 'requested') {
+      await this.deps.withdrawalRequestRepo.transitionStatus({
+        id: request.id,
+        nextStatus: 'under_review',
+        actedByUserId: input.actorUserId,
+        actedByApiKeyId: input.actorApiKeyId
+      });
+    }
+
+    const rejected = await this.deps.withdrawalRequestRepo.transitionStatus({
+      id: request.id,
+      nextStatus: 'rejected',
+      actedByUserId: input.actorUserId,
+      actedByApiKeyId: input.actorApiKeyId
+    });
+
+    if (request.status !== 'settlement_failed') {
+      await this.deps.earningsLedgerRepo.appendEntry({
+        ownerOrgId: request.owner_org_id,
+        contributorUserId: request.contributor_user_id,
+        effectType: 'withdrawal_release',
+        balanceBucket: 'withdrawable',
+        amountMinor: request.amount_minor,
+        currency: request.currency,
+        actorUserId: input.actorUserId,
+        actorApiKeyId: input.actorApiKeyId,
+        reason: input.reason,
+        withdrawalRequestId: request.id
+      });
+    }
+
+    return rejected;
+  }
+
+  async markSettlementFailed(input: {
+    withdrawalRequestId: string;
+    actorUserId: string | null;
+    actorApiKeyId: string | null;
+    settlementFailureReason: string;
+    adjustmentMinor?: number;
+    adjustmentReason?: string | null;
+  }): Promise<WithdrawalRequestRow> {
+    const request = await this.requireWithdrawal(input.withdrawalRequestId);
+    const updated = await this.deps.withdrawalRequestRepo.transitionStatus({
+      id: request.id,
+      nextStatus: 'settlement_failed',
+      actedByUserId: input.actorUserId,
+      actedByApiKeyId: input.actorApiKeyId,
+      settlementFailureReason: input.settlementFailureReason
+    });
+
+    await this.deps.earningsLedgerRepo.appendEntry({
+      ownerOrgId: request.owner_org_id,
+      contributorUserId: request.contributor_user_id,
+      effectType: 'withdrawal_release',
+      balanceBucket: 'withdrawable',
+      amountMinor: request.amount_minor,
+      currency: request.currency,
+      actorUserId: input.actorUserId,
+      actorApiKeyId: input.actorApiKeyId,
+      reason: input.settlementFailureReason,
+      withdrawalRequestId: request.id
+    });
+
+    await this.appendAdjustmentIfNeeded(request, {
+      actorUserId: input.actorUserId,
+      actorApiKeyId: input.actorApiKeyId,
+      adjustmentMinor: input.adjustmentMinor,
+      adjustmentReason: input.adjustmentReason ?? input.settlementFailureReason
+    });
+
+    return updated;
+  }
+
+  async markSettled(input: {
+    withdrawalRequestId: string;
+    actorUserId: string | null;
+    actorApiKeyId: string | null;
+    settlementReference: string;
+    adjustmentMinor?: number;
+    adjustmentReason?: string | null;
+  }): Promise<WithdrawalRequestRow> {
+    const request = await this.requireWithdrawal(input.withdrawalRequestId);
+    const updated = await this.deps.withdrawalRequestRepo.transitionStatus({
+      id: request.id,
+      nextStatus: 'settled',
+      actedByUserId: input.actorUserId,
+      actedByApiKeyId: input.actorApiKeyId,
+      settlementReference: input.settlementReference
+    });
+
+    await this.deps.earningsLedgerRepo.appendEntry({
+      ownerOrgId: request.owner_org_id,
+      contributorUserId: request.contributor_user_id,
+      effectType: 'payout_settlement',
+      balanceBucket: 'settled',
+      amountMinor: request.amount_minor,
+      currency: request.currency,
+      actorUserId: input.actorUserId,
+      actorApiKeyId: input.actorApiKeyId,
+      reason: 'withdrawal settled',
+      withdrawalRequestId: request.id,
+      payoutReference: input.settlementReference
+    });
+
+    await this.appendAdjustmentIfNeeded(request, {
+      actorUserId: input.actorUserId,
+      actorApiKeyId: input.actorApiKeyId,
+      adjustmentMinor: input.adjustmentMinor,
+      adjustmentReason: input.adjustmentReason ?? 'payout adjustment'
+    });
+
+    return updated;
+  }
+
+  async listAdminWithdrawals(ownerOrgId: string): Promise<WithdrawalRequestRow[]> {
+    return this.deps.withdrawalRequestRepo.listByOwnerOrgId(ownerOrgId);
+  }
+
+  private async computePendingMinor(input: {
+    ownerOrgId: string;
+    contributorUserId: string;
+  }): Promise<number> {
+    const pending = await this.deps.meteringProjectorStateRepo.listByProjectorAndState({
+      projector: 'earnings',
+      state: 'pending_projection'
+    });
+    const stuck = await this.deps.meteringProjectorStateRepo.listByProjectorAndState({
+      projector: 'earnings',
+      state: 'needs_operator_correction'
+    });
+
+    let total = 0;
+    for (const row of [...pending, ...stuck]) {
+      total += await this.pendingMinorForRow(row, input);
+    }
+
+    return total;
+  }
+
+  private async pendingMinorForRow(
+    row: Pick<MeteringProjectorStateRow, 'metering_event_id'>,
+    input: { ownerOrgId: string; contributorUserId: string; }
+  ): Promise<number> {
+    const event = await this.deps.canonicalMeteringRepo.findById(row.metering_event_id);
+    if (!event) {
+      return 0;
+    }
+    if (event.serving_org_id !== input.ownerOrgId) {
+      return 0;
+    }
+    if (event.capacity_owner_user_id !== input.contributorUserId) {
+      return 0;
+    }
+    if (event.admission_routing_mode !== 'team-overflow-on-contributor-capacity') {
+      return 0;
+    }
+    return event.contributor_earnings_minor;
+  }
+
+  private async appendAdjustmentIfNeeded(
+    request: WithdrawalRequestRow,
+    input: {
+      actorUserId: string | null;
+      actorApiKeyId: string | null;
+      adjustmentMinor?: number;
+      adjustmentReason?: string | null;
+    }
+  ): Promise<void> {
+    if (!input.adjustmentMinor) {
+      return;
+    }
+
+    await this.deps.earningsLedgerRepo.appendEntry({
+      ownerOrgId: request.owner_org_id,
+      contributorUserId: request.contributor_user_id,
+      effectType: 'payout_adjustment',
+      balanceBucket: 'adjusted',
+      amountMinor: input.adjustmentMinor,
+      currency: request.currency,
+      actorUserId: input.actorUserId,
+      actorApiKeyId: input.actorApiKeyId,
+      reason: input.adjustmentReason ?? 'payout adjustment',
+      withdrawalRequestId: request.id,
+      payoutReference: request.settlement_reference
+    });
+  }
+
+  private async requireWithdrawal(id: string): Promise<WithdrawalRequestRow> {
+    const request = await this.deps.withdrawalRequestRepo.findById(id);
+    if (!request) {
+      throw new Error(`withdrawal request not found: ${id}`);
+    }
+    return request;
+  }
+}
+
+function sumLedgerAmounts(
+  rows: Array<Pick<EarningsLedgerRow, 'effect_type' | 'amount_minor'>>,
+  effectTypes: readonly string[]
+): number {
+  return rows
+    .filter((row) => effectTypes.includes(row.effect_type))
+    .reduce((sum, row) => sum + row.amount_minor, 0);
+}
+
+function summarizePostedLedger(rows: Array<Pick<EarningsLedgerRow, 'effect_type' | 'amount_minor'>>): {
+  withdrawableMinor: number;
+  reservedForPayoutMinor: number;
+  settledMinor: number;
+  adjustedMinor: number;
+} {
+  const accrualMinor = sumLedgerAmounts(rows, ['contributor_accrual']);
+  const adjustedMinor = sumLedgerAmounts(rows, [
+    'contributor_correction',
+    'contributor_reversal',
+    'payout_adjustment'
+  ]);
+  const reserveMinor = sumLedgerAmounts(rows, ['withdrawal_reserve']);
+  const releaseMinor = sumLedgerAmounts(rows, ['withdrawal_release']);
+  const settledMinor = sumLedgerAmounts(rows, ['payout_settlement']);
+  const reservedForPayoutMinor = reserveMinor - releaseMinor - settledMinor;
+  const withdrawableMinor = accrualMinor + adjustedMinor - reservedForPayoutMinor - settledMinor;
+
+  return {
+    withdrawableMinor,
+    reservedForPayoutMinor,
+    settledMinor,
+    adjustedMinor
+  };
+}

--- a/api/src/services/runtime.ts
+++ b/api/src/services/runtime.ts
@@ -2,6 +2,7 @@ import { buildPgClient } from '../repos/pgClient.js';
 import { ApiKeyRepository } from '../repos/apiKeyRepository.js';
 import { AuditLogRepository } from '../repos/auditLogRepository.js';
 import { CanonicalMeteringRepository } from '../repos/canonicalMeteringRepository.js';
+import { EarningsLedgerRepository } from '../repos/earningsLedgerRepository.js';
 import { FnfOwnershipRepository } from '../repos/fnfOwnershipRepository.js';
 import { IdempotencyRepository } from '../repos/idempotencyRepository.js';
 import { KillSwitchRepository } from '../repos/killSwitchRepository.js';
@@ -13,6 +14,7 @@ import { RoutingEventsRepository } from '../repos/routingEventsRepository.js';
 import { SellerKeyRepository } from '../repos/sellerKeyRepository.js';
 import { UsageLedgerRepository } from '../repos/usageLedgerRepository.js';
 import { UsageQueryRepository } from '../repos/usageQueryRepository.js';
+import { WithdrawalRequestRepository } from '../repos/withdrawalRequestRepository.js';
 import { TokenCredentialRepository } from '../repos/tokenCredentialRepository.js';
 import { TokenCredentialProviderUsageRepository } from '../repos/tokenCredentialProviderUsageRepository.js';
 import { AnalyticsRepository } from '../repos/analyticsRepository.js';
@@ -27,6 +29,8 @@ import { RouterEngine } from './routerEngine.js';
 import { RoutingService } from './routingService.js';
 import { IdempotencyService } from './idempotencyService.js';
 import { UsageMeteringWriter } from './metering/usageMeteringWriter.js';
+import { EarningsProjectorService } from './earnings/earningsProjectorService.js';
+import { WithdrawalService } from './earnings/withdrawalService.js';
 import { TokenCredentialService } from './tokenCredentialService.js';
 import { PilotSessionService } from './pilot/pilotSessionService.js';
 import { PilotGithubAuthService } from './pilot/pilotGithubAuthService.js';
@@ -58,11 +62,14 @@ export const runtime = {
     tokenCredentialProviderUsage: new TokenCredentialProviderUsageRepository(sql),
     analytics: new AnalyticsRepository(sql),
     analyticsDashboardSnapshots: new AnalyticsDashboardSnapshotRepository(sql),
+    earningsLedger: new EarningsLedgerRepository(sql),
     requestLog: new RequestLogRepository(sql),
     pilotIdentity: new PilotIdentityRepository(sql),
-    pilotAdmissionFreezes: new PilotAdmissionFreezeRepository(sql)
+    pilotAdmissionFreezes: new PilotAdmissionFreezeRepository(sql),
+    withdrawalRequests: new WithdrawalRequestRepository(sql)
   },
   services: {
+    earningsProjector: undefined as unknown as EarningsProjectorService,
     idempotency: undefined as unknown as IdempotencyService,
     jobs: undefined as unknown as JobScheduler,
     keyPool: new KeyPool(),
@@ -72,7 +79,8 @@ export const runtime = {
     pilotSessions: undefined as unknown as PilotSessionService,
     routerEngine: new RouterEngine(),
     routingService: undefined as unknown as RoutingService,
-    tokenCredentials: undefined as unknown as TokenCredentialService
+    tokenCredentials: undefined as unknown as TokenCredentialService,
+    withdrawals: undefined as unknown as WithdrawalService
   }
 };
 
@@ -117,6 +125,11 @@ runtime.services.pilotCutovers = new PilotCutoverService({
     }
   }
 });
+runtime.services.earningsProjector = new EarningsProjectorService({
+  canonicalMeteringRepo: runtime.repos.canonicalMetering,
+  earningsLedgerRepo: runtime.repos.earningsLedger,
+  meteringProjectorStateRepo: runtime.repos.meteringProjectorStates
+});
 runtime.services.routingService = new RoutingService(
   runtime.services.keyPool,
   runtime.services.routerEngine
@@ -125,6 +138,13 @@ runtime.services.tokenCredentials = new TokenCredentialService(
   runtime.repos.tokenCredentials,
   runtime.repos.auditLogs
 );
+runtime.services.withdrawals = new WithdrawalService({
+  sql: runtime.sql,
+  earningsLedgerRepo: runtime.repos.earningsLedger,
+  withdrawalRequestRepo: runtime.repos.withdrawalRequests,
+  canonicalMeteringRepo: runtime.repos.canonicalMetering,
+  meteringProjectorStateRepo: runtime.repos.meteringProjectorStates
+});
 
 export function startBackgroundJobs(): void {
   runtime.services.jobs.start(buildDefaultJobs(runtime.sql));

--- a/api/tests/admin.pilot.route.test.ts
+++ b/api/tests/admin.pilot.route.test.ts
@@ -130,6 +130,10 @@ describe('admin pilot routes', () => {
   let rateCardListHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
   let rateCardCreateHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
   let meteringCorrectionHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+  let earningsProjectionListHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+  let earningsProjectionRetryHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+  let adminWithdrawalListHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+  let adminWithdrawalActionHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
 
   beforeAll(async () => {
     process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgres://postgres:postgres@127.0.0.1:5432/innies_test';
@@ -145,6 +149,10 @@ describe('admin pilot routes', () => {
     rateCardListHandlers = getRouteHandlers(mod.default as any, '/v1/admin/rate-cards', 'get');
     rateCardCreateHandlers = getRouteHandlers(mod.default as any, '/v1/admin/rate-cards', 'post');
     meteringCorrectionHandlers = getRouteHandlers(mod.default as any, '/v1/admin/metering/corrections', 'post');
+    earningsProjectionListHandlers = getRouteHandlers(mod.default as any, '/v1/admin/pilot/earnings/projections', 'get');
+    earningsProjectionRetryHandlers = getRouteHandlers(mod.default as any, '/v1/admin/pilot/earnings/projections/:meteringEventId/retry', 'post');
+    adminWithdrawalListHandlers = getRouteHandlers(mod.default as any, '/v1/admin/pilot/withdrawals', 'get');
+    adminWithdrawalActionHandlers = getRouteHandlers(mod.default as any, '/v1/admin/pilot/withdrawals/:withdrawalRequestId/actions', 'post');
   });
 
   beforeEach(() => {
@@ -190,6 +198,29 @@ describe('admin pilot routes', () => {
     vi.spyOn(runtimeModule.runtime.services.metering, 'recordUsage').mockResolvedValue({
       id: 'usage_1',
       entry_type: 'usage'
+    } as any);
+    vi.spyOn(runtimeModule.runtime.services.earningsProjector, 'listProjectionBacklog').mockResolvedValue([]);
+    vi.spyOn(runtimeModule.runtime.services.earningsProjector, 'retryBacklog').mockResolvedValue({
+      processed: 1,
+      projected: 1,
+      failed: 0
+    });
+    vi.spyOn(runtimeModule.runtime.services.withdrawals, 'listAdminWithdrawals').mockResolvedValue([]);
+    vi.spyOn(runtimeModule.runtime.services.withdrawals, 'approveWithdrawal').mockResolvedValue({
+      id: 'withdraw_1',
+      status: 'approved'
+    } as any);
+    vi.spyOn(runtimeModule.runtime.services.withdrawals, 'rejectWithdrawal').mockResolvedValue({
+      id: 'withdraw_1',
+      status: 'rejected'
+    } as any);
+    vi.spyOn(runtimeModule.runtime.services.withdrawals, 'markSettled').mockResolvedValue({
+      id: 'withdraw_1',
+      status: 'settled'
+    } as any);
+    vi.spyOn(runtimeModule.runtime.services.withdrawals, 'markSettlementFailed').mockResolvedValue({
+      id: 'withdraw_1',
+      status: 'settlement_failed'
     } as any);
   });
 
@@ -591,5 +622,102 @@ describe('admin pilot routes', () => {
       requestId: 'req_1',
       admissionRoutingMode: 'paid-team-capacity'
     }));
+  });
+
+  it('lists stuck earnings projection backlog for operators', async () => {
+    vi.spyOn(runtimeModule.runtime.services.earningsProjector, 'listProjectionBacklog').mockResolvedValue([{
+      meteringEventId: 'meter_1',
+      requestId: 'req_1',
+      state: 'needs_operator_correction',
+      retryCount: 3
+    }] as any);
+
+    const req = createMockReq({
+      method: 'GET',
+      path: '/v1/admin/pilot/earnings/projections',
+      headers: {
+        authorization: 'Bearer in_admin_token'
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(earningsProjectionListHandlers[0], req, res);
+    await invoke(earningsProjectionListHandlers[1], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      projections: [expect.objectContaining({
+        meteringEventId: 'meter_1',
+        state: 'needs_operator_correction'
+      })]
+    });
+  });
+
+  it('retries one earnings projection from the admin operator route', async () => {
+    const retry = vi.spyOn(runtimeModule.runtime.services.earningsProjector, 'projectMeteringEvent').mockResolvedValue(undefined);
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/admin/pilot/earnings/projections/meter_1/retry',
+      headers: {
+        authorization: 'Bearer in_admin_token',
+        'content-type': 'application/json'
+      },
+      params: {
+        meteringEventId: 'meter_1'
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(earningsProjectionRetryHandlers[0], req, res);
+    await invoke(earningsProjectionRetryHandlers[1], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      meteringEventId: 'meter_1'
+    });
+    expect(retry).toHaveBeenCalledWith('meter_1');
+  });
+
+  it('routes admin withdrawal actions into the withdrawal service', async () => {
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/admin/pilot/withdrawals/withdraw_1/actions',
+      headers: {
+        authorization: 'Bearer in_admin_token',
+        'content-type': 'application/json'
+      },
+      params: {
+        withdrawalRequestId: 'withdraw_1'
+      },
+      body: {
+        action: 'mark_settled',
+        settlementReference: 'wire_123',
+        adjustmentMinor: -10,
+        adjustmentReason: 'network fee'
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(adminWithdrawalActionHandlers[0], req, res);
+    await invoke(adminWithdrawalActionHandlers[1], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(runtimeModule.runtime.services.withdrawals.markSettled).toHaveBeenCalledWith({
+      withdrawalRequestId: 'withdraw_1',
+      actorUserId: null,
+      actorApiKeyId: '99999999-9999-4999-8999-999999999999',
+      settlementReference: 'wire_123',
+      adjustmentMinor: -10,
+      adjustmentReason: 'network fee'
+    });
+    expect(res.body).toEqual({
+      ok: true,
+      withdrawal: expect.objectContaining({
+        id: 'withdraw_1',
+        status: 'settled'
+      })
+    });
   });
 });

--- a/api/tests/canonicalMeteringRepository.test.ts
+++ b/api/tests/canonicalMeteringRepository.test.ts
@@ -117,4 +117,21 @@ describe('CanonicalMeteringRepository', () => {
       'canonical metering idempotent replay mismatch'
     );
   });
+
+  it('finds canonical metering rows by id for downstream projectors', async () => {
+    const db = new MockSqlClient({
+      rows: [{
+        id: 'meter_1',
+        request_id: 'req_1'
+      }],
+      rowCount: 1
+    });
+    const repo = new CanonicalMeteringRepository(db, () => 'meter_1');
+
+    const row = await repo.findById('meter_1');
+
+    expect(row).toEqual(expect.objectContaining({ id: 'meter_1' }));
+    expect(db.queries[0].sql).toContain('where id = $1');
+    expect(db.queries[0].params).toEqual(['meter_1']);
+  });
 });

--- a/api/tests/darrynApiKeyAttributionMigrations.test.ts
+++ b/api/tests/darrynApiKeyAttributionMigrations.test.ts
@@ -1,0 +1,102 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const initMigrationPath = resolve(process.cwd(), '../docs/migrations/001_checkpoint1_init.sql');
+const hardCutoverMigrationPath = resolve(process.cwd(), '../docs/migrations/005_hard_cutover_in_prefix.sql');
+const foundationMigrationPath = resolve(process.cwd(), '../docs/migrations/017_darryn_foundation_contracts.sql');
+const cutoverAccessMigrationPath = resolve(process.cwd(), '../docs/migrations/018_darryn_cutover_access.sql');
+const routingMigrationPath = resolve(process.cwd(), '../docs/migrations/019_darryn_routing_metering.sql');
+const migrationPath = resolve(process.cwd(), '../docs/migrations/020_darryn_api_key_attribution.sql');
+
+const initNoExtensionsMigrationPath = resolve(process.cwd(), '../docs/migrations/001_checkpoint1_init_no_extensions.sql');
+const hardCutoverNoExtensionsMigrationPath = resolve(process.cwd(), '../docs/migrations/005_hard_cutover_in_prefix_no_extensions.sql');
+const foundationNoExtensionsMigrationPath = resolve(process.cwd(), '../docs/migrations/017_darryn_foundation_contracts_no_extensions.sql');
+const cutoverAccessNoExtensionsMigrationPath = resolve(process.cwd(), '../docs/migrations/018_darryn_cutover_access_no_extensions.sql');
+const routingNoExtensionsMigrationPath = resolve(process.cwd(), '../docs/migrations/019_darryn_routing_metering_no_extensions.sql');
+const noExtensionsMigrationPath = resolve(process.cwd(), '../docs/migrations/020_darryn_api_key_attribution_no_extensions.sql');
+
+describe('darryn api-key attribution migrations', () => {
+  it('adds additive api-key attribution columns for earnings and withdrawal review actions in the primary migration', () => {
+    const sql = readFileSync(migrationPath, 'utf8');
+
+    expect(sql).toContain('ALTER TABLE in_earnings_ledger');
+    expect(sql).toContain('ADD COLUMN IF NOT EXISTS actor_api_key_id uuid REFERENCES in_api_keys(id) ON DELETE SET NULL');
+    expect(sql).toContain('ALTER TABLE in_withdrawal_requests');
+    expect(sql).toContain('ADD COLUMN IF NOT EXISTS reviewed_by_api_key_id uuid REFERENCES in_api_keys(id) ON DELETE SET NULL');
+  });
+
+  it('keeps the no-extensions migration aligned with the primary api-key attribution changes', () => {
+    const sql = readFileSync(noExtensionsMigrationPath, 'utf8');
+
+    expect(sql).toContain('ADD COLUMN IF NOT EXISTS actor_api_key_id uuid REFERENCES in_api_keys(id) ON DELETE SET NULL');
+    expect(sql).toContain('ADD COLUMN IF NOT EXISTS reviewed_by_api_key_id uuid REFERENCES in_api_keys(id) ON DELETE SET NULL');
+  });
+
+  it('references only tables that already exist in schema history or are altered in the migration', () => {
+    const priorSql = [
+      readFileSync(initMigrationPath, 'utf8'),
+      readFileSync(hardCutoverMigrationPath, 'utf8'),
+      readFileSync(foundationMigrationPath, 'utf8'),
+      readFileSync(cutoverAccessMigrationPath, 'utf8'),
+      readFileSync(routingMigrationPath, 'utf8')
+    ].join('\n');
+    const sql = readFileSync(migrationPath, 'utf8');
+
+    expect(findUnresolvedTableDependencies(priorSql, sql)).toEqual([]);
+  });
+
+  it('keeps the no-extensions migration on the same dependency graph', () => {
+    const priorSql = [
+      readFileSync(initNoExtensionsMigrationPath, 'utf8'),
+      readFileSync(hardCutoverNoExtensionsMigrationPath, 'utf8'),
+      readFileSync(foundationNoExtensionsMigrationPath, 'utf8'),
+      readFileSync(cutoverAccessNoExtensionsMigrationPath, 'utf8'),
+      readFileSync(routingNoExtensionsMigrationPath, 'utf8')
+    ].join('\n');
+    const sql = readFileSync(noExtensionsMigrationPath, 'utf8');
+
+    expect(findUnresolvedTableDependencies(priorSql, sql)).toEqual([]);
+  });
+});
+
+function findUnresolvedTableDependencies(priorSql: string, currentSql: string): string[] {
+  const availableTables = new Set<string>([
+    ...extractCreatedTables(priorSql),
+    ...extractRenamedTables(priorSql),
+    ...extractCreatedTables(currentSql)
+  ]);
+
+  const requiredTables = new Set<string>([
+    ...extractReferencedTables(currentSql),
+    ...extractAlteredTables(currentSql)
+  ]);
+
+  return Array.from(requiredTables)
+    .filter((table) => !availableTables.has(table))
+    .sort();
+}
+
+function extractCreatedTables(sql: string): string[] {
+  return extractMatches(sql, /CREATE TABLE IF NOT EXISTS ([a-z0-9_]+)/gi);
+}
+
+function extractRenamedTables(sql: string): string[] {
+  return extractMatches(sql, /ALTER TABLE IF EXISTS [a-z0-9_]+ RENAME TO ([a-z0-9_]+)/gi);
+}
+
+function extractReferencedTables(sql: string): string[] {
+  return extractMatches(sql, /REFERENCES ([a-z0-9_]+)\s*\(/gi);
+}
+
+function extractAlteredTables(sql: string): string[] {
+  return extractMatches(sql, /ALTER TABLE ([a-z0-9_]+)/gi);
+}
+
+function extractMatches(sql: string, pattern: RegExp): string[] {
+  const matches: string[] = [];
+  for (const match of sql.matchAll(pattern)) {
+    matches.push(match[1]);
+  }
+  return matches;
+}

--- a/api/tests/earningsLedgerRepository.test.ts
+++ b/api/tests/earningsLedgerRepository.test.ts
@@ -27,7 +27,7 @@ describe('EarningsLedgerRepository', () => {
     expect(db.queries[0].params).toContain('pending');
   });
 
-  it('requires actor and reason metadata for non-metering earnings actions', async () => {
+  it('requires reason metadata for non-metering earnings actions', async () => {
     const db = new MockSqlClient();
     const repo = new EarningsLedgerRepository(db, () => 'earnings_entry_2');
 
@@ -37,7 +37,60 @@ describe('EarningsLedgerRepository', () => {
       effectType: 'payout_adjustment',
       balanceBucket: 'adjusted',
       amountMinor: -50
-    })).rejects.toThrow('manual earnings entries require actorUserId and reason');
+    })).rejects.toThrow('manual earnings entries require reason');
+  });
+
+  it('requires actor attribution for manual earnings actions', async () => {
+    const db = new MockSqlClient();
+    const repo = new EarningsLedgerRepository(db, () => 'earnings_entry_2a');
+
+    await expect(repo.appendEntry({
+      ownerOrgId: 'org_fnf',
+      contributorUserId: 'user_darryn',
+      effectType: 'payout_adjustment',
+      balanceBucket: 'adjusted',
+      amountMinor: -50,
+      reason: 'network fee'
+    })).rejects.toThrow('manual earnings entries require actor attribution');
+  });
+
+  it('writes api-key attribution for manual earnings actions', async () => {
+    const db = new MockSqlClient({
+      rows: [{ id: 'earnings_entry_2b', effect_type: 'payout_adjustment', actor_api_key_id: 'key_admin_1' }],
+      rowCount: 1
+    });
+    const repo = new EarningsLedgerRepository(db, () => 'earnings_entry_2b');
+
+    const row = await repo.appendEntry({
+      ownerOrgId: 'org_fnf',
+      contributorUserId: 'user_darryn',
+      effectType: 'payout_adjustment',
+      balanceBucket: 'adjusted',
+      amountMinor: -50,
+      actorApiKeyId: 'key_admin_1',
+      reason: 'network fee'
+    });
+
+    expect(row).toEqual(expect.objectContaining({ id: 'earnings_entry_2b' }));
+    expect(db.queries[0].sql).toContain('actor_api_key_id');
+    expect(db.queries[0].params).toContain('key_admin_1');
+  });
+
+  it('lists earnings rows scoped to owner org and contributor user', async () => {
+    const db = new MockSqlClient({
+      rows: [{ id: 'earnings_entry_5', owner_org_id: 'org_fnf', contributor_user_id: 'user_darryn' }],
+      rowCount: 1
+    });
+    const repo = new EarningsLedgerRepository(db, () => 'earnings_entry_5');
+
+    const rows = await repo.listByOwnerOrgAndContributorUserId({
+      ownerOrgId: 'org_fnf',
+      contributorUserId: 'user_darryn'
+    });
+
+    expect(rows).toEqual([expect.objectContaining({ id: 'earnings_entry_5' })]);
+    expect(db.queries[0].sql).toContain('where owner_org_id = $1');
+    expect(db.queries[0].sql).toContain('and contributor_user_id = $2');
   });
 
   it('returns the existing metering-derived earnings row on duplicate projection keys', async () => {
@@ -54,6 +107,7 @@ describe('EarningsLedgerRepository', () => {
           amount_minor: 180,
           currency: 'USD',
           actor_user_id: null,
+          actor_api_key_id: null,
           reason: null,
           withdrawal_request_id: null,
           payout_reference: null,
@@ -93,6 +147,7 @@ describe('EarningsLedgerRepository', () => {
           amount_minor: 180,
           currency: 'USD',
           actor_user_id: null,
+          actor_api_key_id: null,
           reason: null,
           withdrawal_request_id: null,
           payout_reference: null,

--- a/api/tests/earningsProjectorJob.test.ts
+++ b/api/tests/earningsProjectorJob.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createEarningsProjectorJob } from '../src/jobs/earningsProjectorJob.js';
+import { createLoggerSpy } from './testHelpers.js';
+
+describe('createEarningsProjectorJob', () => {
+  it('retries a bounded backlog batch and logs the result', async () => {
+    const retryBacklog = vi.fn().mockResolvedValue({
+      processed: 2,
+      projected: 1,
+      failed: 1
+    });
+    const { logger, infoCalls } = createLoggerSpy();
+    const job = createEarningsProjectorJob({
+      retryBacklog
+    } as any);
+
+    await job.run({
+      now: new Date('2026-03-20T17:00:00Z'),
+      logger
+    });
+
+    expect(retryBacklog).toHaveBeenCalledWith({ limit: 25 });
+    expect(infoCalls).toEqual([{
+      message: 'earnings projector batch processed',
+      fields: {
+        processed: 2,
+        projected: 1,
+        failed: 1
+      }
+    }]);
+  });
+});

--- a/api/tests/earningsProjectorService.test.ts
+++ b/api/tests/earningsProjectorService.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it, vi } from 'vitest';
+import { EarningsProjectorService } from '../src/services/earnings/earningsProjectorService.js';
+
+describe('EarningsProjectorService', () => {
+  it('projects team-overflow accruals into withdrawable earnings and marks the projector projected', async () => {
+    const findById = vi.fn().mockResolvedValue({
+      id: 'meter_1',
+      request_id: 'req_1',
+      attempt_no: 1,
+      finalization_kind: 'served_request',
+      idempotency_key: 'req_1:1:served_request',
+      session_id: null,
+      source_metering_event_id: null,
+      admission_org_id: 'org_innies',
+      admission_cutover_id: 'cut_1',
+      admission_routing_mode: 'team-overflow-on-contributor-capacity',
+      consumer_org_id: 'org_innies',
+      consumer_user_id: null,
+      team_consumer_id: 'innies-team',
+      buyer_key_id: null,
+      serving_org_id: 'org_fnf',
+      provider_account_id: 'acct_1',
+      token_credential_id: 'cred_1',
+      capacity_owner_user_id: 'user_darryn',
+      provider: 'anthropic',
+      model: 'claude-sonnet',
+      rate_card_version_id: 'rate_1',
+      input_tokens: 100,
+      output_tokens: 200,
+      usage_units: 300,
+      buyer_debit_minor: 0,
+      contributor_earnings_minor: 780,
+      currency: 'USD',
+      metadata: null,
+      created_at: '2026-03-20T12:00:00Z'
+    });
+    const appendEntry = vi.fn().mockResolvedValue({ id: 'earn_1' });
+    const listByMeteringEventId = vi.fn().mockResolvedValue([{
+      metering_event_id: 'meter_1',
+      projector: 'earnings',
+      state: 'pending_projection',
+      retry_count: 0,
+      last_attempt_at: null,
+      next_retry_at: null,
+      last_error_code: null,
+      last_error_message: null,
+      projected_at: null,
+      created_at: '2026-03-20T12:00:00Z',
+      updated_at: '2026-03-20T12:00:00Z'
+    }]);
+    const markProjected = vi.fn().mockResolvedValue({});
+
+    const service = new EarningsProjectorService({
+      canonicalMeteringRepo: { findById } as any,
+      earningsLedgerRepo: { appendEntry } as any,
+      meteringProjectorStateRepo: {
+        listByMeteringEventId,
+        markProjected,
+        markNeedsOperatorCorrection: vi.fn(),
+        listByProjectorAndState: vi.fn()
+      } as any
+    });
+
+    await service.projectMeteringEvent('meter_1');
+
+    expect(appendEntry).toHaveBeenCalledWith(expect.objectContaining({
+      ownerOrgId: 'org_fnf',
+      contributorUserId: 'user_darryn',
+      meteringEventId: 'meter_1',
+      effectType: 'contributor_accrual',
+      balanceBucket: 'withdrawable',
+      amountMinor: 780,
+      currency: 'USD'
+    }));
+    expect(markProjected).toHaveBeenCalledWith({
+      meteringEventId: 'meter_1',
+      projector: 'earnings'
+    });
+  });
+
+  it('projects reversals into the adjusted bucket without mutating prior accrual rows', async () => {
+    const appendEntry = vi.fn().mockResolvedValue({ id: 'earn_reverse_1' });
+    const service = new EarningsProjectorService({
+      canonicalMeteringRepo: {
+        findById: vi.fn().mockResolvedValue({
+          id: 'meter_2',
+          request_id: 'req_2',
+          attempt_no: 1,
+          finalization_kind: 'reversal',
+          idempotency_key: 'req_2:1:reversal',
+          session_id: null,
+          source_metering_event_id: 'meter_orig',
+          admission_org_id: 'org_innies',
+          admission_cutover_id: 'cut_1',
+          admission_routing_mode: 'team-overflow-on-contributor-capacity',
+          consumer_org_id: 'org_innies',
+          consumer_user_id: null,
+          team_consumer_id: 'innies-team',
+          buyer_key_id: null,
+          serving_org_id: 'org_fnf',
+          provider_account_id: 'acct_1',
+          token_credential_id: 'cred_1',
+          capacity_owner_user_id: 'user_darryn',
+          provider: 'anthropic',
+          model: 'claude-sonnet',
+          rate_card_version_id: 'rate_1',
+          input_tokens: 0,
+          output_tokens: 0,
+          usage_units: 0,
+          buyer_debit_minor: 0,
+          contributor_earnings_minor: -780,
+          currency: 'USD',
+          metadata: null,
+          created_at: '2026-03-20T12:10:00Z'
+        })
+      } as any,
+      earningsLedgerRepo: { appendEntry } as any,
+      meteringProjectorStateRepo: {
+        listByMeteringEventId: vi.fn().mockResolvedValue([{
+          metering_event_id: 'meter_2',
+          projector: 'earnings',
+          state: 'pending_projection',
+          retry_count: 0,
+          last_attempt_at: null,
+          next_retry_at: null,
+          last_error_code: null,
+          last_error_message: null,
+          projected_at: null,
+          created_at: '2026-03-20T12:10:00Z',
+          updated_at: '2026-03-20T12:10:00Z'
+        }]),
+        markProjected: vi.fn().mockResolvedValue({}),
+        markNeedsOperatorCorrection: vi.fn(),
+        listByProjectorAndState: vi.fn()
+      } as any
+    });
+
+    await service.projectMeteringEvent('meter_2');
+
+    expect(appendEntry).toHaveBeenCalledWith(expect.objectContaining({
+      effectType: 'contributor_reversal',
+      balanceBucket: 'adjusted',
+      amountMinor: -780
+    }));
+  });
+
+  it('marks disallowed non-overflow earnings rows for operator correction instead of creating ledger entries', async () => {
+    const appendEntry = vi.fn();
+    const markNeedsOperatorCorrection = vi.fn().mockResolvedValue({});
+    const service = new EarningsProjectorService({
+      canonicalMeteringRepo: {
+        findById: vi.fn().mockResolvedValue({
+          id: 'meter_3',
+          request_id: 'req_3',
+          attempt_no: 1,
+          finalization_kind: 'served_request',
+          idempotency_key: 'req_3:1:served_request',
+          session_id: null,
+          source_metering_event_id: null,
+          admission_org_id: 'org_fnf',
+          admission_cutover_id: 'cut_1',
+          admission_routing_mode: 'paid-team-capacity',
+          consumer_org_id: 'org_fnf',
+          consumer_user_id: 'user_darryn',
+          team_consumer_id: null,
+          buyer_key_id: 'buyer_1',
+          serving_org_id: 'org_innies',
+          provider_account_id: 'acct_2',
+          token_credential_id: 'cred_2',
+          capacity_owner_user_id: 'user_darryn',
+          provider: 'openai',
+          model: 'gpt-5-codex',
+          rate_card_version_id: 'rate_2',
+          input_tokens: 10,
+          output_tokens: 20,
+          usage_units: 30,
+          buyer_debit_minor: 60,
+          contributor_earnings_minor: 55,
+          currency: 'USD',
+          metadata: null,
+          created_at: '2026-03-20T12:20:00Z'
+        })
+      } as any,
+      earningsLedgerRepo: { appendEntry } as any,
+      meteringProjectorStateRepo: {
+        listByMeteringEventId: vi.fn().mockResolvedValue([{
+          metering_event_id: 'meter_3',
+          projector: 'earnings',
+          state: 'pending_projection',
+          retry_count: 1,
+          last_attempt_at: null,
+          next_retry_at: null,
+          last_error_code: null,
+          last_error_message: null,
+          projected_at: null,
+          created_at: '2026-03-20T12:20:00Z',
+          updated_at: '2026-03-20T12:20:00Z'
+        }]),
+        markProjected: vi.fn(),
+        markNeedsOperatorCorrection,
+        listByProjectorAndState: vi.fn()
+      } as any,
+      now: () => new Date('2026-03-20T12:21:00Z')
+    });
+
+    await expect(service.projectMeteringEvent('meter_3')).rejects.toThrow(
+      'contributor earnings are only allowed for team-overflow-on-contributor-capacity'
+    );
+
+    expect(appendEntry).not.toHaveBeenCalled();
+    expect(markNeedsOperatorCorrection).toHaveBeenCalledWith(expect.objectContaining({
+      meteringEventId: 'meter_3',
+      projector: 'earnings',
+      retryCount: 2,
+      lastErrorCode: 'projection_failed'
+    }));
+  });
+
+  it('retries pending and due stuck earnings projections from the backlog', async () => {
+    const projectMeteringEvent = vi.fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('boom'));
+    const now = new Date('2026-03-20T13:00:00Z');
+    const service = new EarningsProjectorService({
+      canonicalMeteringRepo: { findById: vi.fn() } as any,
+      earningsLedgerRepo: { appendEntry: vi.fn() } as any,
+      meteringProjectorStateRepo: {
+        listByMeteringEventId: vi.fn().mockResolvedValue([]),
+        markProjected: vi.fn(),
+        markNeedsOperatorCorrection: vi.fn(),
+        listByProjectorAndState: vi.fn()
+          .mockResolvedValueOnce([{
+            metering_event_id: 'meter_pending',
+            projector: 'earnings',
+            state: 'pending_projection',
+            retry_count: 0,
+            last_attempt_at: null,
+            next_retry_at: null,
+            last_error_code: null,
+            last_error_message: null,
+            projected_at: null,
+            created_at: '2026-03-20T12:30:00Z',
+            updated_at: '2026-03-20T12:30:00Z'
+          }])
+          .mockResolvedValueOnce([{
+            metering_event_id: 'meter_stuck',
+            projector: 'earnings',
+            state: 'needs_operator_correction',
+            retry_count: 3,
+            last_attempt_at: '2026-03-20T12:40:00Z',
+            next_retry_at: '2026-03-20T12:59:00Z',
+            last_error_code: 'projection_failed',
+            last_error_message: 'boom',
+            projected_at: null,
+            created_at: '2026-03-20T12:35:00Z',
+            updated_at: '2026-03-20T12:40:00Z'
+          }])
+      } as any,
+      now: () => now
+    });
+    vi.spyOn(service, 'projectMeteringEvent').mockImplementation(projectMeteringEvent);
+
+    const result = await service.retryBacklog({ limit: 10 });
+
+    expect(projectMeteringEvent).toHaveBeenCalledTimes(2);
+    expect(projectMeteringEvent).toHaveBeenNthCalledWith(1, 'meter_pending');
+    expect(projectMeteringEvent).toHaveBeenNthCalledWith(2, 'meter_stuck');
+    expect(result).toEqual({
+      processed: 2,
+      projected: 1,
+      failed: 1
+    });
+  });
+});

--- a/api/tests/pilot.route.test.ts
+++ b/api/tests/pilot.route.test.ts
@@ -131,6 +131,10 @@ describe('pilot routes', () => {
   let authStartHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
   let authCallbackHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
   let logoutHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+  let earningsSummaryHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+  let earningsHistoryHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+  let withdrawalsListHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+  let withdrawalsCreateHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
 
   beforeAll(async () => {
     process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgres://postgres:postgres@127.0.0.1:5432/innies_test';
@@ -141,10 +145,43 @@ describe('pilot routes', () => {
     authStartHandlers = getRouteHandlers(mod.default as any, '/v1/pilot/auth/github/start', 'get');
     authCallbackHandlers = getRouteHandlers(mod.default as any, '/v1/pilot/auth/github/callback', 'get');
     logoutHandlers = getRouteHandlers(mod.default as any, '/v1/pilot/session/logout', 'post');
+    earningsSummaryHandlers = getRouteHandlers(mod.default as any, '/v1/pilot/earnings/summary', 'get');
+    earningsHistoryHandlers = getRouteHandlers(mod.default as any, '/v1/pilot/earnings/history', 'get');
+    withdrawalsListHandlers = getRouteHandlers(mod.default as any, '/v1/pilot/withdrawals', 'get');
+    withdrawalsCreateHandlers = getRouteHandlers(mod.default as any, '/v1/pilot/withdrawals', 'post');
   });
 
   beforeEach(() => {
     vi.restoreAllMocks();
+    vi.spyOn(runtimeModule.runtime.services.pilotSessions, 'readTokenFromRequest').mockReturnValue('pilot-token');
+    vi.spyOn(runtimeModule.runtime.services.pilotSessions, 'readSession').mockReturnValue({
+      sessionKind: 'darryn_self',
+      actorUserId: 'user_darryn',
+      actorApiKeyId: null,
+      actorOrgId: 'org_fnf',
+      effectiveOrgId: 'org_fnf',
+      effectiveOrgSlug: 'fnf',
+      effectiveOrgName: 'Friends & Family',
+      githubLogin: 'darryn',
+      userEmail: 'darryn@example.com',
+      impersonatedUserId: null,
+      issuedAt: '2026-03-20T00:00:00Z',
+      expiresAt: '2026-03-20T01:00:00Z'
+    } as any);
+    vi.spyOn(runtimeModule.runtime.services.withdrawals, 'getContributorSummary').mockResolvedValue({
+      pendingMinor: 50,
+      withdrawableMinor: 700,
+      reservedForPayoutMinor: 0,
+      settledMinor: 120,
+      adjustedMinor: -10
+    });
+    vi.spyOn(runtimeModule.runtime.services.withdrawals, 'listContributorHistory').mockResolvedValue([]);
+    vi.spyOn(runtimeModule.runtime.services.withdrawals, 'listContributorWithdrawals').mockResolvedValue([]);
+    vi.spyOn(runtimeModule.runtime.services.withdrawals, 'createWithdrawalRequest').mockResolvedValue({
+      id: 'withdraw_1',
+      status: 'requested',
+      amount_minor: 250
+    } as any);
   });
 
   afterEach(() => {
@@ -291,5 +328,111 @@ describe('pilot routes', () => {
     expect(res.statusCode).toBe(200);
     expect(res.headers['set-cookie']).toContain('innies_pilot_session=');
     expect(res.headers['set-cookie']).toContain('Max-Age=0');
+  });
+
+  it('returns contributor earnings summary in the effective pilot session context', async () => {
+    const req = createMockReq({
+      method: 'GET',
+      path: '/v1/pilot/earnings/summary',
+      headers: {
+        authorization: 'Bearer pilot-token'
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(earningsSummaryHandlers[0], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      summary: {
+        pendingMinor: 50,
+        withdrawableMinor: 700,
+        reservedForPayoutMinor: 0,
+        settledMinor: 120,
+        adjustedMinor: -10
+      }
+    });
+    expect(runtimeModule.runtime.services.withdrawals.getContributorSummary).toHaveBeenCalledWith({
+      ownerOrgId: 'org_fnf',
+      contributorUserId: 'user_darryn'
+    });
+  });
+
+  it('passes the effective org boundary into earnings history and withdrawal list reads', async () => {
+    const historyReq = createMockReq({
+      method: 'GET',
+      path: '/v1/pilot/earnings/history',
+      headers: {
+        authorization: 'Bearer pilot-token'
+      }
+    });
+    const historyRes = createMockRes();
+
+    await invoke(earningsHistoryHandlers[0], historyReq, historyRes);
+
+    expect(runtimeModule.runtime.services.withdrawals.listContributorHistory).toHaveBeenCalledWith({
+      ownerOrgId: 'org_fnf',
+      contributorUserId: 'user_darryn'
+    });
+
+    const withdrawalsReq = createMockReq({
+      method: 'GET',
+      path: '/v1/pilot/withdrawals',
+      headers: {
+        authorization: 'Bearer pilot-token'
+      }
+    });
+    const withdrawalsRes = createMockRes();
+
+    await invoke(withdrawalsListHandlers[0], withdrawalsReq, withdrawalsRes);
+
+    expect(runtimeModule.runtime.services.withdrawals.listContributorWithdrawals).toHaveBeenCalledWith({
+      ownerOrgId: 'org_fnf',
+      contributorUserId: 'user_darryn'
+    });
+  });
+
+  it('creates contributor withdrawal requests against the pilot session user and org', async () => {
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/pilot/withdrawals',
+      headers: {
+        authorization: 'Bearer pilot-token',
+        'content-type': 'application/json'
+      }
+    });
+    req.body = {
+      amountMinor: 250,
+      destination: {
+        rail: 'manual_usdc',
+        address: '0xabc'
+      },
+      note: 'pilot payout'
+    };
+    const res = createMockRes();
+
+    await invoke(withdrawalsCreateHandlers[0], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      withdrawal: expect.objectContaining({
+        id: 'withdraw_1',
+        status: 'requested',
+        amount_minor: 250
+      })
+    });
+    expect(runtimeModule.runtime.services.withdrawals.createWithdrawalRequest).toHaveBeenCalledWith({
+      ownerOrgId: 'org_fnf',
+      contributorUserId: 'user_darryn',
+      requestedByUserId: 'user_darryn',
+      amountMinor: 250,
+      destination: {
+        rail: 'manual_usdc',
+        address: '0xabc'
+      },
+      note: 'pilot payout'
+    });
   });
 });

--- a/api/tests/withdrawalRequestRepository.test.ts
+++ b/api/tests/withdrawalRequestRepository.test.ts
@@ -60,4 +60,59 @@ describe('WithdrawalRequestRepository', () => {
 
     expect(db.queries[1].sql).toContain('and status = $2');
   });
+
+  it('writes api-key attribution for admin review transitions', async () => {
+    const db = new SequenceSqlClient([
+      {
+        rows: [{ id: 'withdraw_3a', status: 'under_review' }],
+        rowCount: 1
+      },
+      {
+        rows: [{ id: 'withdraw_3a', status: 'approved', reviewed_by_api_key_id: 'key_admin_1' }],
+        rowCount: 1
+      }
+    ]);
+    const repo = new WithdrawalRequestRepository(db, () => 'withdraw_3a');
+
+    const row = await repo.transitionStatus({
+      id: 'withdraw_3a',
+      nextStatus: 'approved',
+      actedByUserId: null,
+      actedByApiKeyId: 'key_admin_1'
+    });
+
+    expect(row).toEqual(expect.objectContaining({ id: 'withdraw_3a' }));
+    expect(db.queries[1].sql).toContain('reviewed_by_api_key_id = $5');
+    expect(db.queries[1].params).toContain('key_admin_1');
+  });
+
+  it('lists withdrawals by owner org for admin review queues', async () => {
+    const db = new SequenceSqlClient([{
+      rows: [{ id: 'withdraw_4', owner_org_id: 'org_fnf' }],
+      rowCount: 1
+    }]);
+    const repo = new WithdrawalRequestRepository(db, () => 'withdraw_4');
+
+    const rows = await repo.listByOwnerOrgId('org_fnf');
+
+    expect(rows).toEqual([expect.objectContaining({ id: 'withdraw_4' })]);
+    expect(db.queries[0].sql).toContain('where owner_org_id = $1');
+  });
+
+  it('lists withdrawals scoped to owner org and contributor user for pilot views', async () => {
+    const db = new SequenceSqlClient([{
+      rows: [{ id: 'withdraw_5', owner_org_id: 'org_fnf', contributor_user_id: 'user_darryn' }],
+      rowCount: 1
+    }]);
+    const repo = new WithdrawalRequestRepository(db, () => 'withdraw_5');
+
+    const rows = await repo.listByOwnerOrgAndContributorUserId({
+      ownerOrgId: 'org_fnf',
+      contributorUserId: 'user_darryn'
+    });
+
+    expect(rows).toEqual([expect.objectContaining({ id: 'withdraw_5' })]);
+    expect(db.queries[0].sql).toContain('where owner_org_id = $1');
+    expect(db.queries[0].sql).toContain('and contributor_user_id = $2');
+  });
 });

--- a/api/tests/withdrawalService.test.ts
+++ b/api/tests/withdrawalService.test.ts
@@ -234,9 +234,10 @@ describe('WithdrawalService', () => {
         amount_minor: 500,
         status: 'approved'
       });
+    const transaction = vi.fn(async (run) => run({ query: vi.fn().mockResolvedValue({ rows: [], rowCount: 1 }) }));
 
     const service = new WithdrawalService({
-      sql: { transaction: vi.fn() } as any,
+      sql: { transaction } as any,
       earningsLedgerRepo: {
         listByOwnerOrgAndContributorUserId: vi.fn().mockResolvedValue([]),
         appendEntry
@@ -246,6 +247,16 @@ describe('WithdrawalService', () => {
         transitionStatus,
         listByOwnerOrgAndContributorUserId: vi.fn().mockResolvedValue([])
       } as any,
+      repoFactory: {
+        earningsLedger: vi.fn().mockReturnValue({
+          listByOwnerOrgAndContributorUserId: vi.fn().mockResolvedValue([]),
+          appendEntry
+        }),
+        withdrawalRequests: vi.fn().mockReturnValue({
+          findById,
+          transitionStatus
+        })
+      },
       canonicalMeteringRepo: { findById: vi.fn() } as any,
       meteringProjectorStateRepo: {
         listByProjectorAndState: vi.fn().mockResolvedValue([])
@@ -299,6 +310,7 @@ describe('WithdrawalService', () => {
       withdrawalRequestId: 'withdraw_4',
       reason: 'network fee'
     }));
+    expect(transaction).toHaveBeenCalledTimes(3);
   });
 
   it('propagates admin api-key attribution through review transitions and payout ledger rows', async () => {
@@ -314,9 +326,10 @@ describe('WithdrawalService', () => {
       currency: 'USD',
       status: 'requested'
     });
+    const transaction = vi.fn(async (run) => run({ query: vi.fn().mockResolvedValue({ rows: [], rowCount: 1 }) }));
 
     const service = new WithdrawalService({
-      sql: { transaction: vi.fn() } as any,
+      sql: { transaction } as any,
       earningsLedgerRepo: {
         listByOwnerOrgAndContributorUserId: vi.fn().mockResolvedValue([]),
         appendEntry
@@ -326,6 +339,16 @@ describe('WithdrawalService', () => {
         transitionStatus,
         listByOwnerOrgAndContributorUserId: vi.fn().mockResolvedValue([])
       } as any,
+      repoFactory: {
+        earningsLedger: vi.fn().mockReturnValue({
+          listByOwnerOrgAndContributorUserId: vi.fn().mockResolvedValue([]),
+          appendEntry
+        }),
+        withdrawalRequests: vi.fn().mockReturnValue({
+          findById,
+          transitionStatus
+        })
+      },
       canonicalMeteringRepo: { findById: vi.fn() } as any,
       meteringProjectorStateRepo: {
         listByProjectorAndState: vi.fn().mockResolvedValue([])
@@ -352,6 +375,203 @@ describe('WithdrawalService', () => {
       actedByApiKeyId: 'key_admin_1'
     }));
     expect(appendEntry).not.toHaveBeenCalled();
+    expect(transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('rolls back rejection status when the release ledger write fails inside the transaction path', async () => {
+    const committed = {
+      status: 'requested',
+      ledgerEffects: [] as string[]
+    };
+    const transaction = vi.fn(async (run) => {
+      const staged = {
+        status: committed.status,
+        ledgerEffects: [...committed.ledgerEffects]
+      };
+      const tx = {
+        query: vi.fn().mockResolvedValue({ rows: [], rowCount: 1 }),
+        __state: staged
+      };
+
+      try {
+        const result = await run(tx as any);
+        committed.status = staged.status;
+        committed.ledgerEffects = [...staged.ledgerEffects];
+        return result;
+      } catch (error) {
+        throw error;
+      }
+    });
+
+    const transitionStatus = vi.fn(async ({ nextStatus }) => {
+      throw new Error(`transitionStatus called outside tx: ${nextStatus}`);
+    });
+    const appendEntry = vi.fn(async () => {
+      throw new Error('appendEntry called outside tx');
+    });
+
+    const service = new WithdrawalService({
+      sql: { transaction } as any,
+      earningsLedgerRepo: {
+        listByOwnerOrgAndContributorUserId: vi.fn().mockResolvedValue([]),
+        appendEntry
+      } as any,
+      withdrawalRequestRepo: {
+        findById: vi.fn().mockResolvedValue(null),
+        transitionStatus,
+        listByOwnerOrgAndContributorUserId: vi.fn().mockResolvedValue([])
+      } as any,
+      repoFactory: {
+        earningsLedger: vi.fn((tx: any) => ({
+          listByOwnerOrgAndContributorUserId: vi.fn().mockResolvedValue([]),
+          appendEntry: vi.fn(async () => {
+            throw new Error('release write failed');
+          })
+        })),
+        withdrawalRequests: vi.fn((tx: any) => ({
+          findById: vi.fn(async () => ({
+            id: 'withdraw_10',
+            owner_org_id: 'org_fnf',
+            contributor_user_id: 'user_darryn',
+            amount_minor: 250,
+            currency: 'USD',
+            status: tx.__state.status,
+            settlement_reference: null,
+            settlement_failure_reason: null
+          })),
+          transitionStatus: vi.fn(async ({ nextStatus }) => {
+            tx.__state.status = nextStatus;
+            return {
+              id: 'withdraw_10',
+              owner_org_id: 'org_fnf',
+              contributor_user_id: 'user_darryn',
+              amount_minor: 250,
+              currency: 'USD',
+              status: nextStatus,
+              settlement_reference: null,
+              settlement_failure_reason: null
+            };
+          })
+        }))
+      },
+      canonicalMeteringRepo: { findById: vi.fn() } as any,
+      meteringProjectorStateRepo: {
+        listByProjectorAndState: vi.fn().mockResolvedValue([])
+      } as any
+    });
+
+    await expect(service.rejectWithdrawal({
+      withdrawalRequestId: 'withdraw_10',
+      actorUserId: 'admin_1',
+      actorApiKeyId: null,
+      reason: 'duplicate request'
+    })).rejects.toThrow('release write failed');
+
+    expect(transaction).toHaveBeenCalledTimes(1);
+    expect(committed.status).toBe('requested');
+    expect(committed.ledgerEffects).toEqual([]);
+    expect(transitionStatus).not.toHaveBeenCalled();
+    expect(appendEntry).not.toHaveBeenCalled();
+  });
+
+  it('rolls back settlement status and settlement ledger effects when the adjustment write fails inside the transaction path', async () => {
+    const committed = {
+      status: 'approved',
+      settlementReference: null as string | null,
+      ledgerEffects: [] as string[]
+    };
+    const transaction = vi.fn(async (run) => {
+      const staged = {
+        status: committed.status,
+        settlementReference: committed.settlementReference,
+        ledgerEffects: [...committed.ledgerEffects]
+      };
+      const tx = {
+        query: vi.fn().mockResolvedValue({ rows: [], rowCount: 1 }),
+        __state: staged
+      };
+
+      try {
+        const result = await run(tx as any);
+        committed.status = staged.status;
+        committed.settlementReference = staged.settlementReference;
+        committed.ledgerEffects = [...staged.ledgerEffects];
+        return result;
+      } catch (error) {
+        throw error;
+      }
+    });
+
+    const service = new WithdrawalService({
+      sql: { transaction } as any,
+      earningsLedgerRepo: {
+        listByOwnerOrgAndContributorUserId: vi.fn().mockResolvedValue([]),
+        appendEntry: vi.fn()
+      } as any,
+      withdrawalRequestRepo: {
+        findById: vi.fn().mockResolvedValue(null),
+        transitionStatus: vi.fn(),
+        listByOwnerOrgAndContributorUserId: vi.fn().mockResolvedValue([])
+      } as any,
+      repoFactory: {
+        earningsLedger: vi.fn((tx: any) => ({
+          listByOwnerOrgAndContributorUserId: vi.fn().mockResolvedValue([]),
+          appendEntry: vi.fn(async (entry) => {
+            if (entry.effectType === 'payout_adjustment') {
+              throw new Error('adjustment write failed');
+            }
+            tx.__state.ledgerEffects.push(entry.effectType);
+            return { id: `entry_${tx.__state.ledgerEffects.length}` };
+          })
+        })),
+        withdrawalRequests: vi.fn((tx: any) => ({
+          findById: vi.fn(async () => ({
+            id: 'withdraw_11',
+            owner_org_id: 'org_fnf',
+            contributor_user_id: 'user_darryn',
+            amount_minor: 500,
+            currency: 'USD',
+            status: tx.__state.status,
+            settlement_reference: tx.__state.settlementReference,
+            settlement_failure_reason: null
+          })),
+          transitionStatus: vi.fn(async ({ nextStatus, settlementReference }) => {
+            tx.__state.status = nextStatus;
+            if (settlementReference !== undefined) {
+              tx.__state.settlementReference = settlementReference;
+            }
+            return {
+              id: 'withdraw_11',
+              owner_org_id: 'org_fnf',
+              contributor_user_id: 'user_darryn',
+              amount_minor: 500,
+              currency: 'USD',
+              status: nextStatus,
+              settlement_reference: tx.__state.settlementReference,
+              settlement_failure_reason: null
+            };
+          })
+        }))
+      },
+      canonicalMeteringRepo: { findById: vi.fn() } as any,
+      meteringProjectorStateRepo: {
+        listByProjectorAndState: vi.fn().mockResolvedValue([])
+      } as any
+    });
+
+    await expect(service.markSettled({
+      withdrawalRequestId: 'withdraw_11',
+      actorUserId: 'admin_1',
+      actorApiKeyId: null,
+      settlementReference: 'wire_456',
+      adjustmentMinor: -15,
+      adjustmentReason: 'network fee'
+    })).rejects.toThrow('adjustment write failed');
+
+    expect(transaction).toHaveBeenCalledTimes(1);
+    expect(committed.status).toBe('approved');
+    expect(committed.settlementReference).toBeNull();
+    expect(committed.ledgerEffects).toEqual([]);
   });
 
   it('bubbles reserve-write failures from the transaction path so the request insert can roll back', async () => {

--- a/api/tests/withdrawalService.test.ts
+++ b/api/tests/withdrawalService.test.ts
@@ -211,7 +211,15 @@ describe('WithdrawalService', () => {
       .mockResolvedValueOnce({ id: 'withdraw_2', status: 'under_review', amount_minor: 250 })
       .mockResolvedValueOnce({ id: 'withdraw_2', status: 'rejected', amount_minor: 250 })
       .mockResolvedValueOnce({ id: 'withdraw_3', status: 'settlement_failed', amount_minor: 300 })
-      .mockResolvedValueOnce({ id: 'withdraw_4', status: 'settled', amount_minor: 500 });
+      .mockResolvedValueOnce({
+        id: 'withdraw_4',
+        owner_org_id: 'org_fnf',
+        contributor_user_id: 'user_darryn',
+        amount_minor: 500,
+        currency: 'USD',
+        settlement_reference: 'wire_123',
+        status: 'settled'
+      });
     const findById = vi.fn()
       .mockResolvedValueOnce({
         id: 'withdraw_2',
@@ -308,6 +316,7 @@ describe('WithdrawalService', () => {
       balanceBucket: 'adjusted',
       amountMinor: -15,
       withdrawalRequestId: 'withdraw_4',
+      payoutReference: 'wire_123',
       reason: 'network fee'
     }));
     expect(transaction).toHaveBeenCalledTimes(3);

--- a/api/tests/withdrawalService.test.ts
+++ b/api/tests/withdrawalService.test.ts
@@ -1,0 +1,402 @@
+import { describe, expect, it, vi } from 'vitest';
+import { WithdrawalService } from '../src/services/earnings/withdrawalService.js';
+
+describe('WithdrawalService', () => {
+  it('derives pending, withdrawable, reserved, settled, and adjusted balances from projector state plus ledger entries', async () => {
+    const service = new WithdrawalService({
+      sql: { transaction: vi.fn() } as any,
+      earningsLedgerRepo: {
+        listByOwnerOrgAndContributorUserId: vi.fn().mockResolvedValue([
+          { effect_type: 'contributor_accrual', amount_minor: 900 },
+          { effect_type: 'contributor_correction', amount_minor: -50 },
+          { effect_type: 'withdrawal_reserve', amount_minor: 200 },
+          { effect_type: 'payout_settlement', amount_minor: 100 }
+        ])
+      } as any,
+      withdrawalRequestRepo: {
+        listByOwnerOrgAndContributorUserId: vi.fn().mockResolvedValue([])
+      } as any,
+      canonicalMeteringRepo: {
+        findById: vi.fn().mockResolvedValue({
+          id: 'meter_pending',
+          serving_org_id: 'org_fnf',
+          capacity_owner_user_id: 'user_darryn',
+          admission_routing_mode: 'team-overflow-on-contributor-capacity',
+          contributor_earnings_minor: 75
+        })
+      } as any,
+      meteringProjectorStateRepo: {
+        listByProjectorAndState: vi.fn()
+          .mockResolvedValueOnce([{
+            metering_event_id: 'meter_pending',
+            projector: 'earnings',
+            state: 'pending_projection'
+          }])
+          .mockResolvedValueOnce([])
+      } as any
+    });
+
+    const summary = await service.getContributorSummary({
+      ownerOrgId: 'org_fnf',
+      contributorUserId: 'user_darryn'
+    });
+
+    expect(summary).toEqual({
+      pendingMinor: 75,
+      withdrawableMinor: 650,
+      reservedForPayoutMinor: 100,
+      settledMinor: 100,
+      adjustedMinor: -50
+    });
+  });
+
+  it('creates withdrawal requests only against withdrawable funds and records the reserve effect immediately', async () => {
+    const txQuery = vi.fn().mockResolvedValue({ rows: [], rowCount: 1 });
+    const create = vi.fn().mockResolvedValue({
+      id: 'withdraw_1',
+      owner_org_id: 'org_fnf',
+      contributor_user_id: 'user_darryn',
+      amount_minor: 400,
+      currency: 'USD',
+      destination: { rail: 'manual_usdc', address: '0xabc' },
+      status: 'requested',
+      requested_by_user_id: 'user_darryn',
+      reviewed_by_user_id: null,
+      reviewed_by_api_key_id: null,
+      note: null,
+      settlement_reference: null,
+      settlement_failure_reason: null,
+      created_at: '2026-03-20T12:00:00Z',
+      updated_at: '2026-03-20T12:00:00Z'
+    });
+    const appendEntry = vi.fn().mockResolvedValue({ id: 'earn_reserve_1' });
+    const service = new WithdrawalService({
+      sql: {
+        transaction: vi.fn(async (run) => run({ query: txQuery }))
+      } as any,
+      earningsLedgerRepo: {
+        listByOwnerOrgAndContributorUserId: vi.fn().mockResolvedValue([
+          { effect_type: 'contributor_accrual', amount_minor: 700 }
+        ]),
+        appendEntry
+      } as any,
+      withdrawalRequestRepo: {
+        create,
+        listByOwnerOrgAndContributorUserId: vi.fn().mockResolvedValue([])
+      } as any,
+      repoFactory: {
+        earningsLedger: vi.fn().mockReturnValue({
+          listByOwnerOrgAndContributorUserId: vi.fn().mockResolvedValue([
+            { effect_type: 'contributor_accrual', amount_minor: 700 }
+          ]),
+          appendEntry
+        }),
+        withdrawalRequests: vi.fn().mockReturnValue({
+          create
+        })
+      },
+      canonicalMeteringRepo: { findById: vi.fn() } as any,
+      meteringProjectorStateRepo: {
+        listByProjectorAndState: vi.fn().mockResolvedValue([])
+      } as any
+    });
+
+    const request = await service.createWithdrawalRequest({
+      ownerOrgId: 'org_fnf',
+      contributorUserId: 'user_darryn',
+      requestedByUserId: 'user_darryn',
+      amountMinor: 400,
+      destination: { rail: 'manual_usdc', address: '0xabc' }
+    });
+
+    expect(request.id).toBe('withdraw_1');
+    expect(txQuery).toHaveBeenCalledWith(
+      expect.stringContaining('pg_advisory_xact_lock'),
+      ['org_fnf', 'user_darryn']
+    );
+    expect(create).toHaveBeenCalledWith(expect.objectContaining({
+      ownerOrgId: 'org_fnf',
+      contributorUserId: 'user_darryn',
+      amountMinor: 400
+    }));
+    expect(appendEntry).toHaveBeenCalledWith(expect.objectContaining({
+      effectType: 'withdrawal_reserve',
+      balanceBucket: 'reserved_for_payout',
+      amountMinor: 400,
+      withdrawalRequestId: 'withdraw_1'
+    }));
+  });
+
+  it('uses org-scoped reads for contributor history and withdrawals', async () => {
+    const listHistory = vi.fn().mockResolvedValue([{ id: 'earn_1' }]);
+    const listWithdrawals = vi.fn().mockResolvedValue([{ id: 'withdraw_1' }]);
+    const service = new WithdrawalService({
+      sql: { transaction: vi.fn() } as any,
+      earningsLedgerRepo: {
+        listByOwnerOrgAndContributorUserId: listHistory,
+        appendEntry: vi.fn()
+      } as any,
+      withdrawalRequestRepo: {
+        listByOwnerOrgAndContributorUserId: listWithdrawals
+      } as any,
+      canonicalMeteringRepo: { findById: vi.fn() } as any,
+      meteringProjectorStateRepo: {
+        listByProjectorAndState: vi.fn().mockResolvedValue([])
+      } as any
+    });
+
+    await service.listContributorHistory({
+      ownerOrgId: 'org_fnf',
+      contributorUserId: 'user_darryn'
+    });
+    await service.listContributorWithdrawals({
+      ownerOrgId: 'org_fnf',
+      contributorUserId: 'user_darryn'
+    });
+
+    expect(listHistory).toHaveBeenCalledWith({
+      ownerOrgId: 'org_fnf',
+      contributorUserId: 'user_darryn'
+    });
+    expect(listWithdrawals).toHaveBeenCalledWith({
+      ownerOrgId: 'org_fnf',
+      contributorUserId: 'user_darryn'
+    });
+  });
+
+  it('rejects withdrawal requests that exceed withdrawable funds', async () => {
+    const service = new WithdrawalService({
+      sql: {
+        transaction: vi.fn(async (run) => run({ query: vi.fn().mockResolvedValue({ rows: [], rowCount: 1 }) }))
+      } as any,
+      earningsLedgerRepo: {
+        listByOwnerOrgAndContributorUserId: vi.fn().mockResolvedValue([
+          { effect_type: 'contributor_accrual', amount_minor: 150 }
+        ]),
+        appendEntry: vi.fn()
+      } as any,
+      withdrawalRequestRepo: {
+        create: vi.fn(),
+        listByOwnerOrgAndContributorUserId: vi.fn().mockResolvedValue([])
+      } as any,
+      repoFactory: {
+        earningsLedger: vi.fn().mockReturnValue({
+          listByOwnerOrgAndContributorUserId: vi.fn().mockResolvedValue([
+            { effect_type: 'contributor_accrual', amount_minor: 150 }
+          ]),
+          appendEntry: vi.fn()
+        }),
+        withdrawalRequests: vi.fn().mockReturnValue({
+          create: vi.fn()
+        })
+      },
+      canonicalMeteringRepo: { findById: vi.fn() } as any,
+      meteringProjectorStateRepo: {
+        listByProjectorAndState: vi.fn().mockResolvedValue([])
+      } as any
+    });
+
+    await expect(service.createWithdrawalRequest({
+      ownerOrgId: 'org_fnf',
+      contributorUserId: 'user_darryn',
+      requestedByUserId: 'user_darryn',
+      amountMinor: 200,
+      destination: { rail: 'manual_usdc', address: '0xabc' }
+    })).rejects.toThrow('withdrawal amount exceeds withdrawable earnings');
+  });
+
+  it('releases reserved funds on rejection and settlement failure, and records settlement plus adjustment effects on success', async () => {
+    const appendEntry = vi.fn().mockResolvedValue({ id: 'entry_1' });
+    const transitionStatus = vi.fn()
+      .mockResolvedValueOnce({ id: 'withdraw_2', status: 'under_review', amount_minor: 250 })
+      .mockResolvedValueOnce({ id: 'withdraw_2', status: 'rejected', amount_minor: 250 })
+      .mockResolvedValueOnce({ id: 'withdraw_3', status: 'settlement_failed', amount_minor: 300 })
+      .mockResolvedValueOnce({ id: 'withdraw_4', status: 'settled', amount_minor: 500 });
+    const findById = vi.fn()
+      .mockResolvedValueOnce({
+        id: 'withdraw_2',
+        owner_org_id: 'org_fnf',
+        contributor_user_id: 'user_darryn',
+        amount_minor: 250,
+        status: 'requested'
+      })
+      .mockResolvedValueOnce({
+        id: 'withdraw_3',
+        owner_org_id: 'org_fnf',
+        contributor_user_id: 'user_darryn',
+        amount_minor: 300,
+        status: 'approved'
+      })
+      .mockResolvedValueOnce({
+        id: 'withdraw_4',
+        owner_org_id: 'org_fnf',
+        contributor_user_id: 'user_darryn',
+        amount_minor: 500,
+        status: 'approved'
+      });
+
+    const service = new WithdrawalService({
+      sql: { transaction: vi.fn() } as any,
+      earningsLedgerRepo: {
+        listByOwnerOrgAndContributorUserId: vi.fn().mockResolvedValue([]),
+        appendEntry
+      } as any,
+      withdrawalRequestRepo: {
+        findById,
+        transitionStatus,
+        listByOwnerOrgAndContributorUserId: vi.fn().mockResolvedValue([])
+      } as any,
+      canonicalMeteringRepo: { findById: vi.fn() } as any,
+      meteringProjectorStateRepo: {
+        listByProjectorAndState: vi.fn().mockResolvedValue([])
+      } as any
+    });
+
+    await service.rejectWithdrawal({
+      withdrawalRequestId: 'withdraw_2',
+      actorUserId: 'admin_1',
+      actorApiKeyId: null,
+      reason: 'duplicate request'
+    });
+    await service.markSettlementFailed({
+      withdrawalRequestId: 'withdraw_3',
+      actorUserId: 'admin_1',
+      actorApiKeyId: null,
+      settlementFailureReason: 'bank rejected payout'
+    });
+    await service.markSettled({
+      withdrawalRequestId: 'withdraw_4',
+      actorUserId: 'admin_1',
+      actorApiKeyId: null,
+      settlementReference: 'wire_123',
+      adjustmentMinor: -15,
+      adjustmentReason: 'network fee'
+    });
+
+    expect(appendEntry).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      effectType: 'withdrawal_release',
+      balanceBucket: 'withdrawable',
+      amountMinor: 250,
+      withdrawalRequestId: 'withdraw_2'
+    }));
+    expect(appendEntry).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      effectType: 'withdrawal_release',
+      balanceBucket: 'withdrawable',
+      amountMinor: 300,
+      withdrawalRequestId: 'withdraw_3'
+    }));
+    expect(appendEntry).toHaveBeenNthCalledWith(3, expect.objectContaining({
+      effectType: 'payout_settlement',
+      balanceBucket: 'settled',
+      amountMinor: 500,
+      withdrawalRequestId: 'withdraw_4',
+      payoutReference: 'wire_123'
+    }));
+    expect(appendEntry).toHaveBeenNthCalledWith(4, expect.objectContaining({
+      effectType: 'payout_adjustment',
+      balanceBucket: 'adjusted',
+      amountMinor: -15,
+      withdrawalRequestId: 'withdraw_4',
+      reason: 'network fee'
+    }));
+  });
+
+  it('propagates admin api-key attribution through review transitions and payout ledger rows', async () => {
+    const appendEntry = vi.fn().mockResolvedValue({ id: 'entry_1' });
+    const transitionStatus = vi.fn()
+      .mockResolvedValueOnce({ id: 'withdraw_7', status: 'under_review', amount_minor: 250 })
+      .mockResolvedValueOnce({ id: 'withdraw_7', status: 'approved', amount_minor: 250 });
+    const findById = vi.fn().mockResolvedValueOnce({
+      id: 'withdraw_7',
+      owner_org_id: 'org_fnf',
+      contributor_user_id: 'user_darryn',
+      amount_minor: 250,
+      currency: 'USD',
+      status: 'requested'
+    });
+
+    const service = new WithdrawalService({
+      sql: { transaction: vi.fn() } as any,
+      earningsLedgerRepo: {
+        listByOwnerOrgAndContributorUserId: vi.fn().mockResolvedValue([]),
+        appendEntry
+      } as any,
+      withdrawalRequestRepo: {
+        findById,
+        transitionStatus,
+        listByOwnerOrgAndContributorUserId: vi.fn().mockResolvedValue([])
+      } as any,
+      canonicalMeteringRepo: { findById: vi.fn() } as any,
+      meteringProjectorStateRepo: {
+        listByProjectorAndState: vi.fn().mockResolvedValue([])
+      } as any
+    });
+
+    await service.approveWithdrawal({
+      withdrawalRequestId: 'withdraw_7',
+      actorUserId: null,
+      actorApiKeyId: 'key_admin_1',
+      reason: 'review complete'
+    });
+
+    expect(transitionStatus).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      id: 'withdraw_7',
+      nextStatus: 'under_review',
+      actedByUserId: null,
+      actedByApiKeyId: 'key_admin_1'
+    }));
+    expect(transitionStatus).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      id: 'withdraw_7',
+      nextStatus: 'approved',
+      actedByUserId: null,
+      actedByApiKeyId: 'key_admin_1'
+    }));
+    expect(appendEntry).not.toHaveBeenCalled();
+  });
+
+  it('bubbles reserve-write failures from the transaction path so the request insert can roll back', async () => {
+    const create = vi.fn().mockResolvedValue({
+      id: 'withdraw_9',
+      owner_org_id: 'org_fnf',
+      contributor_user_id: 'user_darryn',
+      amount_minor: 400,
+      currency: 'USD'
+    });
+    const appendEntry = vi.fn().mockRejectedValue(new Error('reserve write failed'));
+    const transaction = vi.fn(async (run) => run({ query: vi.fn().mockResolvedValue({ rows: [], rowCount: 1 }) }));
+    const service = new WithdrawalService({
+      sql: { transaction } as any,
+      earningsLedgerRepo: {
+        listByOwnerOrgAndContributorUserId: vi.fn().mockResolvedValue([])
+      } as any,
+      withdrawalRequestRepo: {} as any,
+      repoFactory: {
+        earningsLedger: vi.fn().mockReturnValue({
+          listByOwnerOrgAndContributorUserId: vi.fn().mockResolvedValue([
+            { effect_type: 'contributor_accrual', amount_minor: 700 }
+          ]),
+          appendEntry
+        }),
+        withdrawalRequests: vi.fn().mockReturnValue({
+          create
+        })
+      },
+      canonicalMeteringRepo: { findById: vi.fn() } as any,
+      meteringProjectorStateRepo: {
+        listByProjectorAndState: vi.fn().mockResolvedValue([])
+      } as any
+    });
+
+    await expect(service.createWithdrawalRequest({
+      ownerOrgId: 'org_fnf',
+      contributorUserId: 'user_darryn',
+      requestedByUserId: 'user_darryn',
+      amountMinor: 400,
+      destination: { rail: 'manual_usdc', address: '0xabc' }
+    })).rejects.toThrow('reserve write failed');
+
+    expect(transaction).toHaveBeenCalledTimes(1);
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(appendEntry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/docs/migrations/020_darryn_api_key_attribution.sql
+++ b/docs/migrations/020_darryn_api_key_attribution.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+ALTER TABLE in_earnings_ledger
+  ADD COLUMN IF NOT EXISTS actor_api_key_id uuid REFERENCES in_api_keys(id) ON DELETE SET NULL;
+
+ALTER TABLE in_withdrawal_requests
+  ADD COLUMN IF NOT EXISTS reviewed_by_api_key_id uuid REFERENCES in_api_keys(id) ON DELETE SET NULL;
+
+COMMIT;

--- a/docs/migrations/020_darryn_api_key_attribution_no_extensions.sql
+++ b/docs/migrations/020_darryn_api_key_attribution_no_extensions.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+ALTER TABLE in_earnings_ledger
+  ADD COLUMN IF NOT EXISTS actor_api_key_id uuid REFERENCES in_api_keys(id) ON DELETE SET NULL;
+
+ALTER TABLE in_withdrawal_requests
+  ADD COLUMN IF NOT EXISTS reviewed_by_api_key_id uuid REFERENCES in_api_keys(id) ON DELETE SET NULL;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- implement the Darryn Phase 2 contributor earnings and withdrawals workstream
- add earnings projection backlog and retry handling, contributor/admin APIs, and explicit earnings ledger effects for accrual, reserve, release, settlement, and adjustment
- add additive API-key attribution for admin withdrawal review and payout actions using `req.auth.apiKeyId` while leaving `*_user_id` null for API-key-only actions

## Verification
- `npm test -- earningsProjectorService.test.ts earningsProjectorJob.test.ts withdrawalService.test.ts canonicalMeteringRepository.test.ts earningsLedgerRepository.test.ts withdrawalRequestRepository.test.ts pilot.route.test.ts admin.pilot.route.test.ts darrynApiKeyAttributionMigrations.test.ts`
- `npm run build`

## Notes
- Full `npm test` is still red only in the pre-existing `tests/anthropicCompat.route.test.ts` area.
- Fresh full-suite run result: `18` failures in `tests/anthropicCompat.route.test.ts`; no other test files were red.