### PR TITLE
Add Darryn pilot dashboards

### DIFF
--- a/api/src/repos/pilotIdentityRepository.ts
+++ b/api/src/repos/pilotIdentityRepository.ts
@@ -31,6 +31,24 @@ export type MembershipRow = {
   created_at: string;
 };
 
+type OrgUserDirectoryRow = {
+  org_id: string;
+  org_slug: string;
+  org_name: string;
+  user_id: string;
+  user_email: string;
+  display_name: string | null;
+};
+
+export type OrgUserDirectoryEntry = {
+  orgId: string;
+  orgSlug: string;
+  orgName: string;
+  userId: string;
+  userEmail: string;
+  displayName: string | null;
+};
+
 export class PilotIdentityRepository {
   constructor(
     private readonly db: SqlClient,
@@ -142,6 +160,34 @@ export class PilotIdentityRepository {
       input.userId,
       input.role
     ]);
+  }
+
+  async listOrgUserDirectoryBySlug(slug: string): Promise<OrgUserDirectoryEntry[]> {
+    const sql = `
+      select
+        org.id as org_id,
+        org.slug as org_slug,
+        org.name as org_name,
+        "user".id as user_id,
+        "user".email as user_email,
+        "user".display_name
+      from ${TABLES.orgs} org
+      join in_memberships membership
+        on membership.org_id = org.id
+      join in_users "user"
+        on "user".id = membership.user_id
+      where org.slug = $1
+      order by lower("user".email) asc, membership.created_at asc
+    `;
+    const result = await this.db.query<OrgUserDirectoryRow>(sql, [slug]);
+    return result.rows.map((row) => ({
+      orgId: row.org_id,
+      orgSlug: row.org_slug,
+      orgName: row.org_name,
+      userId: row.user_id,
+      userEmail: row.user_email,
+      displayName: row.display_name
+    }));
   }
 
   async reassignBuyerKeysToOrg(input: {

--- a/api/src/repos/tokenCredentialRepository.ts
+++ b/api/src/repos/tokenCredentialRepository.ts
@@ -288,6 +288,26 @@ function contributionCapLifecycleMetadata(input: {
 export class TokenCredentialRepository {
   constructor(private readonly db: SqlClient) {}
 
+  async listByOrg(orgId: string): Promise<TokenCredential[]> {
+    const sql = (input: {
+      includeContributionCapColumns: boolean;
+      includeFreezeJoin: boolean;
+    }) => `
+      select
+        ${tokenCredentialSelectColumns(input.includeContributionCapColumns)}
+      from ${TABLES.tokenCredentials}
+      where org_id = $1
+        and status <> 'revoked'
+      order by provider asc, updated_at desc, rotation_version desc
+    `;
+
+    const result = await queryTokenCredentialRowsWithSchemaFallback(this.db, sql, [orgId], {
+      includeContributionCapColumns: true,
+      includeFreezeJoin: false
+    });
+    return result.rows.map(mapRow);
+  }
+
   async create(input: CreateTokenCredentialInput): Promise<{ id: string; rotationVersion: number }> {
     return this.db.transaction(async (tx) => {
       const latestSql = `

--- a/api/src/routes/admin.ts
+++ b/api/src/routes/admin.ts
@@ -20,6 +20,7 @@ import {
   refreshAnthropicOauthUsageWithCredentialRefresh,
   refreshTokenCredentialProviderUsageWithCredentialRefresh
 } from '../services/tokenCredentialOauthRefresh.js';
+import { buildConnectedAccountInventory } from '../services/pilot/pilotConnectedAccountInventory.js';
 import {
   probeAndUpdateTokenCredential,
   readTokenCredentialProbeIntervalMinutes,
@@ -255,6 +256,14 @@ const adminWithdrawalListQuerySchema = z.object({
   ownerOrgId: z.string().min(1)
 });
 
+const adminPilotConnectedAccountsQuerySchema = z.object({
+  ownerOrgId: z.string().min(1)
+});
+
+const adminPilotIdentityDiscoveryQuerySchema = z.object({
+  orgSlug: z.string().trim().min(1).optional()
+});
+
 const adminWithdrawalActionSchema = z.discriminatedUnion('action', [
   z.object({
     action: z.literal('approve'),
@@ -392,6 +401,47 @@ router.post('/v1/admin/pilot/session', requireApiKey(runtime.repos.apiKeys, ['ad
       ok: true,
       sessionToken,
       session
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/v1/admin/pilot/identities', requireApiKey(runtime.repos.apiKeys, ['admin']), async (req, res, next) => {
+  try {
+    const query = adminPilotIdentityDiscoveryQuerySchema.parse(req.query ?? {});
+    const orgSlug = query.orgSlug ?? process.env.PILOT_TARGET_ORG_SLUG ?? 'fnf';
+    const identities = await runtime.repos.pilotIdentity.listOrgUserDirectoryBySlug(orgSlug);
+    res.status(200).json({
+      ok: true,
+      identities: identities.map((identity) => ({
+        targetUserId: identity.userId,
+        targetOrgId: identity.orgId,
+        targetOrgSlug: identity.orgSlug,
+        targetOrgName: identity.orgName,
+        githubLogin: null,
+        userEmail: identity.userEmail,
+        displayName: identity.displayName
+      }))
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/v1/admin/pilot/connected-accounts', requireApiKey(runtime.repos.apiKeys, ['admin']), async (req, res, next) => {
+  try {
+    const query = adminPilotConnectedAccountsQuerySchema.parse(req.query ?? {});
+    const credentials = await runtime.repos.tokenCredentials.listByOrg(query.ownerOrgId);
+    const snapshots = await runtime.repos.tokenCredentialProviderUsage.listByTokenCredentialIds(
+      credentials.map((credential) => credential.id)
+    );
+    res.status(200).json({
+      ok: true,
+      accounts: buildConnectedAccountInventory({
+        credentials,
+        snapshots
+      })
     });
   } catch (error) {
     next(error);

--- a/api/src/routes/pilot.ts
+++ b/api/src/routes/pilot.ts
@@ -3,7 +3,13 @@
 import { Router } from 'express';
 import { z } from 'zod';
 import { runtime } from '../services/runtime.js';
+import { buildConnectedAccountInventory } from '../services/pilot/pilotConnectedAccountInventory.js';
 import { AppError } from '../utils/errors.js';
+import {
+  decodeRequestHistoryCursor,
+  encodeRequestHistoryCursor,
+  requestHistoryQuerySchema
+} from '../utils/requestHistoryCursor.js';
 
 const router = Router();
 
@@ -110,6 +116,53 @@ router.get('/v1/pilot/wallet', async (req, res, next) => {
     res.status(200).json({
       ok: true,
       wallet
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/v1/pilot/connected-accounts', async (req, res, next) => {
+  try {
+    const session = readPilotSession(req);
+    const credentials = await runtime.repos.tokenCredentials.listByOrg(session.effectiveOrgId);
+    const snapshots = await runtime.repos.tokenCredentialProviderUsage.listByTokenCredentialIds(
+      credentials.map((credential) => credential.id)
+    );
+
+    res.status(200).json({
+      ok: true,
+      accounts: buildConnectedAccountInventory({
+        credentials,
+        snapshots
+      })
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/v1/pilot/requests', async (req, res, next) => {
+  try {
+    const session = readPilotSession(req);
+    const query = requestHistoryQuerySchema.parse(req.query ?? {});
+    const cursor = decodeRequestHistoryCursor(query.cursor);
+    const rows = await runtime.repos.routingAttribution.listOrgRequestHistory({
+      orgId: session.effectiveOrgId,
+      limit: query.limit,
+      cursor,
+      historyScope: 'post_cutover'
+    });
+
+    const last = rows[rows.length - 1];
+    res.status(200).json({
+      orgId: session.effectiveOrgId,
+      requests: rows,
+      nextCursor: rows.length === query.limit && last ? encodeRequestHistoryCursor({
+        createdAt: last.created_at,
+        requestId: last.request_id,
+        attemptNo: last.attempt_no
+      }) : null
     });
   } catch (error) {
     next(error);

--- a/api/src/routes/usage.ts
+++ b/api/src/routes/usage.ts
@@ -3,25 +3,18 @@
 import { Router } from 'express';
 import { z } from 'zod';
 import { requireApiKey } from '../middleware/auth.js';
-import type { RequestHistoryCursor } from '../repos/routingAttributionRepository.js';
 import { runtime } from '../services/runtime.js';
+import {
+  decodeRequestHistoryCursor,
+  encodeRequestHistoryCursor,
+  requestHistoryQuerySchema
+} from '../utils/requestHistoryCursor.js';
 import { AppError } from '../utils/errors.js';
 
 const router = Router();
 
 const querySchema = z.object({
   days: z.coerce.number().int().min(1).max(90).optional().default(30)
-});
-
-const requestHistoryQuerySchema = z.object({
-  limit: z.coerce.number().int().min(1).max(100).optional().default(20),
-  cursor: z.string().min(1).optional()
-});
-
-const requestHistoryCursorSchema = z.object({
-  createdAt: z.string().min(1),
-  requestId: z.string().min(1),
-  attemptNo: z.number().int().min(1)
 });
 
 router.get('/v1/usage/me', requireApiKey(runtime.repos.apiKeys, ['buyer_proxy', 'admin']), async (req, res, next) => {
@@ -49,7 +42,7 @@ router.get('/v1/usage/me/requests', requireApiKey(runtime.repos.apiKeys, ['buyer
     }
 
     const query = requestHistoryQuerySchema.parse(req.query);
-    const cursor = decodeCursor(query.cursor);
+    const cursor = decodeRequestHistoryCursor(query.cursor);
     const rows = await runtime.repos.routingAttribution.listOrgRequestHistory({
       orgId: req.auth.orgId,
       limit: query.limit,
@@ -61,7 +54,7 @@ router.get('/v1/usage/me/requests', requireApiKey(runtime.repos.apiKeys, ['buyer
     res.json({
       orgId: req.auth.orgId,
       requests: rows,
-      nextCursor: rows.length === query.limit && last ? encodeCursor({
+      nextCursor: rows.length === query.limit && last ? encodeRequestHistoryCursor({
         createdAt: last.created_at,
         requestId: last.request_id,
         attemptNo: last.attempt_no
@@ -71,19 +64,5 @@ router.get('/v1/usage/me/requests', requireApiKey(runtime.repos.apiKeys, ['buyer
     next(error);
   }
 });
-
-function encodeCursor(cursor: RequestHistoryCursor): string {
-  return Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url');
-}
-
-function decodeCursor(cursor: string | undefined): RequestHistoryCursor | null {
-  if (!cursor) return null;
-  try {
-    const decoded = Buffer.from(cursor, 'base64url').toString('utf8');
-    return requestHistoryCursorSchema.parse(JSON.parse(decoded));
-  } catch {
-    throw new AppError('invalid_request', 400, 'Invalid request-history cursor');
-  }
-}
 
 export default router;

--- a/api/src/services/pilot/pilotConnectedAccountInventory.ts
+++ b/api/src/services/pilot/pilotConnectedAccountInventory.ts
@@ -1,0 +1,196 @@
+import type { TokenCredential } from '../../repos/tokenCredentialRepository.js';
+import type { TokenCredentialProviderUsageSnapshot } from '../../repos/tokenCredentialProviderUsageRepository.js';
+import { deriveDashboardTokenStatusRow } from '../dashboardTokenStatus.js';
+import { deriveTokenCredentialAuthDiagnosis } from '../tokenCredentialAuthDiagnosis.js';
+import {
+  evaluateClaudeContributionCap,
+  isTokenCredentialProviderUsageRefreshSupported,
+  readTokenCredentialProviderUsageHardStaleMs,
+  readTokenCredentialProviderUsageSoftStaleMs
+} from '../tokenCredentialProviderUsage.js';
+import { readClaudeContributionCapSnapshotState } from '../claudeContributionCapState.js';
+
+export type ConnectedAccountProviderUsageState =
+  | 'unsupported'
+  | 'missing'
+  | 'fresh'
+  | 'soft_stale'
+  | 'hard_stale';
+
+export type ConnectedAccountInventoryRow = {
+  credentialId: string;
+  orgId: string;
+  provider: string;
+  debugLabel: string | null;
+  status: string;
+  rawStatus: string;
+  expandedStatus: string;
+  statusSource: string | null;
+  exclusionReason: string | null;
+  authDiagnosis: string | null;
+  accessTokenExpiresAt: string | null;
+  refreshTokenState: 'missing' | 'present' | null;
+  expiresAt: string;
+  rateLimitedUntil: string | null;
+  nextProbeAt: string | null;
+  fiveHourReservePercent: number;
+  sevenDayReservePercent: number;
+  providerUsageRefreshSupported: boolean;
+  providerUsageSource: string | null;
+  providerUsageFetchedAt: string | null;
+  providerUsageState: ConnectedAccountProviderUsageState;
+  providerUsageWarning: string | null;
+  fiveHourUtilizationRatio: number | null;
+  fiveHourResetsAt: string | null;
+  fiveHourContributionCapExhausted: boolean | null;
+  fiveHourUsageExhausted: boolean | null;
+  sevenDayUtilizationRatio: number | null;
+  sevenDayResetsAt: string | null;
+  sevenDayContributionCapExhausted: boolean | null;
+  sevenDayUsageExhausted: boolean | null;
+};
+
+export function buildConnectedAccountInventory(input: {
+  credentials: TokenCredential[];
+  snapshots: TokenCredentialProviderUsageSnapshot[];
+  now?: Date;
+}): ConnectedAccountInventoryRow[] {
+  const now = input.now ?? new Date();
+  const snapshotsByCredentialId = new Map(
+    input.snapshots.map((snapshot) => [snapshot.tokenCredentialId, snapshot] as const)
+  );
+
+  return input.credentials.map((credential) => {
+    const snapshot = snapshotsByCredentialId.get(credential.id) ?? null;
+    const providerUsageRefreshSupported = isTokenCredentialProviderUsageRefreshSupported(credential);
+    const providerUsageState = deriveProviderUsageState({
+      snapshot,
+      supported: providerUsageRefreshSupported,
+      now
+    });
+    const auth = deriveTokenCredentialAuthDiagnosis({
+      provider: credential.provider,
+      accessToken: credential.accessToken,
+      hasRefreshToken: credential.refreshToken !== null,
+      lastFailedStatus: credential.lastFailedStatus,
+      now
+    });
+    const normalizedStatusProvider = credential.provider === 'codex' ? 'openai' : credential.provider;
+
+    const claudeState = normalizedStatusProvider === 'anthropic'
+      ? readClaudeContributionCapSnapshotState({ credential, snapshot })
+      : null;
+    const claudeCapEvaluation = normalizedStatusProvider === 'anthropic'
+      ? evaluateClaudeContributionCap({ credential, snapshot, now })
+      : null;
+
+    const fiveHourUsageExhausted = snapshot ? snapshot.fiveHourUtilizationRatio >= 1 : null;
+    const sevenDayUsageExhausted = snapshot ? snapshot.sevenDayUtilizationRatio >= 1 : null;
+
+    const derivedStatus = deriveDashboardTokenStatusRow({
+      provider: normalizedStatusProvider,
+      rawStatus: credential.status,
+      authDiagnosis: auth.authDiagnosis,
+      accessTokenExpiresAt: auth.accessTokenExpiresAt,
+      refreshTokenState: auth.refreshTokenState,
+      consecutiveFailures: credential.consecutiveFailureCount,
+      consecutiveRateLimitCount: credential.consecutiveRateLimitCount,
+      lastFailedStatus: credential.lastFailedStatus,
+      rateLimitedUntil: credential.rateLimitedUntil,
+      nextProbeAt: credential.nextProbeAt,
+      fiveHourReservePercent: credential.fiveHourReservePercent,
+      fiveHourUtilizationRatio: snapshot?.fiveHourUtilizationRatio ?? null,
+      fiveHourResetsAt: snapshot?.fiveHourResetsAt ?? null,
+      fiveHourContributionCapExhausted: claudeState?.fiveHourContributionCapExhausted ?? null,
+      sevenDayReservePercent: credential.sevenDayReservePercent,
+      sevenDayUtilizationRatio: snapshot?.sevenDayUtilizationRatio ?? null,
+      sevenDayResetsAt: snapshot?.sevenDayResetsAt ?? null,
+      sevenDayContributionCapExhausted: claudeState?.sevenDayContributionCapExhausted ?? null,
+      providerUsageFetchedAt: snapshot?.fetchedAt ?? null,
+      now
+    });
+
+    return {
+      credentialId: credential.id,
+      orgId: credential.orgId,
+      provider: credential.provider,
+      debugLabel: credential.debugLabel,
+      status: derivedStatus.compactStatus,
+      rawStatus: derivedStatus.rawStatus,
+      expandedStatus: derivedStatus.expandedStatus,
+      statusSource: derivedStatus.statusSource,
+      exclusionReason: derivedStatus.exclusionReason,
+      authDiagnosis: auth.authDiagnosis,
+      accessTokenExpiresAt: auth.accessTokenExpiresAt,
+      refreshTokenState: auth.refreshTokenState,
+      expiresAt: credential.expiresAt.toISOString(),
+      rateLimitedUntil: credential.rateLimitedUntil?.toISOString() ?? null,
+      nextProbeAt: credential.nextProbeAt?.toISOString() ?? null,
+      fiveHourReservePercent: credential.fiveHourReservePercent,
+      sevenDayReservePercent: credential.sevenDayReservePercent,
+      providerUsageRefreshSupported,
+      providerUsageSource: snapshot?.usageSource ?? null,
+      providerUsageFetchedAt: snapshot?.fetchedAt.toISOString() ?? null,
+      providerUsageState,
+      providerUsageWarning: deriveProviderUsageWarning({
+        provider: normalizedStatusProvider,
+        providerUsageState,
+        snapshot,
+        claudeCapEvaluation
+      }),
+      fiveHourUtilizationRatio: snapshot?.fiveHourUtilizationRatio ?? null,
+      fiveHourResetsAt: snapshot?.fiveHourResetsAt?.toISOString() ?? null,
+      fiveHourContributionCapExhausted: claudeState?.fiveHourContributionCapExhausted ?? null,
+      fiveHourUsageExhausted,
+      sevenDayUtilizationRatio: snapshot?.sevenDayUtilizationRatio ?? null,
+      sevenDayResetsAt: snapshot?.sevenDayResetsAt?.toISOString() ?? null,
+      sevenDayContributionCapExhausted: claudeState?.sevenDayContributionCapExhausted ?? null,
+      sevenDayUsageExhausted
+    };
+  });
+}
+
+function deriveProviderUsageState(input: {
+  snapshot: TokenCredentialProviderUsageSnapshot | null;
+  supported: boolean;
+  now: Date;
+}): ConnectedAccountProviderUsageState {
+  if (!input.supported) return 'unsupported';
+  if (!input.snapshot) return 'missing';
+
+  const ageMs = Math.max(0, input.now.getTime() - input.snapshot.fetchedAt.getTime());
+  if (ageMs > readTokenCredentialProviderUsageHardStaleMs()) {
+    return 'hard_stale';
+  }
+  if (ageMs > readTokenCredentialProviderUsageSoftStaleMs()) {
+    return 'soft_stale';
+  }
+  return 'fresh';
+}
+
+function deriveProviderUsageWarning(input: {
+  provider: string;
+  providerUsageState: ConnectedAccountProviderUsageState;
+  snapshot: TokenCredentialProviderUsageSnapshot | null;
+  claudeCapEvaluation: ReturnType<typeof evaluateClaudeContributionCap> | null;
+}): string | null {
+  if (input.provider === 'anthropic' && input.claudeCapEvaluation?.exclusionReason) {
+    return input.claudeCapEvaluation.exclusionReason;
+  }
+
+  switch (input.providerUsageState) {
+    case 'missing':
+      return 'provider_usage_snapshot_missing';
+    case 'soft_stale':
+      return 'provider_usage_snapshot_soft_stale';
+    case 'hard_stale':
+      return 'provider_usage_snapshot_hard_stale';
+    default:
+      break;
+  }
+
+  if (!input.snapshot) return null;
+  if (input.snapshot.fiveHourUtilizationRatio >= 1) return 'usage_exhausted_5h';
+  if (input.snapshot.sevenDayUtilizationRatio >= 1) return 'usage_exhausted_7d';
+  return null;
+}

--- a/api/src/utils/requestHistoryCursor.ts
+++ b/api/src/utils/requestHistoryCursor.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+import type { RequestHistoryCursor } from '../repos/routingAttributionRepository.js';
+import { AppError } from './errors.js';
+
+export const requestHistoryQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).optional().default(20),
+  cursor: z.string().min(1).optional()
+});
+
+const requestHistoryCursorSchema = z.object({
+  createdAt: z.string().min(1),
+  requestId: z.string().min(1),
+  attemptNo: z.number().int().min(1)
+});
+
+export function encodeRequestHistoryCursor(cursor: RequestHistoryCursor): string {
+  return Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url');
+}
+
+export function decodeRequestHistoryCursor(cursor: string | undefined): RequestHistoryCursor | null {
+  if (!cursor) return null;
+  try {
+    const decoded = Buffer.from(cursor, 'base64url').toString('utf8');
+    return requestHistoryCursorSchema.parse(JSON.parse(decoded));
+  } catch {
+    throw new AppError('invalid_request', 400, 'Invalid request-history cursor');
+  }
+}

--- a/api/tests/admin.pilot.route.test.ts
+++ b/api/tests/admin.pilot.route.test.ts
@@ -123,6 +123,8 @@ function getRouteHandlers(router: any, routePath: string, method: 'get' | 'post'
 describe('admin pilot routes', () => {
   let runtimeModule: RuntimeModule;
   let sessionHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+  let pilotIdentityHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+  let connectedAccountsHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
   let cutoverHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
   let rollbackHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
   let requestHistoryHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
@@ -147,6 +149,8 @@ describe('admin pilot routes', () => {
     runtimeModule = await import('../src/services/runtime.js');
     const mod = await import('../src/routes/admin.js') as AdminRouteModule;
     sessionHandlers = getRouteHandlers(mod.default as any, '/v1/admin/pilot/session', 'post');
+    pilotIdentityHandlers = getRouteHandlers(mod.default as any, '/v1/admin/pilot/identities', 'get');
+    connectedAccountsHandlers = getRouteHandlers(mod.default as any, '/v1/admin/pilot/connected-accounts', 'get');
     cutoverHandlers = getRouteHandlers(mod.default as any, '/v1/admin/pilot/cutover', 'post');
     rollbackHandlers = getRouteHandlers(mod.default as any, '/v1/admin/pilot/rollback', 'post');
     requestHistoryHandlers = getRouteHandlers(mod.default as any, '/v1/admin/requests', 'get');
@@ -252,6 +256,57 @@ describe('admin pilot routes', () => {
       id: 'withdraw_1',
       status: 'settlement_failed'
     } as any);
+    (runtimeModule.runtime.repos.pilotIdentity as any).listOrgUserDirectoryBySlug = vi.fn().mockResolvedValue([{
+      orgId: 'org_fnf',
+      orgSlug: 'fnf',
+      orgName: 'Friends & Family',
+      userId: 'user_darryn',
+      userEmail: 'darryn@example.com',
+      displayName: 'Darryn'
+    }]);
+    (runtimeModule.runtime.repos.tokenCredentials as any).listByOrg = vi.fn().mockResolvedValue([{
+      id: 'cred_2',
+      orgId: 'org_fnf',
+      provider: 'openai',
+      authScheme: 'bearer',
+      accessToken: 'header.payload.sig',
+      refreshToken: 'refresh_2',
+      expiresAt: new Date('2026-03-22T00:00:00.000Z'),
+      status: 'active',
+      rotationVersion: 1,
+      createdAt: new Date('2026-03-19T00:00:00.000Z'),
+      updatedAt: new Date('2026-03-20T00:00:00.000Z'),
+      revokedAt: null,
+      monthlyContributionLimitUnits: null,
+      monthlyContributionUsedUnits: 0,
+      monthlyWindowStartAt: new Date('2026-03-01T00:00:00.000Z'),
+      fiveHourReservePercent: 10,
+      sevenDayReservePercent: 20,
+      debugLabel: 'darryn-codex',
+      consecutiveFailureCount: 0,
+      consecutiveRateLimitCount: 0,
+      lastFailedStatus: null,
+      lastFailedAt: null,
+      lastRateLimitedAt: null,
+      maxedAt: null,
+      rateLimitedUntil: null,
+      nextProbeAt: null,
+      lastProbeAt: null
+    }]);
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentialProviderUsage, 'listByTokenCredentialIds').mockResolvedValue([{
+      tokenCredentialId: 'cred_2',
+      orgId: 'org_fnf',
+      provider: 'openai',
+      usageSource: 'openai_wham_usage',
+      fiveHourUtilizationRatio: 0.18,
+      fiveHourResetsAt: new Date('2026-03-20T15:00:00.000Z'),
+      sevenDayUtilizationRatio: 0.34,
+      sevenDayResetsAt: new Date('2026-03-27T00:00:00.000Z'),
+      rawPayload: {},
+      fetchedAt: new Date('2026-03-20T12:30:00.000Z'),
+      createdAt: new Date('2026-03-20T12:30:00.000Z'),
+      updatedAt: new Date('2026-03-20T12:30:00.000Z')
+    }]);
   });
 
   afterEach(() => {
@@ -294,6 +349,72 @@ describe('admin pilot routes', () => {
       })
     }));
     expect(res.headers['set-cookie']).toContain('innies_pilot_session=admin-session-token');
+  });
+
+  it('lists pilot identity discovery entries for admin impersonation', async () => {
+    const req = createMockReq({
+      method: 'GET',
+      path: '/v1/admin/pilot/identities',
+      headers: {
+        authorization: 'Bearer in_admin_token'
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(pilotIdentityHandlers[0], req, res);
+    await invoke(pilotIdentityHandlers[1], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      identities: [{
+        targetUserId: 'user_darryn',
+        targetOrgId: 'org_fnf',
+        targetOrgSlug: 'fnf',
+        targetOrgName: 'Friends & Family',
+        githubLogin: null,
+        userEmail: 'darryn@example.com',
+        displayName: 'Darryn'
+      }]
+    });
+    expect((runtimeModule.runtime.repos.pilotIdentity as any).listOrgUserDirectoryBySlug).toHaveBeenCalledWith('fnf');
+  });
+
+  it('returns admin pilot connected-account inventory for an owner org', async () => {
+    const req = createMockReq({
+      method: 'GET',
+      path: '/v1/admin/pilot/connected-accounts',
+      headers: {
+        authorization: 'Bearer in_admin_token'
+      },
+      query: {
+        ownerOrgId: 'org_fnf'
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(connectedAccountsHandlers[0], req, res);
+    await invoke(connectedAccountsHandlers[1], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      accounts: [expect.objectContaining({
+        credentialId: 'cred_2',
+        orgId: 'org_fnf',
+        provider: 'openai',
+        debugLabel: 'darryn-codex',
+        status: 'active',
+        rawStatus: 'active',
+        fiveHourReservePercent: 10,
+        sevenDayReservePercent: 20,
+        providerUsageFetchedAt: '2026-03-20T12:30:00.000Z',
+        fiveHourUtilizationRatio: 0.18,
+        sevenDayUtilizationRatio: 0.34
+      })]
+    });
+    expect((runtimeModule.runtime.repos.tokenCredentials as any).listByOrg).toHaveBeenCalledWith('org_fnf');
+    expect(runtimeModule.runtime.repos.tokenCredentialProviderUsage.listByTokenCredentialIds).toHaveBeenCalledWith(['cred_2']);
   });
 
   it('starts a cutover through the cutover service', async () => {

--- a/api/tests/pilot.route.test.ts
+++ b/api/tests/pilot.route.test.ts
@@ -128,6 +128,8 @@ function getRouteHandlers(router: any, routePath: string, method: 'get' | 'post'
 describe('pilot routes', () => {
   let runtimeModule: RuntimeModule;
   let sessionHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+  let requestHistoryHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+  let connectedAccountsHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
   let walletHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
   let walletLedgerHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
   let authStartHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
@@ -144,6 +146,8 @@ describe('pilot routes', () => {
     runtimeModule = await import('../src/services/runtime.js');
     const mod = await import('../src/routes/pilot.js') as PilotRouteModule;
     sessionHandlers = getRouteHandlers(mod.default as any, '/v1/pilot/session', 'get');
+    requestHistoryHandlers = getRouteHandlers(mod.default as any, '/v1/pilot/requests', 'get');
+    connectedAccountsHandlers = getRouteHandlers(mod.default as any, '/v1/pilot/connected-accounts', 'get');
     walletHandlers = getRouteHandlers(mod.default as any, '/v1/pilot/wallet', 'get');
     walletLedgerHandlers = getRouteHandlers(mod.default as any, '/v1/pilot/wallet/ledger', 'get');
     authStartHandlers = getRouteHandlers(mod.default as any, '/v1/pilot/auth/github/start', 'get');
@@ -156,6 +160,7 @@ describe('pilot routes', () => {
   });
 
   beforeEach(() => {
+    const now = Date.now();
     vi.restoreAllMocks();
     vi.spyOn(runtimeModule.runtime.services.pilotSessions, 'readTokenFromRequest').mockReturnValue('pilot-token');
     vi.spyOn(runtimeModule.runtime.services.pilotSessions, 'readSession').mockReturnValue({
@@ -186,6 +191,78 @@ describe('pilot routes', () => {
       status: 'requested',
       amount_minor: 250
     } as any);
+    vi.spyOn(runtimeModule.runtime.repos.routingAttribution, 'listOrgRequestHistory').mockResolvedValue([{
+      request_id: 'req_1',
+      attempt_no: 1,
+      session_id: 'sess_1',
+      admission_org_id: 'org_fnf',
+      admission_cutover_id: 'cut_1',
+      admission_routing_mode: 'self-free',
+      consumer_org_id: 'org_fnf',
+      buyer_key_id: 'buyer_1',
+      serving_org_id: 'org_fnf',
+      provider_account_id: 'acct_1',
+      token_credential_id: 'cred_1',
+      capacity_owner_user_id: 'user_darryn',
+      provider: 'anthropic',
+      model: 'claude-opus-4-6',
+      rate_card_version_id: 'rate_1',
+      input_tokens: 11,
+      output_tokens: 22,
+      usage_units: 33,
+      buyer_debit_minor: 0,
+      contributor_earnings_minor: 0,
+      currency: 'USD',
+      metadata: null,
+      created_at: '2026-03-20T10:00:00.000Z',
+      prompt_preview: 'hello',
+      response_preview: 'world',
+      route_decision: { reason: 'cli_provider_pinned' },
+      projector_states: []
+    }] as any);
+    (runtimeModule.runtime.repos.tokenCredentials as any).listByOrg = vi.fn().mockResolvedValue([{
+      id: 'cred_1',
+      orgId: 'org_fnf',
+      provider: 'anthropic',
+      authScheme: 'bearer',
+      accessToken: 'sk-ant-oat-pilot',
+      refreshToken: 'refresh_1',
+      expiresAt: new Date('2026-03-21T00:00:00.000Z'),
+      status: 'active',
+      rotationVersion: 2,
+      createdAt: new Date('2026-03-19T00:00:00.000Z'),
+      updatedAt: new Date('2026-03-20T00:00:00.000Z'),
+      revokedAt: null,
+      monthlyContributionLimitUnits: null,
+      monthlyContributionUsedUnits: 0,
+      monthlyWindowStartAt: new Date('2026-03-01T00:00:00.000Z'),
+      fiveHourReservePercent: 15,
+      sevenDayReservePercent: 25,
+      debugLabel: 'darryn-claude',
+      consecutiveFailureCount: 0,
+      consecutiveRateLimitCount: 0,
+      lastFailedStatus: null,
+      lastFailedAt: null,
+      lastRateLimitedAt: null,
+      maxedAt: null,
+      rateLimitedUntil: null,
+      nextProbeAt: null,
+      lastProbeAt: null
+    }]);
+    vi.spyOn(runtimeModule.runtime.repos.tokenCredentialProviderUsage, 'listByTokenCredentialIds').mockResolvedValue([{
+      tokenCredentialId: 'cred_1',
+      orgId: 'org_fnf',
+      provider: 'anthropic',
+      usageSource: 'anthropic_oauth_usage',
+      fiveHourUtilizationRatio: 0.41,
+      fiveHourResetsAt: new Date(now + 2 * 60 * 60 * 1000),
+      sevenDayUtilizationRatio: 0.52,
+      sevenDayResetsAt: new Date(now + 7 * 24 * 60 * 60 * 1000),
+      rawPayload: {},
+      fetchedAt: new Date(now - 30 * 1000),
+      createdAt: new Date(now - 30 * 1000),
+      updatedAt: new Date(now - 30 * 1000)
+    }]);
   });
 
   afterEach(() => {
@@ -272,6 +349,135 @@ describe('pilot routes', () => {
         walletId: 'org_fnf',
         balanceMinor: 1250
       })
+    }));
+  });
+
+  it('returns connected-account inventory for the effective pilot org', async () => {
+    const req = createMockReq({
+      method: 'GET',
+      path: '/v1/pilot/connected-accounts',
+      headers: {
+        authorization: 'Bearer pilot-token'
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(connectedAccountsHandlers[0], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      accounts: [expect.objectContaining({
+        credentialId: 'cred_1',
+        orgId: 'org_fnf',
+        provider: 'anthropic',
+        debugLabel: 'darryn-claude',
+        status: 'active',
+        rawStatus: 'active',
+        fiveHourReservePercent: 15,
+        sevenDayReservePercent: 25,
+        fiveHourUtilizationRatio: 0.41,
+        sevenDayUtilizationRatio: 0.52,
+        fiveHourContributionCapExhausted: false,
+        sevenDayContributionCapExhausted: false
+      })]
+    });
+    expect((runtimeModule.runtime.repos.tokenCredentials as any).listByOrg).toHaveBeenCalledWith('org_fnf');
+    expect(runtimeModule.runtime.repos.tokenCredentialProviderUsage.listByTokenCredentialIds).toHaveBeenCalledWith(['cred_1']);
+  });
+
+  it('returns post-cutover request history for the effective pilot org', async () => {
+    const req = createMockReq({
+      method: 'GET',
+      path: '/v1/pilot/requests',
+      headers: {
+        authorization: 'Bearer pilot-token'
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(requestHistoryHandlers[0], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(expect.objectContaining({
+      orgId: 'org_fnf',
+      requests: [expect.objectContaining({ request_id: 'req_1' })],
+      nextCursor: null
+    }));
+    expect(runtimeModule.runtime.repos.routingAttribution.listOrgRequestHistory).toHaveBeenCalledWith({
+      orgId: 'org_fnf',
+      limit: 20,
+      cursor: null,
+      historyScope: 'post_cutover'
+    });
+  });
+
+  it('accepts and emits full request-history cursors for pilot-session reads', async () => {
+    const decodedCursor = {
+      createdAt: '2026-03-19T09:00:00.000Z',
+      requestId: 'req_8',
+      attemptNo: 2
+    };
+    const encodedCursor = Buffer.from(JSON.stringify(decodedCursor), 'utf8').toString('base64url');
+    vi.spyOn(runtimeModule.runtime.repos.routingAttribution, 'listOrgRequestHistory').mockResolvedValue([{
+      request_id: 'req_9',
+      attempt_no: 3,
+      session_id: 'sess_2',
+      admission_org_id: 'org_fnf',
+      admission_cutover_id: 'cut_2',
+      admission_routing_mode: 'paid-team-capacity',
+      consumer_org_id: 'org_fnf',
+      buyer_key_id: 'buyer_1',
+      serving_org_id: 'org_capacity',
+      provider_account_id: 'acct_2',
+      token_credential_id: 'cred_2',
+      capacity_owner_user_id: 'user_capacity',
+      provider: 'openai',
+      model: 'gpt-5-codex',
+      rate_card_version_id: 'rate_2',
+      input_tokens: 101,
+      output_tokens: 202,
+      usage_units: 303,
+      buyer_debit_minor: 404,
+      contributor_earnings_minor: 55,
+      currency: 'USD',
+      metadata: null,
+      created_at: '2026-03-20T11:00:00.000Z',
+      prompt_preview: 'build',
+      response_preview: 'done',
+      route_decision: { reason: 'team_capacity_available' },
+      projector_states: []
+    }] as any);
+
+    const req = createMockReq({
+      method: 'GET',
+      path: '/v1/pilot/requests',
+      headers: {
+        authorization: 'Bearer pilot-token'
+      },
+      query: {
+        limit: '1',
+        cursor: encodedCursor
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(requestHistoryHandlers[0], req, res);
+
+    expect(runtimeModule.runtime.repos.routingAttribution.listOrgRequestHistory).toHaveBeenCalledWith({
+      orgId: 'org_fnf',
+      limit: 1,
+      cursor: decodedCursor,
+      historyScope: 'post_cutover'
+    });
+    expect(res.body).toEqual(expect.objectContaining({
+      orgId: 'org_fnf',
+      requests: [expect.objectContaining({ request_id: 'req_9' })],
+      nextCursor: Buffer.from(JSON.stringify({
+        createdAt: '2026-03-20T11:00:00.000Z',
+        requestId: 'req_9',
+        attemptNo: 3
+      }), 'utf8').toString('base64url')
     }));
   });
 

--- a/api/tests/pilotIdentityRepository.test.ts
+++ b/api/tests/pilotIdentityRepository.test.ts
@@ -99,4 +99,35 @@ describe('PilotIdentityRepository', () => {
     expect(db.queries[0].sql).toContain('where id = any($1::uuid[])');
     expect(db.queries[0].params?.[1]).toBe('org_fnf');
   });
+
+  it('lists pilot identity discovery rows by org slug for admin impersonation', async () => {
+    const db = new MockSqlClient({
+      rows: [{
+        org_id: 'org_fnf',
+        org_slug: 'fnf',
+        org_name: 'Friends & Family',
+        user_id: 'user_darryn',
+        user_email: 'darryn@example.com',
+        display_name: 'Darryn'
+      }],
+      rowCount: 1
+    });
+    const repo = new PilotIdentityRepository(db);
+
+    const rows = await (repo as any).listOrgUserDirectoryBySlug('fnf');
+
+    expect(rows).toEqual([{
+      orgId: 'org_fnf',
+      orgSlug: 'fnf',
+      orgName: 'Friends & Family',
+      userId: 'user_darryn',
+      userEmail: 'darryn@example.com',
+      displayName: 'Darryn'
+    }]);
+    expect(db.queries[0].sql).toContain('from in_orgs org');
+    expect(db.queries[0].sql).toContain('join in_memberships membership');
+    expect(db.queries[0].sql).toContain('join in_users "user"');
+    expect(db.queries[0].sql).toContain('where org.slug = $1');
+    expect(db.queries[0].params).toEqual(['fnf']);
+  });
 });

--- a/api/tests/tokenCredentialRepository.test.ts
+++ b/api/tests/tokenCredentialRepository.test.ts
@@ -161,6 +161,62 @@ describe('tokenCredentialRepository', () => {
     ]);
   });
 
+  it('lists non-revoked credentials for one org for dashboard inventory reads', async () => {
+    process.env.SELLER_SECRET_ENC_KEY_B64 = Buffer.alloc(32, 31).toString('base64');
+    const db = new SequenceSqlClient([{
+      rows: [{
+        id: 'cred_dashboard_1',
+        org_id: '00000000-0000-0000-0000-000000000099',
+        provider: 'openai',
+        auth_scheme: 'bearer',
+        encrypted_access_token: encryptSecret('dashboard-access'),
+        encrypted_refresh_token: encryptSecret('dashboard-refresh'),
+        expires_at: '2026-03-30T00:00:00Z',
+        status: 'expired',
+        rotation_version: 7,
+        created_at: '2026-03-01T00:00:00Z',
+        updated_at: '2026-03-20T12:00:00Z',
+        revoked_at: null,
+        monthly_contribution_limit_units: null,
+        monthly_contribution_used_units: 0,
+        monthly_window_start_at: '2026-03-01T00:00:00Z',
+        five_hour_reserve_percent: 12,
+        seven_day_reserve_percent: 34,
+        debug_label: 'darryn-codex',
+        consecutive_failure_count: 1,
+        consecutive_rate_limit_count: 2,
+        last_failed_status: 401,
+        last_failed_at: '2026-03-20T11:30:00Z',
+        last_rate_limited_at: null,
+        maxed_at: null,
+        rate_limited_until: null,
+        next_probe_at: '2026-03-20T13:00:00Z',
+        last_probe_at: '2026-03-20T12:00:00Z'
+      }],
+      rowCount: 1
+    }]);
+    const repo = new TokenCredentialRepository(db);
+
+    const rows = await (repo as any).listByOrg('00000000-0000-0000-0000-000000000099');
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toEqual(expect.objectContaining({
+      id: 'cred_dashboard_1',
+      orgId: '00000000-0000-0000-0000-000000000099',
+      provider: 'openai',
+      accessToken: 'dashboard-access',
+      refreshToken: 'dashboard-refresh',
+      status: 'expired',
+      fiveHourReservePercent: 12,
+      sevenDayReservePercent: 34,
+      debugLabel: 'darryn-codex'
+    }));
+    expect(db.queries[0].sql).toContain('where org_id = $1');
+    expect(db.queries[0].sql).not.toContain("status = 'active'");
+    expect(db.queries[0].sql).toContain("status <> 'revoked'");
+    expect(db.queries[0].params).toEqual(['00000000-0000-0000-0000-000000000099']);
+  });
+
   it('falls back cleanly when contribution-cap columns are missing from routing reads', async () => {
     process.env.SELLER_SECRET_ENC_KEY_B64 = Buffer.alloc(32, 10).toString('base64');
     const db = new SequenceSqlClient([

--- a/ui/src/app/admin/pilot/accounts/[orgId]/page.tsx
+++ b/ui/src/app/admin/pilot/accounts/[orgId]/page.tsx
@@ -1,0 +1,75 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import {
+  AdminWithdrawalReviewSection,
+  ConnectedAccountsSection,
+  DashboardPage,
+  EarningsSection,
+  RequestExplanationSection,
+  RequestHistorySection,
+  WalletSection,
+} from '../../../../../components/pilot/DashboardSections';
+import { getAdminPilotAccountView } from '../../../../../lib/pilot/server';
+import { formatCount, formatUsdMinor } from '../../../../../lib/pilot/present';
+
+export const dynamic = 'force-dynamic';
+
+export default async function AdminPilotAccountPage(input: {
+  params: Promise<{ orgId: string }>;
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const params = await input.params;
+  const searchParams = input.searchParams ? await input.searchParams : {};
+  const explain = Array.isArray(searchParams.explain) ? searchParams.explain[0] : searchParams.explain;
+  const view = await getAdminPilotAccountView({
+    orgId: params.orgId,
+    explainRequestId: explain ?? null
+  });
+
+  if (!view) notFound();
+
+  return (
+    <DashboardPage
+      eyebrow="Admin Account View"
+      title={view.identity.displayName || view.identity.userEmail}
+      lede="Admin account-view page for Darryn context, with request explanation, routing attribution, wallet history, connected accounts, earnings, and withdrawal review."
+      actions={(
+        <>
+          <Link href="/admin/pilot">Back to identities</Link>
+          <form action="/api/admin/pilot/impersonate" method="post">
+            <input name="targetUserId" type="hidden" value={view.identity.targetUserId} />
+            <input name="targetOrgId" type="hidden" value={view.identity.targetOrgId} />
+            <input name="targetOrgSlug" type="hidden" value={view.identity.targetOrgSlug || ''} />
+            <input name="targetOrgName" type="hidden" value={view.identity.targetOrgName || ''} />
+            <input name="githubLogin" type="hidden" value={view.identity.githubLogin || ''} />
+            <input name="userEmail" type="hidden" value={view.identity.userEmail} />
+            <button type="submit">Impersonate</button>
+          </form>
+        </>
+      )}
+      stats={[
+        { label: 'Wallet', value: formatUsdMinor(view.wallet.balanceMinor) },
+        { label: 'Requests', value: formatCount(view.requests.length) },
+        { label: 'Withdrawals', value: formatCount(view.withdrawals.length) },
+        { label: 'Accounts', value: formatCount(view.accounts.length) },
+      ]}
+      sections={(
+        <>
+          <WalletSection ledger={view.walletLedger} wallet={view.wallet} />
+          <RequestHistorySection
+            adminBasePath={`/admin/pilot/accounts/${encodeURIComponent(view.identity.targetOrgId)}`}
+            orgId={view.identity.targetOrgId}
+            requests={view.requests}
+          />
+          <RequestExplanationSection request={view.requestExplanation} />
+          <ConnectedAccountsSection accounts={view.accounts} editable={false} returnTo={`/admin/pilot/accounts/${encodeURIComponent(view.identity.targetOrgId)}`} />
+          <EarningsSection history={view.earningsHistory} summary={view.earningsSummary} />
+          <AdminWithdrawalReviewSection
+            returnTo={`/admin/pilot/accounts/${encodeURIComponent(view.identity.targetOrgId)}`}
+            withdrawals={view.withdrawals}
+          />
+        </>
+      )}
+    />
+  );
+}

--- a/ui/src/app/admin/pilot/page.tsx
+++ b/ui/src/app/admin/pilot/page.tsx
@@ -1,0 +1,24 @@
+import { DashboardPage, PilotIdentityListSection } from '../../../components/pilot/DashboardSections';
+import { listAdminPilotIdentities } from '../../../lib/pilot/server';
+import { formatCount } from '../../../lib/pilot/present';
+
+export const dynamic = 'force-dynamic';
+
+export default async function AdminPilotPage() {
+  const identities = await listAdminPilotIdentities();
+
+  return (
+    <DashboardPage
+      eyebrow="Admin Pilot"
+      title="Pilot identity discovery"
+      lede="Admin entry for Darryn context, account-view navigation, and one-click impersonation into the pilot dashboard."
+      stats={[
+        { label: 'Pilot Identities', value: formatCount(identities.length) },
+        { label: 'Impersonate', value: 'Ready' },
+        { label: 'Account Views', value: formatCount(identities.length) },
+        { label: 'Mode', value: 'Admin' },
+      ]}
+      sections={<PilotIdentityListSection identities={identities} />}
+    />
+  );
+}

--- a/ui/src/app/api/admin/pilot/impersonate/route.ts
+++ b/ui/src/app/api/admin/pilot/impersonate/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { PilotServerError, fetchAdminJson } from '../../../../../lib/pilot/server';
+
+export const dynamic = 'force-dynamic';
+
+function readFormString(formData: FormData, key: string): string {
+  const value = formData.get(key);
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+export async function POST(request: NextRequest) {
+  const formData = await request.formData();
+
+  try {
+    const response = await fetchAdminJson<{ ok: true; sessionToken: string }>({
+      path: '/v1/admin/pilot/session',
+      method: 'POST',
+      body: {
+        mode: 'impersonation',
+        targetUserId: readFormString(formData, 'targetUserId'),
+        targetOrgId: readFormString(formData, 'targetOrgId'),
+        targetOrgSlug: readFormString(formData, 'targetOrgSlug') || undefined,
+        targetOrgName: readFormString(formData, 'targetOrgName') || undefined,
+        githubLogin: readFormString(formData, 'githubLogin') || undefined,
+        userEmail: readFormString(formData, 'userEmail') || undefined
+      }
+    });
+
+    const redirect = NextResponse.redirect(new URL('/pilot', request.url));
+    redirect.cookies.set('innies_pilot_session', response.sessionToken, {
+      httpOnly: true,
+      sameSite: 'lax',
+      path: '/'
+    });
+    return redirect;
+  } catch (error) {
+    if (error instanceof PilotServerError) {
+      return NextResponse.json({
+        code: 'admin_pilot_impersonation_error',
+        message: error.message,
+        details: error.details
+      }, { status: error.status });
+    }
+    throw error;
+  }
+}

--- a/ui/src/app/api/admin/pilot/withdrawals/[withdrawalRequestId]/route.ts
+++ b/ui/src/app/api/admin/pilot/withdrawals/[withdrawalRequestId]/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { PilotServerError, fetchAdminJson } from '../../../../../../lib/pilot/server';
+
+export const dynamic = 'force-dynamic';
+
+function readFormString(formData: FormData, key: string): string {
+  const value = formData.get(key);
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function readOptionalInt(value: string): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? Math.trunc(parsed) : undefined;
+}
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ withdrawalRequestId: string }> }
+) {
+  const { withdrawalRequestId } = await context.params;
+  const formData = await request.formData();
+  const action = readFormString(formData, 'action');
+  const returnTo = readFormString(formData, 'returnTo') || '/admin/pilot';
+  const reason = readFormString(formData, 'reason');
+  const settlementReference = readFormString(formData, 'settlementReference');
+  const adjustmentMinor = readOptionalInt(readFormString(formData, 'adjustmentMinor'));
+  const adjustmentReason = readFormString(formData, 'adjustmentReason');
+
+  let body: Record<string, unknown>;
+  switch (action) {
+    case 'approve':
+      body = {
+        action,
+        reason: reason || undefined
+      };
+      break;
+    case 'reject':
+      body = {
+        action,
+        reason: reason || 'Rejected from dashboard'
+      };
+      break;
+    case 'mark_settled':
+      body = {
+        action,
+        settlementReference: settlementReference || 'dashboard_settlement',
+        adjustmentMinor,
+        adjustmentReason: adjustmentReason || undefined
+      };
+      break;
+    case 'mark_settlement_failed':
+      body = {
+        action,
+        settlementFailureReason: reason || adjustmentReason || 'Settlement failed from dashboard',
+        adjustmentMinor,
+        adjustmentReason: adjustmentReason || undefined
+      };
+      break;
+    default:
+      return NextResponse.json({
+        code: 'admin_pilot_withdrawal_error',
+        message: 'Unsupported withdrawal action'
+      }, { status: 400 });
+  }
+
+  try {
+    await fetchAdminJson({
+      path: `/v1/admin/pilot/withdrawals/${withdrawalRequestId}/actions`,
+      method: 'POST',
+      body
+    });
+    return NextResponse.redirect(new URL(returnTo, request.url));
+  } catch (error) {
+    if (error instanceof PilotServerError) {
+      return NextResponse.json({
+        code: 'admin_pilot_withdrawal_error',
+        message: error.message,
+        details: error.details
+      }, { status: error.status });
+    }
+    throw error;
+  }
+}

--- a/ui/src/app/api/pilot/reserve-floors/route.ts
+++ b/ui/src/app/api/pilot/reserve-floors/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  PilotServerError,
+  fetchAdminJson,
+  getPilotConnectedAccounts,
+  getPilotSession
+} from '../../../../lib/pilot/server';
+
+export const dynamic = 'force-dynamic';
+
+function readFormString(formData: FormData, key: string): string {
+  const value = formData.get(key);
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+export async function POST(request: NextRequest) {
+  const formData = await request.formData();
+  const returnTo = readFormString(formData, 'returnTo') || '/pilot';
+  const credentialId = readFormString(formData, 'credentialId');
+  const fiveHourReservePercent = Number(readFormString(formData, 'fiveHourReservePercent'));
+  const sevenDayReservePercent = Number(readFormString(formData, 'sevenDayReservePercent'));
+  const cookieHeader = request.headers.get('cookie');
+
+  try {
+    const session = await getPilotSession(cookieHeader);
+    if (!session) {
+      return NextResponse.redirect(new URL('/pilot', request.url));
+    }
+
+    const accounts = await getPilotConnectedAccounts(cookieHeader);
+    const account = accounts.find((entry) => entry.credentialId === credentialId);
+    if (!account || account.orgId !== session.effectiveOrgId) {
+      return NextResponse.json({
+        code: 'pilot_reserve_floor_error',
+        message: 'Connected account not found in the current pilot org'
+      }, { status: 404 });
+    }
+
+    await fetchAdminJson({
+      path: `/v1/admin/token-credentials/${credentialId}/contribution-cap`,
+      method: 'PATCH',
+      body: {
+        fiveHourReservePercent,
+        sevenDayReservePercent
+      }
+    });
+
+    return NextResponse.redirect(new URL(returnTo, request.url));
+  } catch (error) {
+    if (error instanceof PilotServerError) {
+      return NextResponse.json({
+        code: 'pilot_reserve_floor_error',
+        message: error.message,
+        details: error.details
+      }, { status: error.status });
+    }
+    throw error;
+  }
+}

--- a/ui/src/app/api/pilot/session/logout/route.ts
+++ b/ui/src/app/api/pilot/session/logout/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { PilotServerError, fetchPilotJson } from '../../../../../lib/pilot/server';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: NextRequest) {
+  try {
+    await fetchPilotJson({
+      path: '/v1/pilot/session/logout',
+      method: 'POST',
+      cookieHeader: request.headers.get('cookie')
+    });
+  } catch (error) {
+    if (!(error instanceof PilotServerError)) {
+      throw error;
+    }
+  }
+
+  const response = NextResponse.redirect(new URL('/pilot', request.url));
+  response.cookies.set('innies_pilot_session', '', {
+    httpOnly: true,
+    sameSite: 'lax',
+    path: '/',
+    maxAge: 0
+  });
+  return response;
+}

--- a/ui/src/app/api/pilot/withdrawals/route.ts
+++ b/ui/src/app/api/pilot/withdrawals/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { PilotServerError, fetchPilotJson } from '../../../../lib/pilot/server';
+
+export const dynamic = 'force-dynamic';
+
+function readFormString(formData: FormData, key: string): string {
+  const value = formData.get(key);
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+export async function POST(request: NextRequest) {
+  const formData = await request.formData();
+  const returnTo = readFormString(formData, 'returnTo') || '/pilot';
+  const amountMinor = Number(readFormString(formData, 'amountMinor'));
+  const destinationRail = readFormString(formData, 'destinationRail') || 'manual_usdc';
+  const destinationAddress = readFormString(formData, 'destinationAddress');
+  const note = readFormString(formData, 'note');
+
+  try {
+    await fetchPilotJson({
+      path: '/v1/pilot/withdrawals',
+      method: 'POST',
+      cookieHeader: request.headers.get('cookie'),
+      body: {
+        amountMinor,
+        destination: {
+          rail: destinationRail,
+          address: destinationAddress
+        },
+        note: note || undefined
+      }
+    });
+    return NextResponse.redirect(new URL(returnTo, request.url));
+  } catch (error) {
+    if (error instanceof PilotServerError) {
+      return NextResponse.json({
+        code: 'pilot_withdrawal_error',
+        message: error.message,
+        details: error.details
+      }, { status: error.status });
+    }
+    throw error;
+  }
+}

--- a/ui/src/app/pilot/page.tsx
+++ b/ui/src/app/pilot/page.tsx
@@ -1,0 +1,62 @@
+import {
+  ConnectedAccountsSection,
+  DashboardPage,
+  EarningsSection,
+  PilotWithdrawalsSection,
+  RequestHistorySection,
+  WalletSection,
+} from '../../components/pilot/DashboardSections';
+import { buildPilotAuthStartUrl, getPilotDashboardData } from '../../lib/pilot/server';
+import { formatCount, formatUsdMinor } from '../../lib/pilot/present';
+
+export const dynamic = 'force-dynamic';
+
+export default async function PilotPage() {
+  const dashboard = await getPilotDashboardData();
+
+  if (!dashboard) {
+    return (
+      <DashboardPage
+        eyebrow="Pilot Dashboard"
+        title="Darryn dashboard access"
+        lede="Sign in with the allowlisted pilot GitHub account to see wallet movement, request routing, connected accounts, reserve floors, earnings, and withdrawals."
+        actions={<a href={buildPilotAuthStartUrl('/pilot')}>Sign in with GitHub</a>}
+        stats={[
+          { label: 'Wallet', value: '--' },
+          { label: 'Requests', value: '--' },
+          { label: 'Withdrawable', value: '--' },
+          { label: 'Accounts', value: '--' },
+        ]}
+        sections={null}
+      />
+    );
+  }
+
+  return (
+    <DashboardPage
+      eyebrow={dashboard.session.sessionKind === 'admin_impersonation' ? 'Admin Impersonation' : 'Pilot Dashboard'}
+      title={dashboard.session.githubLogin ? `${dashboard.session.githubLogin} · Phase 2 dashboard` : 'Phase 2 dashboard'}
+      lede="One coherent dashboard for wallet balance, post-cutover request history, connected accounts, Reserve Floors, earnings, and withdrawals."
+      actions={(
+        <form action="/api/pilot/session/logout" method="post">
+          <button type="submit">Log out</button>
+        </form>
+      )}
+      stats={[
+        { label: 'Wallet', value: formatUsdMinor(dashboard.wallet.balanceMinor) },
+        { label: 'Requests', value: formatCount(dashboard.requests.length) },
+        { label: 'Withdrawable', value: formatUsdMinor(dashboard.earningsSummary.withdrawableMinor) },
+        { label: 'Accounts', value: formatCount(dashboard.accounts.length) },
+      ]}
+      sections={(
+        <>
+          <WalletSection ledger={dashboard.walletLedger} wallet={dashboard.wallet} />
+          <RequestHistorySection orgId={dashboard.session.effectiveOrgId} requests={dashboard.requests} />
+          <ConnectedAccountsSection accounts={dashboard.accounts} editable returnTo="/pilot" />
+          <EarningsSection history={dashboard.earningsHistory} summary={dashboard.earningsSummary} />
+          <PilotWithdrawalsSection returnTo="/pilot" withdrawals={dashboard.withdrawals} />
+        </>
+      )}
+    />
+  );
+}

--- a/ui/src/components/pilot/DashboardSections.tsx
+++ b/ui/src/components/pilot/DashboardSections.tsx
@@ -1,0 +1,530 @@
+import Link from 'next/link';
+import styles from './dashboard.module.css';
+import {
+  formatAccountHealth,
+  formatCount,
+  formatPercentRatio,
+  formatProvider,
+  formatProviderUsageWarning,
+  formatRoutingMode,
+  formatTimestamp,
+  formatUsdMinor,
+  formatWalletEffectType,
+  formatWithdrawalDestination,
+  summarizeRouteDecision,
+} from '../../lib/pilot/present';
+import type {
+  AdminPilotAccountView,
+  ConnectedAccount,
+  EarningsHistoryEntry,
+  EarningsSummary,
+  PilotDashboardData,
+  PilotIdentityDiscoveryEntry,
+  RequestHistoryRow,
+  WalletLedgerEntry,
+  Withdrawal,
+} from '../../lib/pilot/types';
+
+function Section(input: {
+  title: string;
+  hint?: string;
+  actions?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className={styles.section}>
+      <div className={styles.sectionHeader}>
+        <div>
+          <h2 className={styles.sectionTitle}>{input.title}</h2>
+          {input.hint ? <p className={styles.sectionHint}>{input.hint}</p> : null}
+        </div>
+        {input.actions}
+      </div>
+      {input.children}
+    </section>
+  );
+}
+
+function pillClass(kind: 'neutral' | 'good' | 'warn' | 'danger') {
+  switch (kind) {
+    case 'good':
+      return styles.goodPill;
+    case 'warn':
+      return styles.warnPill;
+    case 'danger':
+      return styles.dangerPill;
+    default:
+      return styles.pill;
+  }
+}
+
+function warningKind(account: ConnectedAccount): 'neutral' | 'good' | 'warn' | 'danger' {
+  if (!account.providerUsageWarning) return 'good';
+  if (account.providerUsageWarning.includes('exhausted') || account.providerUsageWarning.includes('hard_stale')) {
+    return 'danger';
+  }
+  return 'warn';
+}
+
+export function DashboardPage(input: {
+  title: string;
+  eyebrow: string;
+  lede: string;
+  actions?: React.ReactNode;
+  stats: Array<{ label: string; value: string }>;
+  sections: React.ReactNode;
+}) {
+  return (
+    <main className={styles.page}>
+      <div className={styles.shell}>
+        <section className={styles.hero}>
+          <div className={styles.heroTop}>
+            <div>
+              <div className={styles.eyebrow}>{input.eyebrow}</div>
+              <h1 className={styles.title}>{input.title}</h1>
+              <p className={styles.lede}>{input.lede}</p>
+            </div>
+            {input.actions ? <div className={styles.heroActions}>{input.actions}</div> : null}
+          </div>
+          <div className={styles.heroStats}>
+            {input.stats.map((stat) => (
+              <div className={styles.statCard} key={stat.label}>
+                <p className={styles.statLabel}>{stat.label}</p>
+                <p className={styles.statValue}>{stat.value}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+        <div className={styles.grid}>{input.sections}</div>
+      </div>
+    </main>
+  );
+}
+
+export function WalletSection(input: {
+  wallet: PilotDashboardData['wallet'] | AdminPilotAccountView['wallet'];
+  ledger: WalletLedgerEntry[];
+}) {
+  return (
+    <Section
+      title="Wallet"
+      hint="Balance, manual top-ups, and all wallet ledger movement are shown here from the append-only wallet ledger."
+    >
+      <div className={styles.pillRow}>
+        <span className={styles.goodPill}>Balance {formatUsdMinor(input.wallet.balanceMinor)}</span>
+        <span className={styles.pill}>Wallet id {input.wallet.walletId}</span>
+      </div>
+      <div className={styles.tableWrap}>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>Entry</th>
+              <th>Amount</th>
+              <th>When</th>
+              <th>Reason</th>
+            </tr>
+          </thead>
+          <tbody>
+            {input.ledger.map((entry) => (
+              <tr key={entry.id}>
+                <td>
+                  <strong>{formatWalletEffectType(entry)}</strong>
+                  <div className={styles.muted}>{entry.effect_type}</div>
+                </td>
+                <td>{formatUsdMinor(entry.amount_minor)}</td>
+                <td>{formatTimestamp(entry.created_at ?? null)}</td>
+                <td>{entry.reason || '--'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {input.ledger.length === 0 ? <div className={styles.emptyState}>No wallet history yet.</div> : null}
+    </Section>
+  );
+}
+
+export function RequestHistorySection(input: {
+  orgId: string;
+  requests: RequestHistoryRow[];
+  adminBasePath?: string;
+}) {
+  return (
+    <Section
+      title="Request History"
+      hint="Post-cutover request history with routing attribution, money movement, and request previews."
+    >
+      <div className={styles.tableWrap}>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>Request</th>
+              <th>Route</th>
+              <th>Money</th>
+              <th>Usage</th>
+              <th>When</th>
+            </tr>
+          </thead>
+          <tbody>
+            {input.requests.map((row) => (
+              <tr key={`${row.request_id}:${row.attempt_no}`}>
+                <td>
+                  <strong>{row.request_id}</strong>
+                  <div className={styles.muted}>{formatProvider(row.provider)} · {row.model}</div>
+                  <div className={styles.muted}>{summarizeRouteDecision(row)}</div>
+                  {input.adminBasePath ? (
+                    <Link
+                      className={styles.inlineButton}
+                      href={`${input.adminBasePath}?explain=${encodeURIComponent(row.request_id)}`}
+                    >
+                      Explain
+                    </Link>
+                  ) : null}
+                </td>
+                <td>
+                  <div>{formatRoutingMode(row.admission_routing_mode)}</div>
+                  <div className={styles.muted}>{row.serving_org_id}</div>
+                </td>
+                <td>
+                  <div>Debit {formatUsdMinor(row.buyer_debit_minor)}</div>
+                  <div className={styles.muted}>Earnings {formatUsdMinor(row.contributor_earnings_minor)}</div>
+                </td>
+                <td>
+                  <div>{formatCount(row.usage_units)} units</div>
+                  <div className={styles.muted}>{formatCount(row.input_tokens)} in · {formatCount(row.output_tokens)} out</div>
+                </td>
+                <td>{formatTimestamp(row.created_at)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {input.requests.length === 0 ? <div className={styles.emptyState}>No post-cutover request history for {input.orgId}.</div> : null}
+    </Section>
+  );
+}
+
+export function ConnectedAccountsSection(input: {
+  accounts: ConnectedAccount[];
+  editable: boolean;
+  returnTo: string;
+}) {
+  return (
+    <Section
+      title="Connected Accounts"
+      hint="Connected account status, provider freshness, and Reserve Floors are shown per credential."
+    >
+      <div className={styles.cardGrid}>
+        {input.accounts.map((account) => (
+          <article className={styles.accountCard} key={account.credentialId}>
+            <div className={styles.cardTitleRow}>
+              <div>
+                <h3 className={styles.cardTitle}>{account.debugLabel || account.credentialId}</h3>
+                <p className={styles.cardMeta}>{formatProvider(account.provider)} · {account.credentialId}</p>
+              </div>
+              <span className={pillClass(warningKind(account))}>{account.status}</span>
+            </div>
+            <p className={styles.cardMeta}>{formatAccountHealth(account)}</p>
+            <div className={styles.metricGrid}>
+              <div>
+                <p className={styles.metricLabel}>Provider Usage</p>
+                <p className={styles.metricValue}>{account.providerUsageState.replaceAll('_', ' ')}</p>
+              </div>
+              <div>
+                <p className={styles.metricLabel}>Fetched</p>
+                <p className={styles.metricValue}>{formatTimestamp(account.providerUsageFetchedAt)}</p>
+              </div>
+              <div>
+                <p className={styles.metricLabel}>5h Used</p>
+                <p className={styles.metricValue}>{formatPercentRatio(account.fiveHourUtilizationRatio)}</p>
+              </div>
+              <div>
+                <p className={styles.metricLabel}>7d Used</p>
+                <p className={styles.metricValue}>{formatPercentRatio(account.sevenDayUtilizationRatio)}</p>
+              </div>
+            </div>
+            <div className={styles.pillRow}>
+              <span className={styles.pill}>Auth {account.authDiagnosis || 'ok'}</span>
+              <span className={styles.pill}>Refresh {account.refreshTokenState || '--'}</span>
+              <span className={pillClass(warningKind(account))}>{formatProviderUsageWarning(account)}</span>
+            </div>
+            {input.editable ? (
+              <form action="/api/pilot/reserve-floors" method="post">
+                <input name="credentialId" type="hidden" value={account.credentialId} />
+                <input name="returnTo" type="hidden" value={input.returnTo} />
+                <div className={styles.formGrid}>
+                  <label className={styles.fieldLabel}>
+                    Reserve Floors · 5h
+                    <input
+                      className={styles.input}
+                      defaultValue={String(account.fiveHourReservePercent)}
+                      max="100"
+                      min="0"
+                      name="fiveHourReservePercent"
+                      type="number"
+                    />
+                  </label>
+                  <label className={styles.fieldLabel}>
+                    Reserve Floors · 1w
+                    <input
+                      className={styles.input}
+                      defaultValue={String(account.sevenDayReservePercent)}
+                      max="100"
+                      min="0"
+                      name="sevenDayReservePercent"
+                      type="number"
+                    />
+                  </label>
+                </div>
+                <div className={styles.formActions}>
+                  <button className={styles.actionButton} type="submit">Save Reserve Floors</button>
+                </div>
+              </form>
+            ) : null}
+          </article>
+        ))}
+      </div>
+      {input.accounts.length === 0 ? <div className={styles.emptyState}>No connected pilot accounts found.</div> : null}
+    </Section>
+  );
+}
+
+export function EarningsSection(input: {
+  summary: EarningsSummary | null;
+  history: EarningsHistoryEntry[];
+}) {
+  return (
+    <Section
+      title="Earnings"
+      hint="Contributor earnings are shown from the earnings ledger and grouped into pending, withdrawable, reserved, settled, and adjusted balances."
+    >
+      {input.summary ? (
+        <div className={styles.heroStats}>
+          <div className={styles.statCard}>
+            <p className={styles.statLabel}>Pending</p>
+            <p className={styles.statValue}>{formatUsdMinor(input.summary.pendingMinor)}</p>
+          </div>
+          <div className={styles.statCard}>
+            <p className={styles.statLabel}>Withdrawable</p>
+            <p className={styles.statValue}>{formatUsdMinor(input.summary.withdrawableMinor)}</p>
+          </div>
+          <div className={styles.statCard}>
+            <p className={styles.statLabel}>Reserved</p>
+            <p className={styles.statValue}>{formatUsdMinor(input.summary.reservedForPayoutMinor)}</p>
+          </div>
+          <div className={styles.statCard}>
+            <p className={styles.statLabel}>Settled</p>
+            <p className={styles.statValue}>{formatUsdMinor(input.summary.settledMinor)}</p>
+          </div>
+        </div>
+      ) : (
+        <div className={styles.emptyState}>No contributor earnings summary is available for this pilot account.</div>
+      )}
+      <div className={styles.tableWrap}>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>Entry</th>
+              <th>Bucket</th>
+              <th>Amount</th>
+              <th>When</th>
+            </tr>
+          </thead>
+          <tbody>
+            {input.history.map((entry, index) => (
+              <tr key={entry.id || entry.earnings_ledger_entry_id || String(index)}>
+                <td>{entry.effect_type || 'ledger entry'}</td>
+                <td>{entry.bucket || '--'}</td>
+                <td>{formatUsdMinor(entry.amount_minor ?? null)}</td>
+                <td>{formatTimestamp(entry.created_at ?? null)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {input.history.length === 0 ? <div className={styles.emptyState}>No earnings history yet.</div> : null}
+    </Section>
+  );
+}
+
+export function PilotWithdrawalsSection(input: {
+  withdrawals: Withdrawal[];
+  returnTo: string;
+}) {
+  return (
+    <Section
+      title="Withdrawals"
+      hint="Create a withdrawal request and track status changes from requested through settlement."
+    >
+      <form action="/api/pilot/withdrawals" method="post">
+        <input name="returnTo" type="hidden" value={input.returnTo} />
+        <div className={styles.formGrid}>
+          <label className={styles.fieldLabel}>
+            Amount (minor units)
+            <input className={styles.input} min="1" name="amountMinor" step="1" type="number" />
+          </label>
+          <label className={styles.fieldLabel}>
+            Destination rail
+            <input className={styles.input} defaultValue="manual_usdc" name="destinationRail" type="text" />
+          </label>
+          <label className={styles.fieldLabel}>
+            Destination address
+            <input className={styles.input} name="destinationAddress" type="text" />
+          </label>
+          <label className={styles.fieldLabel}>
+            Note
+            <input className={styles.input} name="note" type="text" />
+          </label>
+        </div>
+        <div className={styles.formActions}>
+          <button className={styles.actionButton} type="submit">Create Withdrawal</button>
+        </div>
+      </form>
+      <div className={styles.tableWrap}>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>Withdrawal</th>
+              <th>Status</th>
+              <th>Destination</th>
+              <th>When</th>
+            </tr>
+          </thead>
+          <tbody>
+            {input.withdrawals.map((withdrawal) => (
+              <tr key={withdrawal.id}>
+                <td>
+                  <strong>{formatUsdMinor(withdrawal.amount_minor)}</strong>
+                  <div className={styles.muted}>{withdrawal.id}</div>
+                </td>
+                <td>{withdrawal.status}</td>
+                <td>{formatWithdrawalDestination(withdrawal)}</td>
+                <td>{formatTimestamp(withdrawal.created_at ?? null)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {input.withdrawals.length === 0 ? <div className={styles.emptyState}>No withdrawals yet.</div> : null}
+    </Section>
+  );
+}
+
+export function AdminWithdrawalReviewSection(input: {
+  withdrawals: Withdrawal[];
+  returnTo: string;
+}) {
+  return (
+    <Section
+      title="Withdrawal Review"
+      hint="Run review actions against the backend-owned pilot withdrawal workflow."
+    >
+      {input.withdrawals.length === 0 ? <div className={styles.emptyState}>No pilot withdrawals found for this account.</div> : null}
+      <div className={styles.cardGrid}>
+        {input.withdrawals.map((withdrawal) => (
+          <article className={styles.identityCard} key={withdrawal.id}>
+            <div className={styles.cardTitleRow}>
+              <div>
+                <h3 className={styles.cardTitle}>{formatUsdMinor(withdrawal.amount_minor)}</h3>
+                <p className={styles.cardMeta}>{withdrawal.id} · {withdrawal.status}</p>
+              </div>
+              <span className={styles.pill}>{formatWithdrawalDestination(withdrawal)}</span>
+            </div>
+            <form action={`/api/admin/pilot/withdrawals/${encodeURIComponent(withdrawal.id)}`} method="post">
+              <input name="returnTo" type="hidden" value={input.returnTo} />
+              <div className={styles.formGrid}>
+                <label className={styles.fieldLabel}>
+                  Action
+                  <select className={styles.select} defaultValue="approve" name="action">
+                    <option value="approve">Approve</option>
+                    <option value="reject">Reject</option>
+                    <option value="mark_settled">Mark settled</option>
+                    <option value="mark_settlement_failed">Mark settlement failed</option>
+                  </select>
+                </label>
+                <label className={styles.fieldLabel}>
+                  Reason
+                  <input className={styles.input} name="reason" type="text" />
+                </label>
+                <label className={styles.fieldLabel}>
+                  Settlement reference
+                  <input className={styles.input} name="settlementReference" type="text" />
+                </label>
+                <label className={styles.fieldLabel}>
+                  Adjustment (minor)
+                  <input className={styles.input} min="-99999999" name="adjustmentMinor" step="1" type="number" />
+                </label>
+              </div>
+              <label className={styles.fieldLabel}>
+                Adjustment / failure detail
+                <textarea className={styles.textarea} name="adjustmentReason" />
+              </label>
+              <div className={styles.formActions}>
+                <button className={styles.actionButton} type="submit">Submit Review Action</button>
+              </div>
+            </form>
+          </article>
+        ))}
+      </div>
+    </Section>
+  );
+}
+
+export function RequestExplanationSection(input: {
+  request: RequestHistoryRow | null;
+}) {
+  if (!input.request) return null;
+
+  return (
+    <Section
+      title="Request Explanation"
+      hint="Expanded routing and money attribution pulled from the backend explanation endpoint."
+    >
+      <pre className={styles.codeBlock}>{JSON.stringify(input.request, null, 2)}</pre>
+    </Section>
+  );
+}
+
+export function PilotIdentityListSection(input: {
+  identities: PilotIdentityDiscoveryEntry[];
+}) {
+  return (
+    <Section
+      title="Pilot Identities"
+      hint="Admin identity discovery feeds the impersonation entry flow without guessing user or org ids."
+    >
+      <div className={styles.cardGrid}>
+        {input.identities.map((identity) => (
+          <article className={styles.identityCard} key={`${identity.targetOrgId}:${identity.targetUserId}`}>
+            <div className={styles.cardTitleRow}>
+              <div>
+                <h3 className={styles.cardTitle}>{identity.displayName || identity.userEmail}</h3>
+                <p className={styles.cardMeta}>{identity.targetOrgName || identity.targetOrgId}</p>
+              </div>
+              <span className={styles.pill}>{identity.targetOrgSlug || 'pilot'}</span>
+            </div>
+            <div className={styles.pillRow}>
+              <span className={styles.pill}>{identity.userEmail}</span>
+              {identity.githubLogin ? <span className={styles.pill}>{identity.githubLogin}</span> : null}
+            </div>
+            <div className={styles.formActions}>
+              <Link className={styles.ghostButton} href={`/admin/pilot/accounts/${encodeURIComponent(identity.targetOrgId)}`}>
+                View Account
+              </Link>
+              <form action="/api/admin/pilot/impersonate" method="post">
+                <input name="targetUserId" type="hidden" value={identity.targetUserId} />
+                <input name="targetOrgId" type="hidden" value={identity.targetOrgId} />
+                <input name="targetOrgSlug" type="hidden" value={identity.targetOrgSlug || ''} />
+                <input name="targetOrgName" type="hidden" value={identity.targetOrgName || ''} />
+                <input name="githubLogin" type="hidden" value={identity.githubLogin || ''} />
+                <input name="userEmail" type="hidden" value={identity.userEmail} />
+                <button className={styles.actionButton} type="submit">Impersonate</button>
+              </form>
+            </div>
+          </article>
+        ))}
+      </div>
+      {input.identities.length === 0 ? <div className={styles.emptyState}>No pilot identities are available.</div> : null}
+    </Section>
+  );
+}

--- a/ui/src/components/pilot/dashboard.module.css
+++ b/ui/src/components/pilot/dashboard.module.css
@@ -1,0 +1,334 @@
+.page {
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at top left, rgba(245, 211, 122, 0.28), transparent 32%),
+    radial-gradient(circle at top right, rgba(76, 110, 93, 0.18), transparent 28%),
+    linear-gradient(180deg, #f8f3e8 0%, #efe7d6 52%, #e7dfcc 100%);
+  color: #142018;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+}
+
+.shell {
+  width: min(1180px, calc(100vw - 32px));
+  margin: 0 auto;
+  padding: 28px 0 56px;
+}
+
+.hero {
+  display: grid;
+  gap: 20px;
+  padding: 24px;
+  border: 1px solid rgba(20, 32, 24, 0.12);
+  border-radius: 28px;
+  background:
+    linear-gradient(135deg, rgba(255, 250, 241, 0.92), rgba(244, 236, 218, 0.82)),
+    rgba(255, 255, 255, 0.6);
+  box-shadow: 0 24px 60px rgba(37, 49, 41, 0.12);
+}
+
+.heroTop {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(20, 32, 24, 0.08);
+  font-size: 12px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.title {
+  margin: 0;
+  font-family: "Iowan Old Style", "Palatino Linotype", serif;
+  font-size: clamp(2rem, 4vw, 3.4rem);
+  line-height: 0.98;
+}
+
+.lede {
+  margin: 12px 0 0;
+  max-width: 760px;
+  color: rgba(20, 32, 24, 0.8);
+  font-size: 1rem;
+  line-height: 1.55;
+}
+
+.heroActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.actionButton,
+.ghostButton,
+.inlineButton {
+  border: 1px solid rgba(20, 32, 24, 0.16);
+  border-radius: 999px;
+  background: rgba(20, 32, 24, 0.92);
+  color: #f6f1e6;
+  padding: 10px 16px;
+  font: inherit;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.ghostButton {
+  background: rgba(255, 255, 255, 0.55);
+  color: #142018;
+}
+
+.inlineButton {
+  padding: 8px 12px;
+  background: rgba(20, 32, 24, 0.08);
+  color: #142018;
+}
+
+.heroStats {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.statCard {
+  padding: 14px 16px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.58);
+  border: 1px solid rgba(20, 32, 24, 0.08);
+}
+
+.statLabel {
+  margin: 0;
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(20, 32, 24, 0.62);
+}
+
+.statValue {
+  margin: 8px 0 0;
+  font-size: clamp(1.3rem, 2.5vw, 2rem);
+  font-weight: 700;
+}
+
+.grid {
+  display: grid;
+  gap: 18px;
+  margin-top: 20px;
+}
+
+.section {
+  padding: 22px;
+  border-radius: 24px;
+  border: 1px solid rgba(20, 32, 24, 0.1);
+  background: rgba(255, 251, 244, 0.86);
+  box-shadow: 0 10px 30px rgba(51, 59, 44, 0.08);
+}
+
+.sectionHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.sectionTitle {
+  margin: 0;
+  font-family: "Iowan Old Style", "Palatino Linotype", serif;
+  font-size: 1.55rem;
+}
+
+.sectionHint {
+  margin: 6px 0 0;
+  color: rgba(20, 32, 24, 0.7);
+  line-height: 1.5;
+}
+
+.tableWrap {
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  padding: 12px 10px;
+  border-top: 1px solid rgba(20, 32, 24, 0.09);
+  vertical-align: top;
+  text-align: left;
+}
+
+.table th {
+  border-top: none;
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(20, 32, 24, 0.58);
+}
+
+.muted {
+  color: rgba(20, 32, 24, 0.62);
+}
+
+.pillRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.pill,
+.warnPill,
+.goodPill,
+.dangerPill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(20, 32, 24, 0.08);
+  font-size: 12px;
+}
+
+.goodPill {
+  background: rgba(76, 110, 93, 0.12);
+}
+
+.warnPill {
+  background: rgba(181, 118, 20, 0.16);
+}
+
+.dangerPill {
+  background: rgba(149, 55, 44, 0.14);
+}
+
+.cardGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.accountCard,
+.identityCard {
+  padding: 16px;
+  border-radius: 20px;
+  border: 1px solid rgba(20, 32, 24, 0.1);
+  background: rgba(255, 255, 255, 0.64);
+}
+
+.cardTitleRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.cardTitle {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.cardMeta {
+  margin: 6px 0 0;
+  color: rgba(20, 32, 24, 0.68);
+  line-height: 1.5;
+}
+
+.metricGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.metricLabel {
+  margin: 0;
+  font-size: 12px;
+  color: rgba(20, 32, 24, 0.58);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.metricValue {
+  margin: 4px 0 0;
+  font-weight: 600;
+}
+
+.formGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.fieldLabel {
+  display: grid;
+  gap: 6px;
+  font-size: 13px;
+  color: rgba(20, 32, 24, 0.78);
+}
+
+.input,
+.select,
+.textarea {
+  width: 100%;
+  border: 1px solid rgba(20, 32, 24, 0.16);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.88);
+  padding: 10px 12px;
+  font: inherit;
+  color: #142018;
+}
+
+.textarea {
+  min-height: 96px;
+  resize: vertical;
+}
+
+.formActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.emptyState {
+  padding: 18px;
+  border-radius: 18px;
+  background: rgba(20, 32, 24, 0.06);
+  color: rgba(20, 32, 24, 0.72);
+}
+
+.codeBlock {
+  margin: 0;
+  padding: 14px;
+  border-radius: 18px;
+  background: #16211b;
+  color: #e5efdd;
+  overflow-x: auto;
+  font-size: 13px;
+}
+
+@media (max-width: 900px) {
+  .heroTop,
+  .sectionHeader,
+  .cardTitleRow {
+    flex-direction: column;
+  }
+
+  .heroStats,
+  .cardGrid,
+  .formGrid,
+  .metricGrid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/ui/src/lib/pilot/present.ts
+++ b/ui/src/lib/pilot/present.ts
@@ -1,0 +1,132 @@
+import type {
+  ConnectedAccount,
+  RequestHistoryRow,
+  WalletLedgerEntry,
+  Withdrawal,
+} from './types';
+
+const moneyFormat = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+const numberFormat = new Intl.NumberFormat('en-US');
+const percentFormat = new Intl.NumberFormat('en-US', {
+  style: 'percent',
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 1,
+});
+
+export function formatUsdMinor(amountMinor: number | null | undefined): string {
+  if (amountMinor === null || amountMinor === undefined) return '--';
+  return moneyFormat.format(amountMinor / 100);
+}
+
+export function formatCount(value: number | null | undefined): string {
+  if (value === null || value === undefined) return '--';
+  return numberFormat.format(value);
+}
+
+export function formatPercentRatio(value: number | null | undefined): string {
+  if (value === null || value === undefined) return '--';
+  return percentFormat.format(Math.max(0, Math.min(1, value)));
+}
+
+export function formatTimestamp(value: string | null | undefined): string {
+  if (!value) return '--';
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return value;
+  return new Intl.DateTimeFormat('en-US', {
+    dateStyle: 'medium',
+    timeStyle: 'short'
+  }).format(new Date(parsed));
+}
+
+export function formatProvider(value: string | null | undefined): string {
+  const normalized = (value ?? '').trim().toLowerCase();
+  if (normalized === 'anthropic') return 'Claude';
+  if (normalized === 'codex') return 'Codex';
+  if (normalized === 'openai') return 'OpenAI';
+  return value?.trim() || '--';
+}
+
+export function formatRoutingMode(value: string | null | undefined): string {
+  switch ((value ?? '').trim().toLowerCase()) {
+    case 'self-free':
+      return 'Self free';
+    case 'paid-team-capacity':
+      return 'Paid team capacity';
+    case 'team-overflow-on-contributor-capacity':
+      return 'Team overflow on contributor capacity';
+    default:
+      return value?.trim() || '--';
+  }
+}
+
+export function formatWalletEffectType(entry: WalletLedgerEntry): string {
+  switch ((entry.effect_type ?? '').trim().toLowerCase()) {
+    case 'manual_credit':
+      return 'Manual top-up';
+    case 'manual_debit':
+      return 'Manual debit';
+    case 'buyer_debit':
+      return 'Request charge';
+    case 'buyer_correction':
+      return 'Charge correction';
+    case 'buyer_reversal':
+      return 'Charge reversal';
+    case 'payment_credit':
+      return 'Card top-up';
+    case 'payment_reversal':
+      return 'Payment reversal';
+    default:
+      return entry.effect_type || 'Ledger entry';
+  }
+}
+
+export function formatProviderUsageWarning(account: ConnectedAccount): string {
+  switch (account.providerUsageWarning) {
+    case 'provider_usage_snapshot_missing':
+      return 'Awaiting provider usage snapshot';
+    case 'provider_usage_snapshot_soft_stale':
+      return 'Provider usage snapshot is aging';
+    case 'provider_usage_snapshot_hard_stale':
+      return 'Provider usage snapshot is stale';
+    case 'contribution_cap_exhausted_5h':
+      return '5h reserve floor is exhausted';
+    case 'contribution_cap_exhausted_7d':
+      return '7d reserve floor is exhausted';
+    case 'usage_exhausted_5h':
+      return 'Provider 5h window is exhausted';
+    case 'usage_exhausted_7d':
+      return 'Provider 7d window is exhausted';
+    default:
+      return '--';
+  }
+}
+
+export function summarizeRouteDecision(row: RequestHistoryRow): string {
+  const reason = row.route_decision && typeof row.route_decision.reason === 'string'
+    ? row.route_decision.reason
+    : null;
+  if (reason) return reason.replaceAll('_', ' ');
+  return formatRoutingMode(row.admission_routing_mode);
+}
+
+export function formatWithdrawalDestination(withdrawal: Withdrawal): string {
+  const destination = withdrawal.destination;
+  if (!destination || typeof destination !== 'object') return '--';
+  const rail = typeof destination.rail === 'string' ? destination.rail : null;
+  const address = typeof destination.address === 'string' ? destination.address : null;
+  return [rail, address].filter(Boolean).join(' · ') || '--';
+}
+
+export function formatAccountHealth(account: ConnectedAccount): string {
+  const pieces = [
+    account.expandedStatus,
+    account.providerUsageWarning ? formatProviderUsageWarning(account) : null
+  ].filter((value): value is string => Boolean(value) && value !== '--');
+  return pieces.join(' · ') || '--';
+}

--- a/ui/src/lib/pilot/server.ts
+++ b/ui/src/lib/pilot/server.ts
@@ -1,0 +1,359 @@
+import 'server-only';
+
+import { headers } from 'next/headers';
+import type {
+  AdminPilotAccountView,
+  ConnectedAccount,
+  EarningsHistoryEntry,
+  EarningsSummary,
+  PilotDashboardData,
+  PilotIdentityDiscoveryEntry,
+  PilotSession,
+  RequestHistoryRow,
+  WalletLedgerEntry,
+  WalletSnapshot,
+  Withdrawal,
+} from './types';
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+type ApiConfig = {
+  baseUrl: string;
+  timeoutMs: number;
+};
+
+type AdminApiConfig = ApiConfig & {
+  apiKey: string;
+};
+
+export class PilotServerError extends Error {
+  readonly status: number;
+  readonly details: unknown;
+
+  constructor(status: number, message: string, details?: unknown) {
+    super(message);
+    this.name = 'PilotServerError';
+    this.status = status;
+    this.details = details ?? null;
+  }
+}
+
+function readBaseApiConfig(): ApiConfig {
+  const baseUrl = process.env.INNIES_API_BASE_URL?.trim()
+    || process.env.INNIES_BASE_URL?.trim();
+  const timeoutMs = Number(process.env.INNIES_API_TIMEOUT_MS ?? DEFAULT_TIMEOUT_MS);
+
+  if (!baseUrl) {
+    throw new PilotServerError(503, 'Missing INNIES_API_BASE_URL or INNIES_BASE_URL');
+  }
+
+  return {
+    baseUrl: baseUrl.replace(/\/+$/, ''),
+    timeoutMs: Number.isFinite(timeoutMs) && timeoutMs > 0 ? Math.floor(timeoutMs) : DEFAULT_TIMEOUT_MS
+  };
+}
+
+function readAdminApiConfig(): AdminApiConfig {
+  const base = readBaseApiConfig();
+  const apiKey = process.env.INNIES_ADMIN_API_KEY?.trim();
+  if (!apiKey) {
+    throw new PilotServerError(503, 'Missing INNIES_ADMIN_API_KEY');
+  }
+  return {
+    ...base,
+    apiKey
+  };
+}
+
+function parseJsonBody(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function readErrorMessage(body: unknown, fallback: string): string {
+  if (body && typeof body === 'object') {
+    const record = body as Record<string, unknown>;
+    if (typeof record.message === 'string' && record.message.trim().length > 0) {
+      return record.message;
+    }
+    if (typeof record.code === 'string' && record.code.trim().length > 0) {
+      return record.code;
+    }
+  }
+  return fallback;
+}
+
+export async function readCurrentCookieHeader(): Promise<string | null> {
+  const headerStore = await headers();
+  return headerStore.get('cookie');
+}
+
+async function fetchJson<T>(input: {
+  config: ApiConfig;
+  path: string;
+  query?: Record<string, string | undefined>;
+  headers?: Record<string, string>;
+  method?: string;
+  body?: unknown;
+}): Promise<T> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), input.config.timeoutMs);
+  const url = new URL(input.path, `${input.config.baseUrl}/`);
+
+  for (const [key, value] of Object.entries(input.query ?? {})) {
+    if (value) url.searchParams.set(key, value);
+  }
+
+  try {
+    const response = await fetch(url, {
+      method: input.method ?? 'GET',
+      headers: {
+        accept: 'application/json',
+        ...(input.body === undefined ? {} : { 'content-type': 'application/json' }),
+        ...(input.headers ?? {})
+      },
+      body: input.body === undefined ? undefined : JSON.stringify(input.body),
+      cache: 'no-store',
+      signal: controller.signal
+    });
+    const text = await response.text();
+    const body = text.length > 0 ? parseJsonBody(text) : null;
+
+    if (!response.ok) {
+      throw new PilotServerError(
+        response.status,
+        readErrorMessage(body, `Innies request failed (${response.status})`),
+        body
+      );
+    }
+
+    return body as T;
+  } catch (error) {
+    if (error instanceof PilotServerError) throw error;
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new PilotServerError(504, `Timed out fetching ${input.path}`);
+    }
+    throw new PilotServerError(502, error instanceof Error ? error.message : `Failed to fetch ${input.path}`);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function fetchPilotJson<T>(input: {
+  path: string;
+  cookieHeader?: string | null;
+  sessionToken?: string | null;
+  method?: string;
+  body?: unknown;
+  query?: Record<string, string | undefined>;
+}): Promise<T> {
+  const config = readBaseApiConfig();
+  const cookieHeader = input.cookieHeader ?? await readCurrentCookieHeader();
+  return fetchJson<T>({
+    config,
+    path: input.path,
+    method: input.method,
+    body: input.body,
+    query: input.query,
+    headers: {
+      ...(cookieHeader ? { cookie: cookieHeader } : {}),
+      ...(input.sessionToken ? { authorization: `Bearer ${input.sessionToken}` } : {})
+    }
+  });
+}
+
+export async function fetchAdminJson<T>(input: {
+  path: string;
+  query?: Record<string, string | undefined>;
+  method?: string;
+  body?: unknown;
+}): Promise<T> {
+  const config = readAdminApiConfig();
+  return fetchJson<T>({
+    config,
+    path: input.path,
+    query: input.query,
+    method: input.method,
+    body: input.body,
+    headers: {
+      'x-api-key': config.apiKey
+    }
+  });
+}
+
+export function buildPilotAuthStartUrl(returnTo = '/pilot'): string {
+  const config = readBaseApiConfig();
+  const url = new URL('/v1/pilot/auth/github/start', `${config.baseUrl}/`);
+  url.searchParams.set('returnTo', returnTo);
+  return url.toString();
+}
+
+export async function getPilotSession(cookieHeader?: string | null): Promise<PilotSession | null> {
+  try {
+    const response = await fetchPilotJson<{ ok: true; session: PilotSession }>({
+      path: '/v1/pilot/session',
+      cookieHeader
+    });
+    return response.session;
+  } catch (error) {
+    if (error instanceof PilotServerError && error.status === 401) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+export async function getPilotConnectedAccounts(cookieHeader?: string | null): Promise<ConnectedAccount[]> {
+  const response = await fetchPilotJson<{ ok: true; accounts: ConnectedAccount[] }>({
+    path: '/v1/pilot/connected-accounts',
+    cookieHeader
+  });
+  return response.accounts;
+}
+
+export async function createAdminPilotSession(identity: PilotIdentityDiscoveryEntry): Promise<string> {
+  const response = await fetchAdminJson<{ ok: true; sessionToken: string }>({
+    path: '/v1/admin/pilot/session',
+    method: 'POST',
+    body: {
+      mode: 'impersonation',
+      targetUserId: identity.targetUserId,
+      targetOrgId: identity.targetOrgId,
+      targetOrgSlug: identity.targetOrgSlug ?? undefined,
+      targetOrgName: identity.targetOrgName ?? undefined,
+      githubLogin: identity.githubLogin ?? undefined,
+      userEmail: identity.userEmail
+    }
+  });
+  return response.sessionToken;
+}
+
+export async function listAdminPilotIdentities(): Promise<PilotIdentityDiscoveryEntry[]> {
+  const response = await fetchAdminJson<{ ok: true; identities: PilotIdentityDiscoveryEntry[] }>({
+    path: '/v1/admin/pilot/identities'
+  });
+  return response.identities;
+}
+
+export async function getPilotDashboardData(cookieHeader?: string | null): Promise<PilotDashboardData | null> {
+  const session = await getPilotSession(cookieHeader);
+  if (!session) return null;
+
+  const [wallet, walletLedger, accounts, earningsSummary, earningsHistory, withdrawals, requests] = await Promise.all([
+    fetchPilotJson<{ ok: true; wallet: WalletSnapshot }>({
+      path: '/v1/pilot/wallet',
+      cookieHeader
+    }).then((response) => response.wallet),
+    fetchPilotJson<{ ok: true; ledger: WalletLedgerEntry[] }>({
+      path: '/v1/pilot/wallet/ledger',
+      cookieHeader,
+      query: { limit: '50' }
+    }).then((response) => response.ledger),
+    getPilotConnectedAccounts(cookieHeader),
+    fetchPilotJson<{ ok: true; summary: EarningsSummary }>({
+      path: '/v1/pilot/earnings/summary',
+      cookieHeader
+    }).then((response) => response.summary),
+    fetchPilotJson<{ ok: true; entries: EarningsHistoryEntry[] }>({
+      path: '/v1/pilot/earnings/history',
+      cookieHeader
+    }).then((response) => response.entries),
+    fetchPilotJson<{ ok: true; withdrawals: Withdrawal[] }>({
+      path: '/v1/pilot/withdrawals',
+      cookieHeader
+    }).then((response) => response.withdrawals),
+    fetchPilotJson<{ requests: RequestHistoryRow[] }>({
+      path: '/v1/pilot/requests',
+      cookieHeader,
+      query: {
+        limit: '50'
+      }
+    }).then((response) => response.requests)
+  ]);
+
+  return {
+    session,
+    wallet,
+    walletLedger,
+    requests,
+    accounts,
+    earningsSummary,
+    earningsHistory,
+    withdrawals
+  };
+}
+
+export async function getAdminPilotAccountView(input: {
+  orgId: string;
+  explainRequestId?: string | null;
+}): Promise<AdminPilotAccountView | null> {
+  const identities = await listAdminPilotIdentities();
+  const identity = identities.find((entry) => entry.targetOrgId === input.orgId) ?? null;
+  if (!identity) return null;
+
+  const sessionToken = await createAdminPilotSession(identity);
+
+  const [wallet, walletLedger, requests, accounts, earningsSummary, earningsHistory, withdrawals, requestExplanation] = await Promise.all([
+    fetchAdminJson<{ ok: true; wallet: WalletSnapshot }>({
+      path: `/v1/admin/wallets/${identity.targetOrgId}`
+    }).then((response) => response.wallet),
+    fetchAdminJson<{ ok: true; ledger: WalletLedgerEntry[] }>({
+      path: `/v1/admin/wallets/${identity.targetOrgId}/ledger`,
+      query: { limit: '50' }
+    }).then((response) => response.ledger),
+    fetchAdminJson<{ requests: RequestHistoryRow[] }>({
+      path: '/v1/admin/requests',
+      query: {
+        consumerOrgId: identity.targetOrgId,
+        historyScope: 'post_cutover',
+        limit: '50'
+      }
+    }).then((response) => response.requests),
+    fetchAdminJson<{ ok: true; accounts: ConnectedAccount[] }>({
+      path: '/v1/admin/pilot/connected-accounts',
+      query: { ownerOrgId: identity.targetOrgId }
+    }).then((response) => response.accounts),
+    fetchPilotJson<{ ok: true; summary: EarningsSummary }>({
+      path: '/v1/pilot/earnings/summary',
+      sessionToken
+    }).then((response) => response.summary).catch((error) => {
+      if (error instanceof PilotServerError && (error.status === 401 || error.status === 403 || error.status === 404)) {
+        return null;
+      }
+      throw error;
+    }),
+    fetchPilotJson<{ ok: true; entries: EarningsHistoryEntry[] }>({
+      path: '/v1/pilot/earnings/history',
+      sessionToken
+    }).then((response) => response.entries).catch((error) => {
+      if (error instanceof PilotServerError && (error.status === 401 || error.status === 403 || error.status === 404)) {
+        return [];
+      }
+      throw error;
+    }),
+    fetchAdminJson<{ withdrawals: Withdrawal[] }>({
+      path: '/v1/admin/pilot/withdrawals',
+      query: { ownerOrgId: identity.targetOrgId }
+    }).then((response) => response.withdrawals),
+    input.explainRequestId
+      ? fetchAdminJson<{ ok: true; request: RequestHistoryRow }>({
+        path: `/v1/admin/requests/${input.explainRequestId}/explanation`
+      }).then((response) => response.request)
+      : Promise.resolve(null)
+  ]);
+
+  return {
+    identity,
+    wallet,
+    walletLedger,
+    requests,
+    requestExplanation,
+    accounts,
+    earningsSummary,
+    earningsHistory,
+    withdrawals
+  };
+}

--- a/ui/src/lib/pilot/types.ts
+++ b/ui/src/lib/pilot/types.ts
@@ -1,0 +1,165 @@
+export type PilotSession = {
+  sessionKind: 'darryn_self' | 'admin_self' | 'admin_impersonation';
+  actorUserId: string | null;
+  actorApiKeyId: string | null;
+  actorOrgId: string | null;
+  effectiveOrgId: string;
+  effectiveOrgSlug: string | null;
+  effectiveOrgName: string | null;
+  githubLogin: string | null;
+  userEmail: string | null;
+  impersonatedUserId: string | null;
+  issuedAt?: string;
+  expiresAt?: string;
+};
+
+export type WalletSnapshot = {
+  walletId: string;
+  ownerOrgId: string;
+  balanceMinor: number;
+  currency: string;
+};
+
+export type WalletLedgerEntry = {
+  id: string;
+  wallet_id?: string;
+  entry_type?: string | null;
+  effect_type: string;
+  amount_minor: number;
+  currency?: string | null;
+  reason?: string | null;
+  metadata?: Record<string, unknown> | null;
+  created_at?: string | null;
+};
+
+export type ConnectedAccount = {
+  credentialId: string;
+  orgId: string;
+  provider: string;
+  debugLabel: string | null;
+  status: string;
+  rawStatus: string;
+  expandedStatus: string;
+  statusSource: string | null;
+  exclusionReason: string | null;
+  authDiagnosis: string | null;
+  accessTokenExpiresAt: string | null;
+  refreshTokenState: 'missing' | 'present' | null;
+  expiresAt: string;
+  rateLimitedUntil: string | null;
+  nextProbeAt: string | null;
+  fiveHourReservePercent: number;
+  sevenDayReservePercent: number;
+  providerUsageRefreshSupported: boolean;
+  providerUsageSource: string | null;
+  providerUsageFetchedAt: string | null;
+  providerUsageState: 'unsupported' | 'missing' | 'fresh' | 'soft_stale' | 'hard_stale';
+  providerUsageWarning: string | null;
+  fiveHourUtilizationRatio: number | null;
+  fiveHourResetsAt: string | null;
+  fiveHourContributionCapExhausted: boolean | null;
+  fiveHourUsageExhausted: boolean | null;
+  sevenDayUtilizationRatio: number | null;
+  sevenDayResetsAt: string | null;
+  sevenDayContributionCapExhausted: boolean | null;
+  sevenDayUsageExhausted: boolean | null;
+};
+
+export type RequestHistoryRow = {
+  request_id: string;
+  attempt_no: number;
+  session_id: string | null;
+  admission_org_id: string;
+  admission_cutover_id: string | null;
+  admission_routing_mode: string;
+  consumer_org_id: string;
+  buyer_key_id: string | null;
+  serving_org_id: string;
+  provider_account_id: string | null;
+  token_credential_id: string | null;
+  capacity_owner_user_id: string | null;
+  provider: string;
+  model: string;
+  rate_card_version_id: string;
+  input_tokens: number;
+  output_tokens: number;
+  usage_units: number;
+  buyer_debit_minor: number;
+  contributor_earnings_minor: number;
+  currency: string;
+  metadata: Record<string, unknown> | null;
+  created_at: string;
+  prompt_preview: string | null;
+  response_preview: string | null;
+  route_decision: Record<string, unknown> | null;
+  projector_states: Array<{
+    projector: string;
+    state: string;
+    retryCount: number;
+    lastErrorCode: string | null;
+    lastErrorMessage: string | null;
+  }> | null;
+};
+
+export type EarningsSummary = {
+  pendingMinor: number;
+  withdrawableMinor: number;
+  reservedForPayoutMinor: number;
+  settledMinor: number;
+  adjustedMinor: number;
+};
+
+export type EarningsHistoryEntry = {
+  id?: string;
+  earnings_ledger_entry_id?: string;
+  effect_type?: string | null;
+  bucket?: string | null;
+  amount_minor?: number | null;
+  created_at?: string | null;
+  metadata?: Record<string, unknown> | null;
+};
+
+export type Withdrawal = {
+  id: string;
+  status: string;
+  amount_minor: number;
+  destination?: Record<string, unknown> | null;
+  note?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+  settlement_reference?: string | null;
+  settlement_failure_reason?: string | null;
+};
+
+export type PilotIdentityDiscoveryEntry = {
+  targetUserId: string;
+  targetOrgId: string;
+  targetOrgSlug: string | null;
+  targetOrgName: string | null;
+  githubLogin: string | null;
+  userEmail: string;
+  displayName: string | null;
+};
+
+export type PilotDashboardData = {
+  session: PilotSession;
+  wallet: WalletSnapshot;
+  walletLedger: WalletLedgerEntry[];
+  requests: RequestHistoryRow[];
+  accounts: ConnectedAccount[];
+  earningsSummary: EarningsSummary;
+  earningsHistory: EarningsHistoryEntry[];
+  withdrawals: Withdrawal[];
+};
+
+export type AdminPilotAccountView = {
+  identity: PilotIdentityDiscoveryEntry;
+  wallet: WalletSnapshot;
+  walletLedger: WalletLedgerEntry[];
+  requests: RequestHistoryRow[];
+  requestExplanation: RequestHistoryRow | null;
+  accounts: ConnectedAccount[];
+  earningsSummary: EarningsSummary | null;
+  earningsHistory: EarningsHistoryEntry[];
+  withdrawals: Withdrawal[];
+};

--- a/ui/tests/pilotDashboard.test.mjs
+++ b/ui/tests/pilotDashboard.test.mjs
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const uiRoot = join(__dirname, '..');
+
+function readSource(relativePath) {
+  return readFileSync(join(uiRoot, relativePath), 'utf8');
+}
+
+function readFunctionBlock(source, startMarker, endMarker) {
+  const start = source.indexOf(startMarker);
+  const end = source.indexOf(endMarker, start);
+  return source.slice(start, end === -1 ? source.length : end);
+}
+
+test('pilot dashboard server fetchers use pilot/admin dashboard contracts instead of global token analytics', () => {
+  const source = readSource('src/lib/pilot/server.ts');
+  const pilotDashboardSource = readFunctionBlock(
+    source,
+    'export async function getPilotDashboardData',
+    'export async function getAdminPilotAccountView'
+  );
+
+  assert.ok(source.includes('/v1/pilot/session'));
+  assert.ok(source.includes('/v1/pilot/wallet'));
+  assert.ok(source.includes('/v1/pilot/wallet/ledger'));
+  assert.ok(source.includes('/v1/pilot/connected-accounts'));
+  assert.ok(pilotDashboardSource.includes('/v1/pilot/requests'));
+  assert.ok(source.includes('/v1/pilot/earnings/summary'));
+  assert.ok(source.includes('/v1/pilot/earnings/history'));
+  assert.ok(source.includes('/v1/pilot/withdrawals'));
+  assert.ok(!pilotDashboardSource.includes('/v1/admin/requests'));
+  assert.ok(source.includes('/v1/admin/pilot/connected-accounts'));
+  assert.ok(source.includes('/v1/admin/pilot/identities'));
+  assert.ok(source.includes('/v1/admin/requests'));
+  assert.ok(source.includes('/v1/admin/requests/:requestId/explanation'.replace(':requestId', '${requestId}')) === false);
+  assert.ok(!source.includes('/v1/admin/analytics/tokens'));
+  assert.ok(!source.includes('/v1/admin/analytics/dashboard'));
+});
+
+test('pilot page includes the required Darryn dashboard sections', () => {
+  const pageSource = readSource('src/app/pilot/page.tsx');
+  const sharedSource = readSource('src/components/pilot/DashboardSections.tsx');
+
+  assert.ok(pageSource.includes('ConnectedAccountsSection'));
+  assert.ok(pageSource.includes('RequestHistorySection'));
+  assert.ok(pageSource.includes('PilotWithdrawalsSection'));
+  assert.ok(sharedSource.includes('Wallet'));
+  assert.ok(sharedSource.includes('Request History'));
+  assert.ok(sharedSource.includes('Connected Accounts'));
+  assert.ok(sharedSource.includes('Reserve Floors'));
+  assert.ok(sharedSource.includes('Earnings'));
+  assert.ok(sharedSource.includes('Withdrawals'));
+});
+
+test('admin pilot entry page includes identity discovery and impersonation entry UI', () => {
+  const pageSource = readSource('src/app/admin/pilot/page.tsx');
+  const sharedSource = readSource('src/components/pilot/DashboardSections.tsx');
+
+  assert.ok(pageSource.includes('PilotIdentityListSection'));
+  assert.ok(sharedSource.includes('Impersonate'));
+  assert.ok(sharedSource.includes('/api/admin/pilot/impersonate'));
+  assert.ok(sharedSource.includes('Pilot Identities'));
+});
+
+test('admin pilot account page includes request explanation and withdrawal review surfaces', () => {
+  const pageSource = readSource('src/app/admin/pilot/accounts/[orgId]/page.tsx');
+  const sharedSource = readSource('src/components/pilot/DashboardSections.tsx');
+
+  assert.ok(pageSource.includes('RequestExplanationSection'));
+  assert.ok(pageSource.includes('AdminWithdrawalReviewSection'));
+  assert.ok(sharedSource.includes('Request Explanation'));
+  assert.ok(sharedSource.includes('Withdrawal Review'));
+  assert.ok(sharedSource.includes('Connected Accounts'));
+});


### PR DESCRIPTION
## Summary
- add the Darryn pilot dashboard and admin pilot account surfaces for wallet, request history, connected accounts, reserve floors, earnings, and withdrawals
- add thin backend discovery routes for pilot/admin connected-account inventory and admin pilot identity lookup
- add a pilot-session-scoped `/v1/pilot/requests` route and switch the Darryn-facing dashboard to it instead of the admin request route

## Test Plan
- cd api && npm test -- pilot.route.test.ts usage.route.test.ts admin.pilot.route.test.ts tokenCredentialRepository.test.ts pilotIdentityRepository.test.ts
- cd api && npm run build
- node --test ui/tests/pilotDashboard.test.mjs
- cd ui && npm run build