### PR TITLE
Add Darryn Phase 2 payments and auto-recharge

### DIFF
--- a/api/src/repos/autoRechargeSettingsRepository.ts
+++ b/api/src/repos/autoRechargeSettingsRepository.ts
@@ -1,0 +1,77 @@
+import type { SqlClient, SqlValue } from './sqlClient.js';
+import { TABLES } from './tableNames.js';
+
+export type AutoRechargeSettingsRow = {
+  wallet_id: string;
+  owner_org_id: string;
+  enabled: boolean;
+  amount_minor: number;
+  currency: string;
+  payment_method_id: string | null;
+  updated_by_user_id: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export class AutoRechargeSettingsRepository {
+  constructor(private readonly db: SqlClient) {}
+
+  async findByWalletId(walletId: string): Promise<AutoRechargeSettingsRow | null> {
+    const sql = `
+      select *
+      from ${TABLES.autoRechargeSettings}
+      where wallet_id = $1
+      limit 1
+    `;
+    const result = await this.db.query<AutoRechargeSettingsRow>(sql, [walletId]);
+    return result.rowCount === 1 ? result.rows[0] : null;
+  }
+
+  async upsertSettings(input: {
+    walletId: string;
+    ownerOrgId: string;
+    enabled: boolean;
+    amountMinor: number;
+    currency?: string;
+    paymentMethodId?: string | null;
+    updatedByUserId?: string | null;
+  }): Promise<AutoRechargeSettingsRow> {
+    const sql = `
+      insert into ${TABLES.autoRechargeSettings} (
+        wallet_id,
+        owner_org_id,
+        enabled,
+        amount_minor,
+        currency,
+        payment_method_id,
+        updated_by_user_id
+      ) values (
+        $1,$2,$3,$4,$5,$6,$7
+      )
+      on conflict (wallet_id)
+      do update set
+        owner_org_id = excluded.owner_org_id,
+        enabled = excluded.enabled,
+        amount_minor = excluded.amount_minor,
+        currency = excluded.currency,
+        payment_method_id = excluded.payment_method_id,
+        updated_by_user_id = excluded.updated_by_user_id,
+        updated_at = now()
+      returning *
+    `;
+    const params: SqlValue[] = [
+      input.walletId,
+      input.ownerOrgId,
+      input.enabled,
+      input.amountMinor,
+      input.currency ?? 'USD',
+      input.paymentMethodId ?? null,
+      input.updatedByUserId ?? null
+    ];
+    const result = await this.db.query<AutoRechargeSettingsRow>(sql, params);
+    if (result.rowCount !== 1) {
+      throw new Error('expected one auto recharge settings row');
+    }
+    return result.rows[0];
+  }
+}

--- a/api/src/repos/paymentAttemptRepository.ts
+++ b/api/src/repos/paymentAttemptRepository.ts
@@ -1,0 +1,194 @@
+import type { SqlClient, SqlValue } from './sqlClient.js';
+import { type IdFactory, uuidV4 } from './idFactory.js';
+import { TABLES } from './tableNames.js';
+import type { AutoRechargeTrigger, PaymentAttemptKind, PaymentAttemptStatus } from '../services/payments/paymentTypes.js';
+
+export type PaymentAttemptRow = {
+  id: string;
+  wallet_id: string;
+  owner_org_id: string;
+  payment_method_id: string | null;
+  processor: string;
+  kind: PaymentAttemptKind;
+  trigger: AutoRechargeTrigger | null;
+  status: PaymentAttemptStatus;
+  amount_minor: number;
+  currency: string;
+  processor_checkout_session_id: string | null;
+  processor_payment_intent_id: string | null;
+  processor_effect_id: string | null;
+  idempotency_key: string | null;
+  initiated_by_user_id: string | null;
+  last_error_code: string | null;
+  last_error_message: string | null;
+  metadata: Record<string, unknown> | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export class PaymentAttemptRepository {
+  constructor(
+    private readonly db: SqlClient,
+    private readonly createId: IdFactory = uuidV4
+  ) {}
+
+  async createAttempt(input: {
+    walletId: string;
+    ownerOrgId: string;
+    paymentMethodId?: string | null;
+    kind: PaymentAttemptKind;
+    trigger?: AutoRechargeTrigger | null;
+    status?: PaymentAttemptStatus;
+    amountMinor: number;
+    currency?: string;
+    idempotencyKey?: string | null;
+    initiatedByUserId?: string | null;
+    metadata?: Record<string, unknown>;
+  }): Promise<PaymentAttemptRow> {
+    const sql = `
+      insert into ${TABLES.paymentAttempts} (
+        id,
+        wallet_id,
+        owner_org_id,
+        payment_method_id,
+        kind,
+        trigger,
+        status,
+        amount_minor,
+        currency,
+        idempotency_key,
+        initiated_by_user_id,
+        metadata
+      ) values (
+        $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12
+      )
+      returning *
+    `;
+    const params: SqlValue[] = [
+      this.createId(),
+      input.walletId,
+      input.ownerOrgId,
+      input.paymentMethodId ?? null,
+      input.kind,
+      input.trigger ?? null,
+      input.status ?? 'pending',
+      input.amountMinor,
+      input.currency ?? 'USD',
+      input.idempotencyKey ?? null,
+      input.initiatedByUserId ?? null,
+      input.metadata ? JSON.stringify(input.metadata) : null
+    ];
+    const result = await this.db.query<PaymentAttemptRow>(sql, params);
+    if (result.rowCount !== 1) {
+      throw new Error('expected one payment attempt row');
+    }
+    return result.rows[0];
+  }
+
+  async findPendingAutoRechargeByWalletId(walletId: string): Promise<PaymentAttemptRow | null> {
+    const sql = `
+      select *
+      from ${TABLES.paymentAttempts}
+      where wallet_id = $1
+        and kind = 'auto_recharge'
+        and status in ('pending', 'processing')
+      order by created_at desc
+      limit 1
+    `;
+    const result = await this.db.query<PaymentAttemptRow>(sql, [walletId]);
+    return result.rowCount === 1 ? result.rows[0] : null;
+  }
+
+  async findManualTopUpByIdempotencyKey(input: {
+    walletId: string;
+    idempotencyKey: string;
+  }): Promise<PaymentAttemptRow | null> {
+    const sql = `
+      select *
+      from ${TABLES.paymentAttempts}
+      where wallet_id = $1
+        and kind = 'manual_topup'
+        and idempotency_key = $2
+      limit 1
+    `;
+    const result = await this.db.query<PaymentAttemptRow>(sql, [input.walletId, input.idempotencyKey]);
+    return result.rowCount === 1 ? result.rows[0] : null;
+  }
+
+  async markProcessing(input: {
+    attemptId: string;
+    processorCheckoutSessionId?: string | null;
+    processorPaymentIntentId?: string | null;
+  }): Promise<void> {
+    const sql = `
+      update ${TABLES.paymentAttempts}
+      set status = 'processing',
+          processor_checkout_session_id = coalesce($2, processor_checkout_session_id),
+          processor_payment_intent_id = coalesce($3, processor_payment_intent_id),
+          updated_at = now()
+      where id = $1
+    `;
+    await this.db.query(sql, [
+      input.attemptId,
+      input.processorCheckoutSessionId ?? null,
+      input.processorPaymentIntentId ?? null
+    ]);
+  }
+
+  async markSucceeded(input: {
+    attemptId: string;
+    processorEffectId: string;
+    processorPaymentIntentId?: string | null;
+  }): Promise<void> {
+    const sql = `
+      update ${TABLES.paymentAttempts}
+      set status = 'succeeded',
+          processor_effect_id = $2,
+          processor_payment_intent_id = coalesce($3, processor_payment_intent_id),
+          updated_at = now()
+      where id = $1
+    `;
+    await this.db.query(sql, [input.attemptId, input.processorEffectId, input.processorPaymentIntentId ?? null]);
+  }
+
+  async markFailed(input: {
+    attemptId: string;
+    processorEffectId?: string | null;
+    processorPaymentIntentId?: string | null;
+    lastErrorCode?: string | null;
+    lastErrorMessage?: string | null;
+  }): Promise<void> {
+    const sql = `
+      update ${TABLES.paymentAttempts}
+      set status = 'failed',
+          processor_effect_id = coalesce($2, processor_effect_id),
+          processor_payment_intent_id = coalesce($3, processor_payment_intent_id),
+          last_error_code = $4,
+          last_error_message = $5,
+          updated_at = now()
+      where id = $1
+    `;
+    await this.db.query(sql, [
+      input.attemptId,
+      input.processorEffectId ?? null,
+      input.processorPaymentIntentId ?? null,
+      input.lastErrorCode ?? null,
+      input.lastErrorMessage ?? null
+    ]);
+  }
+
+  async listRecentByWalletId(input: {
+    walletId: string;
+    limit: number;
+  }): Promise<PaymentAttemptRow[]> {
+    const sql = `
+      select *
+      from ${TABLES.paymentAttempts}
+      where wallet_id = $1
+      order by created_at desc
+      limit $2
+    `;
+    const result = await this.db.query<PaymentAttemptRow>(sql, [input.walletId, input.limit]);
+    return result.rows;
+  }
+}

--- a/api/src/repos/paymentMethodRepository.ts
+++ b/api/src/repos/paymentMethodRepository.ts
@@ -1,0 +1,151 @@
+import type { SqlClient, SqlValue } from './sqlClient.js';
+import { type IdFactory, uuidV4 } from './idFactory.js';
+import { TABLES } from './tableNames.js';
+
+export type PaymentMethodRow = {
+  id: string;
+  wallet_id: string;
+  owner_org_id: string;
+  payment_profile_id: string;
+  processor: string;
+  processor_payment_method_id: string;
+  processor_customer_id: string;
+  brand: string;
+  last4: string;
+  exp_month: number;
+  exp_year: number;
+  funding: string | null;
+  status: string;
+  created_at: string;
+  updated_at: string;
+  detached_at: string | null;
+};
+
+export class PaymentMethodRepository {
+  constructor(
+    private readonly db: SqlClient,
+    private readonly createId: IdFactory = uuidV4
+  ) {}
+
+  async upsertMethod(input: {
+    walletId: string;
+    ownerOrgId: string;
+    paymentProfileId: string;
+    processor?: string;
+    processorPaymentMethodId: string;
+    processorCustomerId: string;
+    brand: string;
+    last4: string;
+    expMonth: number;
+    expYear: number;
+    funding?: string | null;
+    status?: string;
+  }): Promise<PaymentMethodRow> {
+    const sql = `
+      insert into ${TABLES.paymentMethods} (
+        id,
+        wallet_id,
+        owner_org_id,
+        payment_profile_id,
+        processor,
+        processor_payment_method_id,
+        processor_customer_id,
+        brand,
+        last4,
+        exp_month,
+        exp_year,
+        funding,
+        status
+      ) values (
+        $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13
+      )
+      on conflict (processor_payment_method_id)
+      do update set
+        wallet_id = excluded.wallet_id,
+        owner_org_id = excluded.owner_org_id,
+        payment_profile_id = excluded.payment_profile_id,
+        processor = excluded.processor,
+        processor_customer_id = excluded.processor_customer_id,
+        brand = excluded.brand,
+        last4 = excluded.last4,
+        exp_month = excluded.exp_month,
+        exp_year = excluded.exp_year,
+        funding = excluded.funding,
+        status = excluded.status,
+        detached_at = null,
+        updated_at = now()
+      returning *
+    `;
+    const params: SqlValue[] = [
+      this.createId(),
+      input.walletId,
+      input.ownerOrgId,
+      input.paymentProfileId,
+      input.processor ?? 'stripe',
+      input.processorPaymentMethodId,
+      input.processorCustomerId,
+      input.brand,
+      input.last4,
+      input.expMonth,
+      input.expYear,
+      input.funding ?? null,
+      input.status ?? 'active'
+    ];
+    const result = await this.db.query<PaymentMethodRow>(sql, params);
+    if (result.rowCount !== 1) {
+      throw new Error('expected one payment method row');
+    }
+    return result.rows[0];
+  }
+
+  async findDefaultByWalletId(walletId: string): Promise<PaymentMethodRow | null> {
+    const sql = `
+      select method.*
+      from ${TABLES.paymentProfiles} profile
+      join ${TABLES.paymentMethods} method
+        on method.id = profile.default_payment_method_id
+      where profile.wallet_id = $1
+        and method.status = 'active'
+      limit 1
+    `;
+    const result = await this.db.query<PaymentMethodRow>(sql, [walletId]);
+    return result.rowCount === 1 ? result.rows[0] : null;
+  }
+
+  async findById(paymentMethodId: string): Promise<PaymentMethodRow | null> {
+    const sql = `
+      select *
+      from ${TABLES.paymentMethods}
+      where id = $1
+      limit 1
+    `;
+    const result = await this.db.query<PaymentMethodRow>(sql, [paymentMethodId]);
+    return result.rowCount === 1 ? result.rows[0] : null;
+  }
+
+  async findByProcessorPaymentMethodId(processorPaymentMethodId: string): Promise<PaymentMethodRow | null> {
+    const sql = `
+      select *
+      from ${TABLES.paymentMethods}
+      where processor_payment_method_id = $1
+      limit 1
+    `;
+    const result = await this.db.query<PaymentMethodRow>(sql, [processorPaymentMethodId]);
+    return result.rowCount === 1 ? result.rows[0] : null;
+  }
+
+  async markDetached(input: {
+    walletId: string;
+    paymentMethodId: string;
+  }): Promise<void> {
+    const sql = `
+      update ${TABLES.paymentMethods}
+      set status = 'detached',
+          detached_at = now(),
+          updated_at = now()
+      where wallet_id = $1
+        and id = $2
+    `;
+    await this.db.query(sql, [input.walletId, input.paymentMethodId]);
+  }
+}

--- a/api/src/repos/paymentOutcomeRepository.ts
+++ b/api/src/repos/paymentOutcomeRepository.ts
@@ -1,0 +1,141 @@
+import type { SqlClient, SqlValue, TransactionContext } from './sqlClient.js';
+import { type IdFactory, uuidV4 } from './idFactory.js';
+import { TABLES } from './tableNames.js';
+import { assertIdempotentReplayMatches } from './idempotentReplay.js';
+import type { PaymentWalletEffectType } from '../services/payments/paymentTypes.js';
+
+export type PaymentOutcomeRow = {
+  id: string;
+  wallet_id: string;
+  owner_org_id: string;
+  payment_attempt_id: string | null;
+  processor: string;
+  processor_event_id: string;
+  processor_effect_id: string;
+  effect_type: PaymentWalletEffectType;
+  amount_minor: number;
+  currency: string;
+  metadata: Record<string, unknown> | null;
+  wallet_recorded_at: string | null;
+  created_at: string;
+};
+
+export class PaymentOutcomeRepository {
+  constructor(
+    private readonly db: SqlClient,
+    private readonly createId: IdFactory = uuidV4
+  ) {}
+
+  async upsertOutcome(input: {
+    walletId: string;
+    ownerOrgId: string;
+    paymentAttemptId?: string | null;
+    processor?: string;
+    processorEventId: string;
+    processorEffectId: string;
+    effectType: PaymentWalletEffectType;
+    amountMinor: number;
+    currency?: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<PaymentOutcomeRow> {
+    const sql = `
+      insert into ${TABLES.paymentOutcomes} (
+        id,
+        wallet_id,
+        owner_org_id,
+        payment_attempt_id,
+        processor,
+        processor_event_id,
+        processor_effect_id,
+        effect_type,
+        amount_minor,
+        currency,
+        metadata
+      ) values (
+        $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11
+      )
+      on conflict (processor_effect_id) do nothing
+      returning *
+    `;
+    const params: SqlValue[] = [
+      this.createId(),
+      input.walletId,
+      input.ownerOrgId,
+      input.paymentAttemptId ?? null,
+      input.processor ?? 'stripe',
+      input.processorEventId,
+      input.processorEffectId,
+      input.effectType,
+      input.amountMinor,
+      input.currency ?? 'USD',
+      input.metadata ? JSON.stringify(input.metadata) : null
+    ];
+    const result = await this.db.query<PaymentOutcomeRow>(sql, params);
+    if (result.rowCount === 1) {
+      return result.rows[0];
+    }
+
+    const existing = await this.findByProcessorEffectId({
+      processorEffectId: input.processorEffectId,
+      effectType: input.effectType
+    });
+    if (!existing) {
+      throw new Error('expected one payment outcome row');
+    }
+
+    assertIdempotentReplayMatches('payment outcome', [
+      { field: 'walletId', expected: input.walletId, actual: existing.wallet_id },
+      { field: 'ownerOrgId', expected: input.ownerOrgId, actual: existing.owner_org_id },
+      { field: 'paymentAttemptId', expected: input.paymentAttemptId ?? null, actual: existing.payment_attempt_id },
+      { field: 'processorEffectId', expected: input.processorEffectId, actual: existing.processor_effect_id },
+      { field: 'effectType', expected: input.effectType, actual: existing.effect_type },
+      { field: 'amountMinor', expected: input.amountMinor, actual: existing.amount_minor },
+      { field: 'currency', expected: input.currency ?? 'USD', actual: existing.currency }
+    ]);
+    return existing;
+  }
+
+  async findByProcessorEffectId(input: {
+    processorEffectId: string;
+    effectType: PaymentWalletEffectType;
+  }): Promise<PaymentOutcomeRow | null> {
+    const sql = `
+      select *
+      from ${TABLES.paymentOutcomes}
+      where processor_effect_id = $1
+        and effect_type = $2
+      limit 1
+    `;
+    const result = await this.db.query<PaymentOutcomeRow>(sql, [input.processorEffectId, input.effectType]);
+    return result.rowCount === 1 ? result.rows[0] : null;
+  }
+
+  async findLatestUnrecordedAutoRechargeCreditByWalletId(walletId: string): Promise<PaymentOutcomeRow | null> {
+    const sql = `
+      select outcome.*
+      from ${TABLES.paymentOutcomes} outcome
+      join ${TABLES.paymentAttempts} attempt
+        on attempt.id = outcome.payment_attempt_id
+      where outcome.wallet_id = $1
+        and outcome.effect_type = 'payment_credit'
+        and outcome.wallet_recorded_at is null
+        and attempt.kind = 'auto_recharge'
+      order by outcome.created_at desc
+      limit 1
+    `;
+    const result = await this.db.query<PaymentOutcomeRow>(sql, [walletId]);
+    return result.rowCount === 1 ? result.rows[0] : null;
+  }
+
+  async markRecorded(
+    processorEffectId: string,
+    db: Pick<TransactionContext, 'query'> = this.db
+  ): Promise<void> {
+    const sql = `
+      update ${TABLES.paymentOutcomes}
+      set wallet_recorded_at = coalesce(wallet_recorded_at, now())
+      where processor_effect_id = $1
+    `;
+    await db.query(sql, [processorEffectId]);
+  }
+}

--- a/api/src/repos/paymentProfileRepository.ts
+++ b/api/src/repos/paymentProfileRepository.ts
@@ -1,0 +1,81 @@
+import type { SqlClient, SqlValue } from './sqlClient.js';
+import { type IdFactory, uuidV4 } from './idFactory.js';
+import { TABLES } from './tableNames.js';
+
+export type PaymentProfileRow = {
+  id: string;
+  wallet_id: string;
+  owner_org_id: string;
+  processor: string;
+  processor_customer_id: string;
+  default_payment_method_id: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export class PaymentProfileRepository {
+  constructor(
+    private readonly db: SqlClient,
+    private readonly createId: IdFactory = uuidV4
+  ) {}
+
+  async findByWalletId(walletId: string): Promise<PaymentProfileRow | null> {
+    const sql = `
+      select *
+      from ${TABLES.paymentProfiles}
+      where wallet_id = $1
+      limit 1
+    `;
+    const result = await this.db.query<PaymentProfileRow>(sql, [walletId]);
+    return result.rowCount === 1 ? result.rows[0] : null;
+  }
+
+  async ensureProfile(input: {
+    walletId: string;
+    ownerOrgId: string;
+    processorCustomerId: string;
+    processor?: string;
+  }): Promise<PaymentProfileRow> {
+    const sql = `
+      insert into ${TABLES.paymentProfiles} (
+        id,
+        wallet_id,
+        owner_org_id,
+        processor,
+        processor_customer_id
+      ) values (
+        $1,$2,$3,$4,$5
+      )
+      on conflict (wallet_id)
+      do update set
+        owner_org_id = excluded.owner_org_id,
+        updated_at = now()
+      returning *
+    `;
+    const params: SqlValue[] = [
+      this.createId(),
+      input.walletId,
+      input.ownerOrgId,
+      input.processor ?? 'stripe',
+      input.processorCustomerId
+    ];
+    const result = await this.db.query<PaymentProfileRow>(sql, params);
+    if (result.rowCount !== 1) {
+      throw new Error('expected one payment profile row');
+    }
+    return result.rows[0];
+  }
+
+  async setDefaultPaymentMethod(input: {
+    walletId: string;
+    paymentMethodId: string | null;
+  }): Promise<void> {
+    const sql = `
+      update ${TABLES.paymentProfiles}
+      set default_payment_method_id = $2,
+          updated_at = now()
+      where wallet_id = $1
+    `;
+    await this.db.query(sql, [input.walletId, input.paymentMethodId]);
+  }
+}

--- a/api/src/repos/paymentWebhookEventRepository.ts
+++ b/api/src/repos/paymentWebhookEventRepository.ts
@@ -1,0 +1,75 @@
+import type { SqlClient, SqlValue } from './sqlClient.js';
+import { type IdFactory, uuidV4 } from './idFactory.js';
+import { TABLES } from './tableNames.js';
+
+export type PaymentWebhookClaimResult = {
+  state: 'claimed' | 'pending_retry' | 'already_processed';
+  processorEventId: string;
+};
+
+type PaymentWebhookEventStateRow = {
+  processed_at: string | null;
+};
+
+export class PaymentWebhookEventRepository {
+  constructor(
+    private readonly db: SqlClient,
+    private readonly createId: IdFactory = uuidV4
+  ) {}
+
+  async claimEvent(input: {
+    processor?: string;
+    processorEventId: string;
+    eventType: string;
+    payload: Record<string, unknown>;
+  }): Promise<PaymentWebhookClaimResult> {
+    const sql = `
+      insert into ${TABLES.paymentWebhookEvents} (
+        id,
+        processor,
+        processor_event_id,
+        event_type,
+        payload
+      ) values (
+        $1,$2,$3,$4,$5
+      )
+      on conflict (processor_event_id) do nothing
+      returning id
+    `;
+    const params: SqlValue[] = [
+      this.createId(),
+      input.processor ?? 'stripe',
+      input.processorEventId,
+      input.eventType,
+      JSON.stringify(input.payload)
+    ];
+    const result = await this.db.query<{ id: string }>(sql, params);
+    if (result.rowCount === 1) {
+      return {
+        state: 'claimed',
+        processorEventId: input.processorEventId
+      };
+    }
+
+    const existing = await this.db.query<PaymentWebhookEventStateRow>(`
+      select processed_at
+      from ${TABLES.paymentWebhookEvents}
+      where processor_event_id = $1
+      limit 1
+    `, [input.processorEventId]);
+    const row = existing.rows[0];
+    return {
+      state: row?.processed_at ? 'already_processed' : 'pending_retry',
+      processorEventId: input.processorEventId
+    };
+  }
+
+  async markProcessed(processorEventId: string): Promise<void> {
+    const sql = `
+      update ${TABLES.paymentWebhookEvents}
+      set processed_at = now()
+      where processor_event_id = $1
+    `;
+    await this.db.query(sql, [processorEventId]);
+  }
+}

--- a/api/src/repos/tableNames.ts
+++ b/api/src/repos/tableNames.ts
@@ -1,5 +1,6 @@
 export const TABLES = {
   analyticsDashboardSnapshots: 'in_analytics_dashboard_snapshots',
+  autoRechargeSettings: 'in_auto_recharge_settings',
   auditLogEvents: 'in_audit_log_events',
   canonicalMeteringEvents: 'in_canonical_metering_events',
   cutoverRecords: 'in_cutover_records',
@@ -9,6 +10,11 @@ export const TABLES = {
   idempotencyKeys: 'in_idempotency_keys',
   meteringProjectorStates: 'in_metering_projector_states',
   orgs: 'in_orgs',
+  paymentAttempts: 'in_payment_attempts',
+  paymentMethods: 'in_payment_methods',
+  paymentOutcomes: 'in_payment_outcomes',
+  paymentProfiles: 'in_payment_profiles',
+  paymentWebhookEvents: 'in_payment_webhook_events',
   pilotAdmissionFreezes: 'in_pilot_admission_freezes',
   rateCardLineItems: 'in_rate_card_line_items',
   rateCardVersions: 'in_rate_card_versions',

--- a/api/src/repos/walletLedgerRepository.ts
+++ b/api/src/repos/walletLedgerRepository.ts
@@ -63,65 +63,25 @@ export class WalletLedgerRepository {
   ) {}
 
   async appendEntry(input: WalletLedgerEntryInput): Promise<WalletLedgerRow> {
-    if (MANUAL_WALLET_EFFECT_TYPES.has(input.effectType) && (!hasManualActorMetadata(input) || !input.reason)) {
-      throw new Error('manual wallet entries require actor metadata and reason');
-    }
+    const { sql, params } = buildWalletLedgerInsert(input, this.createId);
+    return this.appendEntryWithDb(input, this.db, sql, params);
+  }
 
-    if (PAYMENT_WALLET_EFFECT_TYPES.has(input.effectType) && !input.processorEffectId) {
-      throw new Error('payment wallet entries require processorEffectId');
-    }
-
-    if (
-      !MANUAL_WALLET_EFFECT_TYPES.has(input.effectType)
-      && !PAYMENT_WALLET_EFFECT_TYPES.has(input.effectType)
-      && !input.meteringEventId
-    ) {
-      throw new Error('metering-derived wallet entries require meteringEventId');
-    }
-
-    const metadata = manualWalletMetadata(input);
-    const sql = `
-      insert into ${TABLES.walletLedger} (
-        id,
-        wallet_id,
-        owner_org_id,
-        buyer_key_id,
-        metering_event_id,
-        effect_type,
-        amount_minor,
-        currency,
-        actor_user_id,
-        reason,
-        processor_effect_id,
-        metadata
-      ) values (
-        $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12
-      )
-      on conflict do nothing
-      returning *
-    `;
-
-    const params: SqlValue[] = [
-      input.entryId ?? this.createId(),
-      input.walletId,
-      input.ownerOrgId,
-      input.buyerKeyId ?? null,
-      input.meteringEventId ?? null,
-      input.effectType,
-      input.amountMinor,
-      input.currency ?? 'USD',
-      input.actorUserId ?? null,
-      input.reason ?? null,
-      input.processorEffectId ?? null,
-      metadata ? JSON.stringify(metadata) : null
-    ];
-
-    const result = await this.db.query<WalletLedgerRow>(sql, params);
+  async appendEntryWithDb(
+    input: WalletLedgerEntryInput,
+    db: Pick<TransactionContext, 'query'>,
+    sql?: string,
+    params?: SqlValue[]
+  ): Promise<WalletLedgerRow> {
+    const builtInsert = sql && params
+      ? { sql, params }
+      : buildWalletLedgerInsert(input, this.createId);
+    const result = await db.query<WalletLedgerRow>(builtInsert.sql, builtInsert.params);
     if (result.rowCount === 1) {
       return result.rows[0];
     }
 
-    const existing = await this.findExistingIdempotentEntry(input);
+    const existing = await this.findExistingIdempotentEntry(input, db);
     if (existing) {
       assertWalletLedgerReplayMatches(input, existing);
       return existing;
@@ -211,7 +171,10 @@ export class WalletLedgerRepository {
     return result.rows;
   }
 
-  private async findExistingIdempotentEntry(input: WalletLedgerEntryInput): Promise<WalletLedgerRow | null> {
+  private async findExistingIdempotentEntry(
+    input: WalletLedgerEntryInput,
+    db: Pick<TransactionContext, 'query'> = this.db
+  ): Promise<WalletLedgerRow | null> {
     if (input.entryId) {
       const sql = `
         select *
@@ -219,7 +182,7 @@ export class WalletLedgerRepository {
         where id = $1
         limit 1
       `;
-      const result = await this.db.query<WalletLedgerRow>(sql, [input.entryId]);
+      const result = await db.query<WalletLedgerRow>(sql, [input.entryId]);
       return result.rowCount === 1 ? result.rows[0] : null;
     }
 
@@ -231,7 +194,7 @@ export class WalletLedgerRepository {
           and effect_type = $2
         limit 1
       `;
-      const result = await this.db.query<WalletLedgerRow>(sql, [input.meteringEventId, input.effectType]);
+      const result = await db.query<WalletLedgerRow>(sql, [input.meteringEventId, input.effectType]);
       return result.rowCount === 1 ? result.rows[0] : null;
     }
 
@@ -243,7 +206,7 @@ export class WalletLedgerRepository {
           and effect_type = $2
         limit 1
       `;
-      const result = await this.db.query<WalletLedgerRow>(sql, [input.processorEffectId, input.effectType]);
+      const result = await db.query<WalletLedgerRow>(sql, [input.processorEffectId, input.effectType]);
       return result.rowCount === 1 ? result.rows[0] : null;
     }
 
@@ -280,5 +243,67 @@ function manualWalletMetadata(input: WalletLedgerEntryInput): Record<string, unk
   return {
     ...(input.metadata ?? {}),
     actorApiKeyId: input.actorApiKeyId
+  };
+}
+
+function buildWalletLedgerInsert(
+  input: WalletLedgerEntryInput,
+  createId: IdFactory
+): {
+  sql: string;
+  params: SqlValue[];
+} {
+  if (MANUAL_WALLET_EFFECT_TYPES.has(input.effectType) && (!hasManualActorMetadata(input) || !input.reason)) {
+    throw new Error('manual wallet entries require actor metadata and reason');
+  }
+
+  if (PAYMENT_WALLET_EFFECT_TYPES.has(input.effectType) && !input.processorEffectId) {
+    throw new Error('payment wallet entries require processorEffectId');
+  }
+
+  if (
+    !MANUAL_WALLET_EFFECT_TYPES.has(input.effectType)
+    && !PAYMENT_WALLET_EFFECT_TYPES.has(input.effectType)
+    && !input.meteringEventId
+  ) {
+    throw new Error('metering-derived wallet entries require meteringEventId');
+  }
+
+  const metadata = manualWalletMetadata(input);
+  return {
+    sql: `
+      insert into ${TABLES.walletLedger} (
+        id,
+        wallet_id,
+        owner_org_id,
+        buyer_key_id,
+        metering_event_id,
+        effect_type,
+        amount_minor,
+        currency,
+        actor_user_id,
+        reason,
+        processor_effect_id,
+        metadata
+      ) values (
+        $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12
+      )
+      on conflict do nothing
+      returning *
+    `,
+    params: [
+      input.entryId ?? createId(),
+      input.walletId,
+      input.ownerOrgId,
+      input.buyerKeyId ?? null,
+      input.meteringEventId ?? null,
+      input.effectType,
+      input.amountMinor,
+      input.currency ?? 'USD',
+      input.actorUserId ?? null,
+      input.reason ?? null,
+      input.processorEffectId ?? null,
+      metadata ? JSON.stringify(metadata) : null
+    ]
   };
 }

--- a/api/src/routes/payments.ts
+++ b/api/src/routes/payments.ts
@@ -1,0 +1,40 @@
+/// <reference path="../types/express.d.ts" />
+
+import { Router } from 'express';
+import { runtime } from '../services/runtime.js';
+import { AppError } from '../utils/errors.js';
+
+const router = Router();
+
+router.post('/v1/payments/webhooks/stripe', async (req, res, next) => {
+  try {
+    const rawBody = (req as typeof req & { inniesRawBodyText?: string }).inniesRawBodyText;
+    if (typeof rawBody !== 'string') {
+      throw new AppError('invalid_request', 400, 'Missing raw payment webhook body');
+    }
+
+    const result = await runtime.services.payments.processWebhook({
+      signatureHeader: req.header('stripe-signature'),
+      rawBody
+    });
+
+    for (const outcome of result.outcomes) {
+      await runtime.services.wallets.recordPaymentOutcome({
+        walletId: outcome.walletId,
+        processorEffectId: outcome.processorEffectId,
+        effectType: outcome.effectType
+      });
+    }
+    await runtime.services.payments.markWebhookProcessed(result.processorEventId);
+
+    res.status(200).json({
+      ok: true,
+      accepted: result.accepted,
+      recordedOutcomes: result.outcomes.length
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/api/src/routes/pilot.ts
+++ b/api/src/routes/pilot.ts
@@ -5,6 +5,8 @@ import { z } from 'zod';
 import { runtime } from '../services/runtime.js';
 import { buildConnectedAccountInventory } from '../services/pilot/pilotConnectedAccountInventory.js';
 import { AppError } from '../utils/errors.js';
+import { sha256Hex, stableJson } from '../utils/hash.js';
+import { readAndValidateIdempotencyKey } from '../utils/idempotencyKey.js';
 import {
   decodeRequestHistoryCursor,
   encodeRequestHistoryCursor,
@@ -38,11 +40,26 @@ const walletLedgerCursorSchema = z.object({
   id: z.string().uuid()
 });
 
+const paymentSetupSchema = z.object({
+  returnTo: z.string().min(1).optional()
+});
+
+const paymentTopUpSchema = z.object({
+  amountMinor: z.number().int().positive(),
+  returnTo: z.string().min(1).optional()
+});
+
+const autoRechargeSettingsSchema = z.object({
+  enabled: z.boolean(),
+  amountMinor: z.number().int().positive()
+});
+
 function normalizePilotReturnTo(value: string | undefined | null): string | undefined {
   const normalized = value?.trim();
   if (!normalized) return undefined;
   if (!normalized.startsWith('/')) return undefined;
   if (normalized.startsWith('//')) return undefined;
+  if (normalized.includes('\\')) return undefined;
   return normalized;
 }
 
@@ -182,6 +199,132 @@ router.get('/v1/pilot/wallet/ledger', async (req, res, next) => {
       ok: true,
       ledger: result.entries,
       nextCursor: result.nextCursor ? encodeWalletLedgerCursor(result.nextCursor) : null
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/v1/pilot/payments', async (req, res, next) => {
+  try {
+    const session = readPilotSession(req);
+    const funding = await runtime.services.payments.getFundingState({
+      walletId: runtime.services.wallets.walletIdForOrgId(session.effectiveOrgId),
+      ownerOrgId: session.effectiveOrgId
+    });
+    res.status(200).json({
+      ok: true,
+      funding
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/v1/pilot/payments/setup-session', async (req, res, next) => {
+  try {
+    const session = readPilotSession(req);
+    const parsed = paymentSetupSchema.parse(req.body ?? {});
+    const result = await runtime.services.payments.createSetupSession({
+      walletId: runtime.services.wallets.walletIdForOrgId(session.effectiveOrgId),
+      ownerOrgId: session.effectiveOrgId,
+      requestedByUserId: session.impersonatedUserId ?? session.actorUserId,
+      returnTo: normalizePilotReturnTo(parsed.returnTo)
+    });
+    res.status(200).json({
+      ok: true,
+      checkoutUrl: result.checkoutUrl
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/v1/pilot/payments/top-up-session', async (req, res, next) => {
+  try {
+    const context = readPilotSessionContext(req);
+    const walletId = runtime.services.wallets.walletIdForOrgId(context.ownerOrgId);
+    const parsed = paymentTopUpSchema.parse(req.body ?? {});
+    const returnTo = normalizePilotReturnTo(parsed.returnTo);
+    const idempotencyKey = readAndValidateIdempotencyKey(req.header('idempotency-key') ?? undefined);
+    const requestHash = sha256Hex(stableJson({
+      effectiveOrgId: context.ownerOrgId,
+      requestedByUserId: context.contributorUserId,
+      amountMinor: parsed.amountMinor,
+      returnTo: returnTo ?? null
+    }));
+    const idemStart = await runtime.services.idempotency.start({
+      scope: 'pilot_payment_topup_session_v1',
+      tenantScope: walletId,
+      idempotencyKey,
+      requestHash
+    });
+
+    if (idemStart.replay) {
+      if (!idemStart.responseBody) {
+        throw new AppError('idempotency_replay_unavailable', 409, 'Idempotent replay not available for this request');
+      }
+      res.setHeader('x-idempotent-replay', 'true');
+      res.status(idemStart.responseCode).json(idemStart.responseBody);
+      return;
+    }
+
+    const result = await runtime.services.payments.createTopUpSession({
+      walletId,
+      ownerOrgId: context.ownerOrgId,
+      requestedByUserId: context.contributorUserId,
+      amountMinor: parsed.amountMinor,
+      returnTo,
+      idempotencyKey
+    });
+    const responseBody = {
+      ok: true,
+      checkoutUrl: result.checkoutUrl
+    } as const;
+
+    await runtime.services.idempotency.commit(idemStart, {
+      responseCode: 200,
+      responseBody,
+      responseDigest: sha256Hex(stableJson(responseBody)),
+      responseRef: walletId
+    });
+
+    res.status(200).json(responseBody);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/v1/pilot/payments/payment-method/remove', async (req, res, next) => {
+  try {
+    const session = readPilotSession(req);
+    const result = await runtime.services.payments.removeStoredPaymentMethod({
+      walletId: runtime.services.wallets.walletIdForOrgId(session.effectiveOrgId),
+      ownerOrgId: session.effectiveOrgId
+    });
+    res.status(200).json({
+      ok: true,
+      removed: result.removed
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/v1/pilot/payments/auto-recharge', async (req, res, next) => {
+  try {
+    const session = readPilotSession(req);
+    const parsed = autoRechargeSettingsSchema.parse(req.body ?? {});
+    const autoRecharge = await runtime.services.payments.updateAutoRechargeSettings({
+      walletId: runtime.services.wallets.walletIdForOrgId(session.effectiveOrgId),
+      ownerOrgId: session.effectiveOrgId,
+      enabled: parsed.enabled,
+      amountMinor: parsed.amountMinor,
+      updatedByUserId: session.impersonatedUserId ?? session.actorUserId
+    });
+    res.status(200).json({
+      ok: true,
+      autoRecharge
     });
   } catch (error) {
     next(error);

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import adminRoutes from './routes/admin.js';
 import analyticsRoutes from './routes/analytics.js';
 import anthropicCompatRoutes from './routes/anthropicCompat.js';
+import paymentsRoutes from './routes/payments.js';
 import pilotRoutes from './routes/pilot.js';
 import proxyRoutes from './routes/proxy.js';
 import sellerKeysRoutes from './routes/sellerKeys.js';
@@ -30,6 +31,13 @@ export function createApp(): express.Express {
         path: typeof req.url === 'string' ? req.url.split('?')[0] : undefined,
         body: Buffer.from(buf)
       });
+      const requestPath = typeof req.url === 'string' ? req.url.split('?')[0] : undefined;
+      if (
+        req.method === 'POST'
+        && (requestPath === '/v1/messages' || requestPath === '/v1/payments/webhooks/stripe')
+      ) {
+        (req as express.Request & { inniesRawBodyText?: string }).inniesRawBodyText = Buffer.from(buf).toString('utf8');
+      }
     }
   }));
 
@@ -136,6 +144,7 @@ export function createApp(): express.Express {
   app.use(adminRoutes);
   app.use(analyticsRoutes);
   app.use(anthropicCompatRoutes);
+  app.use(paymentsRoutes);
   app.use(pilotRoutes);
   app.use(sellerKeysRoutes);
   app.use(usageRoutes);

--- a/api/src/services/payments/paymentService.ts
+++ b/api/src/services/payments/paymentService.ts
@@ -1,0 +1,821 @@
+import { AppError } from '../../utils/errors.js';
+import type { TransactionContext } from '../../repos/sqlClient.js';
+import type { AutoRechargeSettingsRepository, AutoRechargeSettingsRow } from '../../repos/autoRechargeSettingsRepository.js';
+import type { PaymentAttemptRepository, PaymentAttemptRow } from '../../repos/paymentAttemptRepository.js';
+import type { PaymentMethodRepository, PaymentMethodRow } from '../../repos/paymentMethodRepository.js';
+import type { PaymentOutcomeRepository, PaymentOutcomeRow } from '../../repos/paymentOutcomeRepository.js';
+import type { PaymentProfileRepository, PaymentProfileRow } from '../../repos/paymentProfileRepository.js';
+import type { PaymentWebhookEventRepository } from '../../repos/paymentWebhookEventRepository.js';
+import {
+  type AutoRechargeAttemptResult,
+  type AutoRechargeTrigger,
+  type FundingStateView,
+  type NormalizedPaymentOutcome,
+  type PaymentWalletEffectType
+} from './paymentTypes.js';
+import type { StripeClient, StripeWebhookEvent } from './stripeClient.js';
+
+export class PaymentService {
+  constructor(private readonly deps: {
+    paymentProfiles: Pick<PaymentProfileRepository, 'findByWalletId' | 'ensureProfile' | 'setDefaultPaymentMethod'>;
+    paymentMethods: Pick<PaymentMethodRepository, 'upsertMethod' | 'findDefaultByWalletId' | 'findById' | 'findByProcessorPaymentMethodId' | 'markDetached'>;
+    autoRechargeSettings: Pick<AutoRechargeSettingsRepository, 'findByWalletId' | 'upsertSettings'>;
+    paymentAttempts: Pick<PaymentAttemptRepository, 'createAttempt' | 'findManualTopUpByIdempotencyKey' | 'findPendingAutoRechargeByWalletId' | 'markProcessing' | 'markSucceeded' | 'markFailed' | 'listRecentByWalletId'>;
+    paymentOutcomes: Pick<PaymentOutcomeRepository, 'upsertOutcome' | 'findByProcessorEffectId' | 'findLatestUnrecordedAutoRechargeCreditByWalletId' | 'markRecorded'>;
+    paymentWebhooks: Pick<PaymentWebhookEventRepository, 'claimEvent' | 'markProcessed'>;
+    stripeClient: Pick<StripeClient, 'createCustomer' | 'createSetupSession' | 'createPaymentSession' | 'createOffSessionCharge' | 'detachPaymentMethod' | 'retrievePaymentMethod' | 'constructWebhookEvent'>;
+  }) {}
+
+  markWebhookProcessed(processorEventId: string): Promise<void> {
+    return this.deps.paymentWebhooks.markProcessed(processorEventId);
+  }
+
+  markPaymentOutcomeRecorded(
+    processorEffectId: string,
+    db?: Pick<TransactionContext, 'query'>
+  ): Promise<void> {
+    return this.deps.paymentOutcomes.markRecorded(processorEffectId, db);
+  }
+
+  async getFundingState(input: {
+    walletId: string;
+    ownerOrgId: string;
+  }): Promise<FundingStateView> {
+    const [storedPaymentMethod, settings, attempts] = await Promise.all([
+      this.deps.paymentMethods.findDefaultByWalletId(input.walletId),
+      this.deps.autoRechargeSettings.findByWalletId(input.walletId),
+      this.deps.paymentAttempts.listRecentByWalletId({
+        walletId: input.walletId,
+        limit: 10
+      })
+    ]);
+    const paymentMethod = activePaymentMethod(storedPaymentMethod);
+
+    return {
+      paymentMethod: paymentMethod ? mapPaymentMethod(paymentMethod) : null,
+      autoRecharge: settings ? mapAutoRecharge(settings) : defaultAutoRechargeSettings(),
+      attempts: attempts.map((attempt) => ({
+        id: attempt.id,
+        kind: attempt.kind,
+        trigger: attempt.trigger,
+        status: attempt.status,
+        amountMinor: Number(attempt.amount_minor),
+        currency: attempt.currency,
+        createdAt: attempt.created_at,
+        updatedAt: attempt.updated_at,
+        lastErrorCode: attempt.last_error_code,
+        lastErrorMessage: attempt.last_error_message
+      }))
+    };
+  }
+
+  async createSetupSession(input: {
+    walletId: string;
+    ownerOrgId: string;
+    requestedByUserId: string | null;
+    returnTo?: string | null;
+  }): Promise<{ checkoutUrl: string }> {
+    const profile = await this.ensureCustomerProfile({
+      walletId: input.walletId,
+      ownerOrgId: input.ownerOrgId
+    });
+    const urls = buildCheckoutUrls(input.returnTo);
+    const session = await this.deps.stripeClient.createSetupSession({
+      customerId: profile.processor_customer_id,
+      successUrl: urls.successUrl,
+      cancelUrl: urls.cancelUrl,
+      metadata: {
+        wallet_id: input.walletId,
+        owner_org_id: input.ownerOrgId,
+        requested_by_user_id: input.requestedByUserId ?? ''
+      }
+    });
+
+    return {
+      checkoutUrl: session.url
+    };
+  }
+
+  async createTopUpSession(input: {
+    walletId: string;
+    ownerOrgId: string;
+    requestedByUserId: string | null;
+    amountMinor: number;
+    returnTo?: string | null;
+    idempotencyKey: string;
+  }): Promise<{ checkoutUrl: string }> {
+    if (!Number.isInteger(input.amountMinor) || input.amountMinor <= 0) {
+      throw new AppError('invalid_request', 400, 'Top-up amount must be a positive integer', {
+        amountMinor: input.amountMinor
+      });
+    }
+
+    const profile = await this.ensureCustomerProfile({
+      walletId: input.walletId,
+      ownerOrgId: input.ownerOrgId
+    });
+    const attempt = await this.findOrCreateManualTopUpAttempt(input);
+    const urls = buildCheckoutUrls(input.returnTo);
+    const session = await this.deps.stripeClient.createPaymentSession({
+      customerId: profile.processor_customer_id,
+      amountMinor: input.amountMinor,
+      currency: 'USD',
+      successUrl: urls.successUrl,
+      cancelUrl: urls.cancelUrl,
+      idempotencyKey: input.idempotencyKey,
+      metadata: {
+        wallet_id: input.walletId,
+        owner_org_id: input.ownerOrgId,
+        payment_attempt_id: attempt.id
+      }
+    });
+    await this.deps.paymentAttempts.markProcessing({
+      attemptId: attempt.id,
+      processorCheckoutSessionId: session.id
+    });
+
+    return {
+      checkoutUrl: session.url
+    };
+  }
+
+  async removeStoredPaymentMethod(input: {
+    walletId: string;
+    ownerOrgId: string;
+  }): Promise<{ removed: boolean }> {
+    const paymentMethod = activePaymentMethod(await this.deps.paymentMethods.findDefaultByWalletId(input.walletId));
+    if (!paymentMethod) {
+      return {
+        removed: false
+      };
+    }
+
+    await this.deps.stripeClient.detachPaymentMethod(paymentMethod.processor_payment_method_id);
+    await this.deps.paymentMethods.markDetached({
+      walletId: input.walletId,
+      paymentMethodId: paymentMethod.id
+    });
+    await this.deps.paymentProfiles.setDefaultPaymentMethod({
+      walletId: input.walletId,
+      paymentMethodId: null
+    });
+
+    const existing = await this.deps.autoRechargeSettings.findByWalletId(input.walletId);
+    if (existing) {
+      await this.deps.autoRechargeSettings.upsertSettings({
+        walletId: input.walletId,
+        ownerOrgId: input.ownerOrgId,
+        enabled: false,
+        amountMinor: Number(existing.amount_minor),
+        currency: existing.currency,
+        paymentMethodId: null,
+        updatedByUserId: null
+      });
+    }
+
+    return {
+      removed: true
+    };
+  }
+
+  async updateAutoRechargeSettings(input: {
+    walletId: string;
+    ownerOrgId: string;
+    enabled: boolean;
+    amountMinor: number;
+    updatedByUserId?: string | null;
+  }): Promise<FundingStateView['autoRecharge']> {
+    const paymentMethod = activePaymentMethod(await this.deps.paymentMethods.findDefaultByWalletId(input.walletId));
+    if (input.enabled && !paymentMethod) {
+      throw new AppError('invalid_request', 400, 'Auto-recharge requires a stored payment method');
+    }
+
+    const settings = await this.deps.autoRechargeSettings.upsertSettings({
+      walletId: input.walletId,
+      ownerOrgId: input.ownerOrgId,
+      enabled: input.enabled,
+      amountMinor: input.amountMinor,
+      currency: 'USD',
+      paymentMethodId: input.enabled ? paymentMethod?.id ?? null : null,
+      updatedByUserId: input.updatedByUserId ?? null
+    });
+
+    return mapAutoRecharge(settings);
+  }
+
+  async attemptAutoRecharge(walletId: string, trigger: AutoRechargeTrigger): Promise<AutoRechargeAttemptResult> {
+    const unrecorded = await this.deps.paymentOutcomes.findLatestUnrecordedAutoRechargeCreditByWalletId(walletId);
+    if (unrecorded) {
+      return {
+        kind: 'charge_succeeded',
+        processorEffectId: unrecorded.processor_effect_id
+      };
+    }
+
+    const settings = await this.deps.autoRechargeSettings.findByWalletId(walletId);
+    if (!settings?.enabled) {
+      return {
+        kind: 'not_configured'
+      };
+    }
+
+    const paymentMethod = activePaymentMethod(await this.deps.paymentMethods.findDefaultByWalletId(walletId));
+    if (!paymentMethod) {
+      return {
+        kind: 'not_configured'
+      };
+    }
+
+    const pending = await this.deps.paymentAttempts.findPendingAutoRechargeByWalletId(walletId);
+    if (pending) {
+      return {
+        kind: 'charge_pending',
+        paymentAttemptId: pending.id
+      };
+    }
+
+    const attempt = await this.deps.paymentAttempts.createAttempt({
+      walletId,
+      ownerOrgId: settings.owner_org_id,
+      paymentMethodId: paymentMethod.id,
+      kind: 'auto_recharge',
+      trigger,
+      amountMinor: Number(settings.amount_minor),
+      currency: settings.currency,
+      metadata: {
+        trigger
+      }
+    });
+
+    const charge = await this.deps.stripeClient.createOffSessionCharge({
+      customerId: paymentMethod.processor_customer_id,
+      paymentMethodId: paymentMethod.processor_payment_method_id,
+      amountMinor: Number(settings.amount_minor),
+      currency: settings.currency,
+      metadata: {
+        wallet_id: walletId,
+        owner_org_id: settings.owner_org_id,
+        payment_attempt_id: attempt.id,
+        auto_recharge_trigger: trigger
+      }
+    });
+
+    if (charge.kind === 'succeeded') {
+      const outcome = await this.deps.paymentOutcomes.upsertOutcome({
+        walletId,
+        ownerOrgId: settings.owner_org_id,
+        paymentAttemptId: attempt.id,
+        processorEventId: `sync:${charge.paymentIntentId}`,
+        processorEffectId: buildPaymentIntentEffectId(charge.paymentIntentId),
+        effectType: 'payment_credit',
+        amountMinor: Number(settings.amount_minor),
+        currency: settings.currency,
+        metadata: {
+          trigger,
+          source: 'sync_auto_recharge'
+        }
+      });
+      await this.deps.paymentAttempts.markSucceeded({
+        attemptId: attempt.id,
+        processorEffectId: outcome.processor_effect_id,
+        processorPaymentIntentId: charge.paymentIntentId
+      });
+      return {
+        kind: 'charge_succeeded',
+        processorEffectId: outcome.processor_effect_id
+      };
+    }
+
+    if (charge.kind === 'pending') {
+      await this.deps.paymentAttempts.markProcessing({
+        attemptId: attempt.id,
+        processorPaymentIntentId: charge.paymentIntentId
+      });
+      return {
+        kind: 'charge_pending',
+        paymentAttemptId: attempt.id
+      };
+    }
+
+    await this.deps.paymentAttempts.markFailed({
+      attemptId: attempt.id,
+      processorEffectId: null,
+      processorPaymentIntentId: charge.paymentIntentId,
+      lastErrorCode: charge.errorCode,
+      lastErrorMessage: charge.errorMessage
+    });
+    return {
+      kind: 'charge_failed',
+      processorEffectId: null
+    };
+  }
+
+  async getNormalizedPaymentOutcome(input: {
+    processorEffectId: string;
+    effectType: PaymentWalletEffectType;
+  }): Promise<NormalizedPaymentOutcome | null> {
+    const outcome = await this.deps.paymentOutcomes.findByProcessorEffectId(input);
+    return outcome ? mapNormalizedOutcome(outcome) : null;
+  }
+
+  async processWebhook(input: {
+    signatureHeader: string | undefined;
+    rawBody: string;
+  }): Promise<{
+    accepted: boolean;
+    processorEventId: string;
+    outcomes: NormalizedPaymentOutcome[];
+  }> {
+    const event = this.deps.stripeClient.constructWebhookEvent(input);
+    const claimed = await this.deps.paymentWebhooks.claimEvent({
+      processor: 'stripe',
+      processorEventId: event.id,
+      eventType: event.type,
+      payload: event as unknown as Record<string, unknown>
+    });
+    if (claimed.state === 'already_processed') {
+      return {
+        accepted: true,
+        processorEventId: claimed.processorEventId,
+        outcomes: []
+      };
+    }
+
+    const outcomes: NormalizedPaymentOutcome[] = [];
+
+    switch (event.type) {
+      case 'setup_intent.succeeded':
+        await this.handleSetupIntentSucceeded(event);
+        break;
+      case 'payment_intent.succeeded': {
+        const outcome = await this.handlePaymentIntentSucceeded(event);
+        if (outcome) outcomes.push(outcome);
+        break;
+      }
+      case 'payment_intent.payment_failed':
+        await this.handlePaymentIntentFailed(event);
+        break;
+      case 'refund.created':
+      case 'charge.refunded': {
+        const outcome = await this.handleRefundCreated(event);
+        if (outcome) outcomes.push(outcome);
+        break;
+      }
+      case 'charge.dispute.funds_withdrawn': {
+        const outcome = await this.handleChargeDisputeFundsWithdrawn(event);
+        if (outcome) outcomes.push(outcome);
+        break;
+      }
+      case 'payment_method.detached':
+        await this.handlePaymentMethodDetached(event);
+        break;
+      default:
+        break;
+    }
+
+    return {
+      accepted: true,
+      processorEventId: claimed.processorEventId,
+      outcomes
+    };
+  }
+
+  private async handleSetupIntentSucceeded(event: StripeWebhookEvent): Promise<void> {
+    const object = event.data.object;
+    const walletId = readMetadataString(object.metadata, 'wallet_id');
+    const ownerOrgId = readMetadataString(object.metadata, 'owner_org_id') ?? walletId;
+    const customerId = readRequiredString(object.customer);
+    const paymentMethodId = readRequiredString(object.payment_method);
+    if (!walletId || !ownerOrgId) {
+      return;
+    }
+
+    const profile = await this.ensureCustomerProfile({
+      walletId,
+      ownerOrgId,
+      processorCustomerId: customerId
+    });
+    const remoteMethod = await this.deps.stripeClient.retrievePaymentMethod(paymentMethodId);
+    const remoteMethodType = readOptionalString(remoteMethod.type);
+    if (remoteMethodType && remoteMethodType !== 'card') {
+      throw new Error(`unsupported payment method type: ${remoteMethodType}`);
+    }
+    const card = asRecord(remoteMethod.card);
+    if (!card) {
+      throw new Error('unsupported payment method type');
+    }
+    const method = await this.deps.paymentMethods.upsertMethod({
+      walletId,
+      ownerOrgId,
+      paymentProfileId: profile.id,
+      processorPaymentMethodId: paymentMethodId,
+      processorCustomerId: customerId,
+      brand: readRequiredString(card?.brand),
+      last4: readRequiredString(card?.last4),
+      expMonth: Number(card?.exp_month),
+      expYear: Number(card?.exp_year),
+      funding: readOptionalString(card?.funding)
+    });
+    await this.deps.paymentProfiles.setDefaultPaymentMethod({
+      walletId,
+      paymentMethodId: method.id
+    });
+
+    const existing = await this.deps.autoRechargeSettings.findByWalletId(walletId);
+    if (existing) {
+      await this.deps.autoRechargeSettings.upsertSettings({
+        walletId,
+        ownerOrgId,
+        enabled: existing.enabled,
+        amountMinor: Number(existing.amount_minor),
+        currency: existing.currency,
+        paymentMethodId: method.id,
+        updatedByUserId: existing.updated_by_user_id
+      });
+    }
+  }
+
+  private async handlePaymentIntentSucceeded(event: StripeWebhookEvent): Promise<NormalizedPaymentOutcome | null> {
+    const object = event.data.object;
+    const walletId = readMetadataString(object.metadata, 'wallet_id');
+    const ownerOrgId = readMetadataString(object.metadata, 'owner_org_id') ?? walletId;
+    if (!walletId || !ownerOrgId) {
+      return null;
+    }
+
+    const paymentAttemptId = readMetadataString(object.metadata, 'payment_attempt_id');
+    const outcome = await this.deps.paymentOutcomes.upsertOutcome({
+      walletId,
+      ownerOrgId,
+      paymentAttemptId,
+      processorEventId: event.id,
+      processorEffectId: buildPaymentIntentEffectId(readRequiredString(object.id)),
+      effectType: 'payment_credit',
+      amountMinor: Number(object.amount_received ?? object.amount ?? 0),
+      currency: normalizeCurrency(object.currency),
+      metadata: {
+        eventType: event.type
+      }
+    });
+
+    if (paymentAttemptId) {
+      await this.deps.paymentAttempts.markSucceeded({
+        attemptId: paymentAttemptId,
+        processorEffectId: outcome.processor_effect_id,
+        processorPaymentIntentId: readRequiredString(object.id)
+      });
+    }
+
+    return mapNormalizedOutcome(outcome);
+  }
+
+  private async handlePaymentIntentFailed(event: StripeWebhookEvent): Promise<void> {
+    const object = event.data.object;
+    const paymentAttemptId = readMetadataString(object.metadata, 'payment_attempt_id');
+    if (!paymentAttemptId) {
+      return;
+    }
+
+    await this.deps.paymentAttempts.markFailed({
+      attemptId: paymentAttemptId,
+      processorPaymentIntentId: readRequiredString(object.id),
+      lastErrorCode: readMetadataString(object.last_payment_error, 'code'),
+      lastErrorMessage: readMetadataString(object.last_payment_error, 'message') ?? 'Payment failed'
+    });
+  }
+
+  private async handleRefundCreated(event: StripeWebhookEvent): Promise<NormalizedPaymentOutcome | null> {
+    const object = event.data.object;
+    const originalOutcome = await this.findOriginalCreditOutcome(object);
+    if (!originalOutcome) {
+      throw new Error('original payment credit outcome not found');
+    }
+
+    const outcome = await this.deps.paymentOutcomes.upsertOutcome({
+      walletId: originalOutcome.wallet_id,
+      ownerOrgId: originalOutcome.owner_org_id,
+      paymentAttemptId: originalOutcome.payment_attempt_id,
+      processorEventId: event.id,
+      processorEffectId: buildRefundEffectId(object),
+      effectType: 'payment_reversal',
+      amountMinor: readRefundAmount(object),
+      currency: normalizeCurrency(object.currency),
+      metadata: {
+        eventType: event.type
+      }
+    });
+    return mapNormalizedOutcome(outcome);
+  }
+
+  private async handleChargeDisputeFundsWithdrawn(event: StripeWebhookEvent): Promise<NormalizedPaymentOutcome | null> {
+    const object = event.data.object;
+    const paymentIntentId = readRequiredString(object.payment_intent);
+    const originalOutcome = await this.deps.paymentOutcomes.findByProcessorEffectId({
+      processorEffectId: buildPaymentIntentEffectId(paymentIntentId),
+      effectType: 'payment_credit'
+    });
+    if (!originalOutcome) {
+      throw new Error('original payment credit outcome not found');
+    }
+
+    const disputeId = buildDisputeEffectId(readRequiredString(object.id));
+    const outcome = await this.deps.paymentOutcomes.upsertOutcome({
+      walletId: originalOutcome.wallet_id,
+      ownerOrgId: originalOutcome.owner_org_id,
+      paymentAttemptId: originalOutcome.payment_attempt_id,
+      processorEventId: event.id,
+      processorEffectId: disputeId,
+      effectType: 'payment_reversal',
+      amountMinor: Number(object.amount ?? 0),
+      currency: normalizeCurrency(object.currency),
+      metadata: {
+        eventType: event.type
+      }
+    });
+    return mapNormalizedOutcome(outcome);
+  }
+
+  private async handlePaymentMethodDetached(event: StripeWebhookEvent): Promise<void> {
+    const object = event.data.object;
+    const paymentMethod = await this.deps.paymentMethods.findByProcessorPaymentMethodId(readRequiredString(object.id));
+    if (!paymentMethod) {
+      return;
+    }
+    const profile = await this.deps.paymentProfiles.findByWalletId(paymentMethod.wallet_id);
+    const detachedDefaultMethod = profile?.default_payment_method_id === paymentMethod.id;
+
+    await this.deps.paymentMethods.markDetached({
+      walletId: paymentMethod.wallet_id,
+      paymentMethodId: paymentMethod.id
+    });
+    if (!detachedDefaultMethod) {
+      return;
+    }
+    await this.deps.paymentProfiles.setDefaultPaymentMethod({
+      walletId: paymentMethod.wallet_id,
+      paymentMethodId: null
+    });
+
+    const settings = await this.deps.autoRechargeSettings.findByWalletId(paymentMethod.wallet_id);
+    if (settings) {
+      await this.deps.autoRechargeSettings.upsertSettings({
+        walletId: paymentMethod.wallet_id,
+        ownerOrgId: paymentMethod.owner_org_id,
+        enabled: false,
+        amountMinor: Number(settings.amount_minor),
+        currency: settings.currency,
+        paymentMethodId: null,
+        updatedByUserId: null
+      });
+    }
+  }
+
+  private async ensureCustomerProfile(input: {
+    walletId: string;
+    ownerOrgId: string;
+    processorCustomerId?: string;
+  }): Promise<PaymentProfileRow> {
+    const existing = await this.deps.paymentProfiles.findByWalletId(input.walletId);
+    if (existing) {
+      if (
+        input.processorCustomerId
+        && existing.processor_customer_id !== input.processorCustomerId
+      ) {
+        throw new Error('payment profile customer mismatch');
+      }
+      return existing;
+    }
+
+    const customer = input.processorCustomerId
+      ? { customerId: input.processorCustomerId }
+      : await this.deps.stripeClient.createCustomer({
+        metadata: {
+          wallet_id: input.walletId,
+          owner_org_id: input.ownerOrgId
+        }
+      });
+    return this.deps.paymentProfiles.ensureProfile({
+      walletId: input.walletId,
+      ownerOrgId: input.ownerOrgId,
+      processorCustomerId: customer.customerId
+    });
+  }
+
+  private async findOrCreateManualTopUpAttempt(input: {
+    walletId: string;
+    ownerOrgId: string;
+    requestedByUserId: string | null;
+    amountMinor: number;
+    returnTo?: string | null;
+    idempotencyKey: string;
+  }): Promise<PaymentAttemptRow> {
+    const existing = await this.deps.paymentAttempts.findManualTopUpByIdempotencyKey({
+      walletId: input.walletId,
+      idempotencyKey: input.idempotencyKey
+    });
+    if (existing) {
+      return validateManualTopUpAttempt(existing, input);
+    }
+
+    try {
+      return await this.deps.paymentAttempts.createAttempt({
+        walletId: input.walletId,
+        ownerOrgId: input.ownerOrgId,
+        kind: 'manual_topup',
+        amountMinor: input.amountMinor,
+        idempotencyKey: input.idempotencyKey,
+        initiatedByUserId: input.requestedByUserId,
+        metadata: {
+          source: 'pilot_dashboard',
+          returnTo: normalizeReturnTo(input.returnTo)
+        }
+      });
+    } catch (error) {
+      if (!isUniqueViolation(error)) {
+        throw error;
+      }
+
+      const retried = await this.deps.paymentAttempts.findManualTopUpByIdempotencyKey({
+        walletId: input.walletId,
+        idempotencyKey: input.idempotencyKey
+      });
+      if (!retried) {
+        throw error;
+      }
+      return validateManualTopUpAttempt(retried, input);
+    }
+  }
+
+  private async findOriginalCreditOutcome(object: Record<string, any>): Promise<PaymentOutcomeRow | null> {
+    const paymentIntentId = readOptionalString(object.payment_intent);
+    if (!paymentIntentId) {
+      return null;
+    }
+    return this.deps.paymentOutcomes.findByProcessorEffectId({
+      processorEffectId: buildPaymentIntentEffectId(paymentIntentId),
+      effectType: 'payment_credit'
+    });
+  }
+}
+
+function buildCheckoutUrls(returnTo: string | null | undefined): {
+  successUrl: string;
+  cancelUrl: string;
+} {
+  const baseUrl = (process.env.PILOT_UI_BASE_URL ?? process.env.UI_BASE_URL ?? 'http://localhost:3000').replace(/\/+$/, '');
+  const safeReturnTo = normalizeReturnTo(returnTo) ?? '/pilot';
+  return {
+    successUrl: `${baseUrl}${safeReturnTo}`,
+    cancelUrl: `${baseUrl}${safeReturnTo}`
+  };
+}
+
+function normalizeReturnTo(value: string | null | undefined): string | null {
+  const normalized = value?.trim();
+  if (!normalized) return null;
+  if (!normalized.startsWith('/')) return null;
+  if (normalized.startsWith('//')) return null;
+  if (normalized.includes('\\')) return null;
+  return normalized;
+}
+
+function validateManualTopUpAttempt(existing: PaymentAttemptRow, input: {
+  walletId: string;
+  ownerOrgId: string;
+  requestedByUserId: string | null;
+  amountMinor: number;
+  returnTo?: string | null;
+}): PaymentAttemptRow {
+  const existingReturnTo = readMetadataString(existing.metadata, 'returnTo');
+  const requestedReturnTo = normalizeReturnTo(input.returnTo);
+  if (
+    existing.wallet_id !== input.walletId
+    || existing.owner_org_id !== input.ownerOrgId
+    || Number(existing.amount_minor) !== input.amountMinor
+    || (existing.initiated_by_user_id ?? null) !== (input.requestedByUserId ?? null)
+    || existingReturnTo !== requestedReturnTo
+  ) {
+    throw new AppError('idempotency_mismatch', 409, 'Top-up idempotency key re-used with different request payload');
+  }
+
+  if (existing.status !== 'pending' && existing.status !== 'processing') {
+    throw new AppError('conflict', 409, 'Top-up request already finalized; refresh and try again');
+  }
+
+  return existing;
+}
+
+function buildPaymentIntentEffectId(paymentIntentId: string): string {
+  return `stripe:payment_intent:${paymentIntentId}`;
+}
+
+function buildRefundEffectId(object: Record<string, any>): string {
+  const refundId = readOptionalString(object.id);
+  if (refundId?.startsWith('re_')) {
+    return `stripe:refund:${refundId}`;
+  }
+
+  const refunds = Array.isArray(object.refunds?.data) ? object.refunds.data : [];
+  const latestRefund = refunds[0];
+  const latestRefundId = readOptionalString(latestRefund?.id);
+  return latestRefundId ? `stripe:refund:${latestRefundId}` : `stripe:charge_refund:${readRequiredString(object.id)}`;
+}
+
+function readRefundAmount(object: Record<string, any>): number {
+  if (readOptionalString(object.id)?.startsWith('re_')) {
+    return Number(object.amount ?? 0);
+  }
+
+  const refunds = Array.isArray(object.refunds?.data) ? object.refunds.data : [];
+  const latestRefund = refunds[0];
+  const latestAmount = latestRefund?.amount;
+  if (typeof latestAmount === 'number' && Number.isFinite(latestAmount)) {
+    return Number(latestAmount);
+  }
+  return Number(object.amount_refunded ?? 0);
+}
+
+function buildDisputeEffectId(disputeId: string): string {
+  return `stripe:dispute:${disputeId}`;
+}
+
+function normalizeCurrency(value: unknown): string {
+  return typeof value === 'string' && value.trim().length > 0 ? value.toUpperCase() : 'USD';
+}
+
+function mapPaymentMethod(row: PaymentMethodRow): FundingStateView['paymentMethod'] {
+  return {
+    id: row.id,
+    processor: 'stripe',
+    brand: row.brand,
+    last4: row.last4,
+    expMonth: Number(row.exp_month),
+    expYear: Number(row.exp_year),
+    funding: row.funding,
+    status: row.status === 'detached' ? 'detached' : 'active'
+  };
+}
+
+function activePaymentMethod(row: PaymentMethodRow | null | undefined): PaymentMethodRow | null {
+  if (!row || row.status !== 'active') {
+    return null;
+  }
+  return row;
+}
+
+function defaultAutoRechargeSettings(): FundingStateView['autoRecharge'] {
+  return {
+    enabled: false,
+    amountMinor: 2500,
+    currency: 'USD'
+  };
+}
+
+function mapAutoRecharge(row: AutoRechargeSettingsRow): FundingStateView['autoRecharge'] {
+  return {
+    enabled: row.enabled,
+    amountMinor: Number(row.amount_minor),
+    currency: row.currency
+  };
+}
+
+function mapNormalizedOutcome(row: PaymentOutcomeRow): NormalizedPaymentOutcome {
+  return {
+    walletId: row.wallet_id,
+    ownerOrgId: row.owner_org_id,
+    paymentAttemptId: row.payment_attempt_id,
+    processor: 'stripe',
+    processorEventId: row.processor_event_id,
+    processorEffectId: row.processor_effect_id,
+    effectType: row.effect_type,
+    amountMinor: Number(row.amount_minor),
+    currency: row.currency,
+    metadata: row.metadata
+  };
+}
+
+function readRequiredString(value: unknown): string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new AppError('payment_processor_error', 502, 'Payment processor response was missing a required id');
+  }
+  return value;
+}
+
+function readMetadataString(metadata: unknown, key: string): string | null {
+  const record = asRecord(metadata);
+  const value = record?.[key];
+  return typeof value === 'string' && value.trim().length > 0 ? value : null;
+}
+
+function readOptionalString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value : null;
+}
+
+function asRecord(value: unknown): Record<string, any> | null {
+  return typeof value === 'object' && value !== null ? value as Record<string, any> : null;
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  return (error as { code?: string }).code === '23505';
+}

--- a/api/src/services/payments/paymentTypes.ts
+++ b/api/src/services/payments/paymentTypes.ts
@@ -1,0 +1,68 @@
+import type { WalletEffectType } from '../../types/phase2Contracts.js';
+
+export type PaymentProcessor = 'stripe';
+
+export type StoredPaymentMethodStatus = 'active' | 'detached';
+
+export type PaymentAttemptKind = 'manual_topup' | 'auto_recharge';
+
+export type PaymentAttemptStatus = 'pending' | 'processing' | 'succeeded' | 'failed';
+
+export type AutoRechargeTrigger = 'admission_blocked' | 'post_finalization_negative';
+
+export type PaymentWalletEffectType = Extract<WalletEffectType, 'payment_credit' | 'payment_reversal'>;
+
+export type AutoRechargeAttemptResult =
+  | { kind: 'not_configured' }
+  | { kind: 'charge_succeeded'; processorEffectId: string }
+  | { kind: 'charge_failed'; processorEffectId: string | null }
+  | { kind: 'charge_pending'; paymentAttemptId: string };
+
+export type NormalizedPaymentOutcome = {
+  walletId: string;
+  ownerOrgId: string;
+  paymentAttemptId: string | null;
+  processor: PaymentProcessor;
+  processorEventId: string;
+  processorEffectId: string;
+  effectType: PaymentWalletEffectType;
+  amountMinor: number;
+  currency: string;
+  metadata?: Record<string, unknown> | null;
+};
+
+export type StoredPaymentMethodView = {
+  id: string;
+  processor: PaymentProcessor;
+  brand: string;
+  last4: string;
+  expMonth: number;
+  expYear: number;
+  funding: string | null;
+  status: StoredPaymentMethodStatus;
+};
+
+export type AutoRechargeSettingsView = {
+  enabled: boolean;
+  amountMinor: number;
+  currency: string;
+};
+
+export type PaymentAttemptView = {
+  id: string;
+  kind: PaymentAttemptKind;
+  trigger: AutoRechargeTrigger | null;
+  status: PaymentAttemptStatus;
+  amountMinor: number;
+  currency: string;
+  createdAt: string;
+  updatedAt: string;
+  lastErrorCode: string | null;
+  lastErrorMessage: string | null;
+};
+
+export type FundingStateView = {
+  paymentMethod: StoredPaymentMethodView | null;
+  autoRecharge: AutoRechargeSettingsView;
+  attempts: PaymentAttemptView[];
+};

--- a/api/src/services/payments/stripeClient.ts
+++ b/api/src/services/payments/stripeClient.ts
@@ -1,0 +1,328 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+export class StripeApiError extends Error {
+  readonly status: number;
+  readonly code: string | null;
+  readonly details: Record<string, unknown> | null;
+
+  constructor(status: number, message: string, code?: string | null, details?: Record<string, unknown> | null) {
+    super(message);
+    this.name = 'StripeApiError';
+    this.status = status;
+    this.code = code ?? null;
+    this.details = details ?? null;
+  }
+}
+
+export type StripeWebhookEvent = {
+  id: string;
+  type: string;
+  data: {
+    object: Record<string, any>;
+  };
+};
+
+export type StripeOffSessionChargeResult =
+  | { kind: 'succeeded'; paymentIntentId: string }
+  | { kind: 'pending'; paymentIntentId: string }
+  | { kind: 'failed'; paymentIntentId: string | null; errorCode: string | null; errorMessage: string };
+
+export class StripeClient {
+  constructor(private readonly config: {
+    secretKey: string;
+    webhookSecret: string;
+    apiBaseUrl?: string;
+  }) {}
+
+  async createCustomer(input: {
+    email?: string | null;
+    metadata?: Record<string, string>;
+  }): Promise<{ customerId: string }> {
+    const response = await this.request('/customers', {
+      method: 'POST',
+      form: {
+        email: input.email ?? undefined,
+        metadata: input.metadata ?? undefined
+      }
+    });
+
+    return {
+      customerId: readRequiredString(response, 'id')
+    };
+  }
+
+  async createSetupSession(input: {
+    customerId: string;
+    successUrl: string;
+    cancelUrl: string;
+    metadata?: Record<string, string>;
+  }): Promise<{ id: string; url: string }> {
+    const response = await this.request('/checkout/sessions', {
+      method: 'POST',
+      form: {
+        mode: 'setup',
+        customer: input.customerId,
+        payment_method_types: ['card'],
+        success_url: input.successUrl,
+        cancel_url: input.cancelUrl,
+        setup_intent_data: {
+          metadata: input.metadata ?? {}
+        }
+      }
+    });
+
+    return {
+      id: readRequiredString(response, 'id'),
+      url: readRequiredString(response, 'url')
+    };
+  }
+
+  async createPaymentSession(input: {
+    customerId: string;
+    amountMinor: number;
+    currency: string;
+    successUrl: string;
+    cancelUrl: string;
+    idempotencyKey?: string;
+    metadata?: Record<string, string>;
+  }): Promise<{ id: string; url: string }> {
+    const response = await this.request('/checkout/sessions', {
+      method: 'POST',
+      headers: input.idempotencyKey
+        ? {
+          'Idempotency-Key': input.idempotencyKey
+        }
+        : undefined,
+      form: {
+        mode: 'payment',
+        customer: input.customerId,
+        success_url: input.successUrl,
+        cancel_url: input.cancelUrl,
+        'line_items[0][quantity]': '1',
+        'line_items[0][price_data][currency]': input.currency.toLowerCase(),
+        'line_items[0][price_data][unit_amount]': String(input.amountMinor),
+        'line_items[0][price_data][product_data][name]': 'Innies wallet top-up',
+        payment_intent_data: {
+          metadata: input.metadata ?? {}
+        }
+      }
+    });
+
+    return {
+      id: readRequiredString(response, 'id'),
+      url: readRequiredString(response, 'url')
+    };
+  }
+
+  async createOffSessionCharge(input: {
+    customerId: string;
+    paymentMethodId: string;
+    amountMinor: number;
+    currency: string;
+    metadata?: Record<string, string>;
+  }): Promise<StripeOffSessionChargeResult> {
+    try {
+      const response = await this.request('/payment_intents', {
+        method: 'POST',
+        form: {
+          amount: String(input.amountMinor),
+          currency: input.currency.toLowerCase(),
+          customer: input.customerId,
+          payment_method: input.paymentMethodId,
+          off_session: 'true',
+          confirm: 'true',
+          metadata: input.metadata ?? {}
+        }
+      });
+
+      const paymentIntentId = readRequiredString(response, 'id');
+      const status = readRequiredString(response, 'status');
+      if (status === 'succeeded') {
+        return {
+          kind: 'succeeded',
+          paymentIntentId
+        };
+      }
+
+      if (status === 'processing' || status === 'requires_action' || status === 'requires_capture') {
+        return {
+          kind: 'pending',
+          paymentIntentId
+        };
+      }
+
+      const lastError = asRecord(response.last_payment_error);
+      return {
+        kind: 'failed',
+        paymentIntentId,
+        errorCode: readOptionalString(lastError?.code),
+        errorMessage: readOptionalString(lastError?.message) ?? 'Stripe payment intent failed'
+      };
+    } catch (error) {
+      if (error instanceof StripeApiError) {
+        const errorBody = asRecord(error.details?.error);
+        return {
+          kind: 'failed',
+          paymentIntentId: readOptionalString(errorBody?.payment_intent),
+          errorCode: error.code,
+          errorMessage: error.message
+        };
+      }
+      throw error;
+    }
+  }
+
+  async detachPaymentMethod(processorPaymentMethodId: string): Promise<void> {
+    await this.request(`/payment_methods/${processorPaymentMethodId}/detach`, {
+      method: 'POST',
+      form: {}
+    });
+  }
+
+  async retrievePaymentMethod(processorPaymentMethodId: string): Promise<Record<string, any>> {
+    return this.request(`/payment_methods/${processorPaymentMethodId}`, {
+      method: 'GET'
+    });
+  }
+
+  constructWebhookEvent(input: {
+    signatureHeader: string | undefined;
+    rawBody: string;
+  }): StripeWebhookEvent {
+    if (!input.signatureHeader) {
+      throw new StripeApiError(400, 'Missing Stripe signature header');
+    }
+
+    const webhookSecret = this.config.webhookSecret.trim();
+    if (!webhookSecret) {
+      throw new StripeApiError(500, 'Missing Stripe webhook secret');
+    }
+
+    const parsed = parseStripeSignature(input.signatureHeader);
+    const payload = `${parsed.timestamp}.${input.rawBody}`;
+    const expected = createHmac('sha256', webhookSecret).update(payload, 'utf8').digest('hex');
+    const actualBuffer = Buffer.from(parsed.signature, 'hex');
+    const expectedBuffer = Buffer.from(expected, 'hex');
+
+    if (
+      actualBuffer.length !== expectedBuffer.length
+      || !timingSafeEqual(actualBuffer, expectedBuffer)
+    ) {
+      throw new StripeApiError(400, 'Invalid Stripe signature');
+    }
+
+    const body = JSON.parse(input.rawBody) as StripeWebhookEvent;
+    if (!body || typeof body.id !== 'string' || typeof body.type !== 'string') {
+      throw new StripeApiError(400, 'Invalid Stripe webhook payload');
+    }
+    return body;
+  }
+
+  private async request(path: string, input: {
+    method: 'GET' | 'POST';
+    headers?: Record<string, string>;
+    form?: Record<string, unknown>;
+  }): Promise<Record<string, any>> {
+    const secretKey = this.config.secretKey.trim();
+    if (!secretKey) {
+      throw new StripeApiError(500, 'Missing Stripe secret key');
+    }
+
+    const body = input.form ? toFormBody(input.form).toString() : undefined;
+    const response = await fetch(`${this.config.apiBaseUrl ?? 'https://api.stripe.com/v1'}${path}`, {
+      method: input.method,
+      headers: {
+        authorization: `Bearer ${secretKey}`,
+        ...(body ? { 'content-type': 'application/x-www-form-urlencoded' } : {}),
+        ...(input.headers ?? {})
+      },
+      body
+    });
+
+    const text = await response.text();
+    const parsed = text.length > 0 ? JSON.parse(text) as Record<string, any> : {};
+    if (!response.ok) {
+      const errorBody = asRecord(parsed.error);
+      throw new StripeApiError(
+        response.status,
+        readOptionalString(errorBody?.message) ?? `Stripe request failed (${response.status})`,
+        readOptionalString(errorBody?.code),
+        parsed
+      );
+    }
+
+    return parsed;
+  }
+}
+
+function toFormBody(input: Record<string, unknown>): URLSearchParams {
+  const params = new URLSearchParams();
+  appendFormEntries(params, '', input);
+  return params;
+}
+
+function appendFormEntries(params: URLSearchParams, prefix: string, value: unknown): void {
+  if (value === undefined) {
+    return;
+  }
+
+  if (value === null) {
+    params.append(prefix, '');
+    return;
+  }
+
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    params.append(prefix, String(value));
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => {
+      appendFormEntries(params, `${prefix}[${index}]`, item);
+    });
+    return;
+  }
+
+  for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+    const nextPrefix = prefix ? `${prefix}[${key}]` : key;
+    appendFormEntries(params, nextPrefix, nested);
+  }
+}
+
+function parseStripeSignature(header: string): {
+  timestamp: string;
+  signature: string;
+} {
+  const values = Object.fromEntries(
+    header.split(',')
+      .map((part) => part.trim().split('='))
+      .filter((entry): entry is [string, string] => entry.length === 2)
+  );
+
+  const timestamp = values.t;
+  const signature = values.v1;
+  if (!timestamp || !signature) {
+    throw new StripeApiError(400, 'Invalid Stripe signature header');
+  }
+
+  return {
+    timestamp,
+    signature
+  };
+}
+
+function readRequiredString(input: Record<string, any>, key: string): string {
+  const value = input[key];
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new StripeApiError(500, `Missing Stripe response field: ${key}`);
+  }
+  return value;
+}
+
+function readOptionalString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value : null;
+}
+
+function asRecord(value: unknown): Record<string, any> | null {
+  return typeof value === 'object' && value !== null ? value as Record<string, any> : null;
+}

--- a/api/src/services/runtime.ts
+++ b/api/src/services/runtime.ts
@@ -23,6 +23,12 @@ import { AnalyticsDashboardSnapshotRepository } from '../repos/analyticsDashboar
 import { RequestLogRepository } from '../repos/requestLogRepository.js';
 import { PilotIdentityRepository } from '../repos/pilotIdentityRepository.js';
 import { PilotAdmissionFreezeRepository } from '../repos/pilotAdmissionFreezeRepository.js';
+import { PaymentProfileRepository } from '../repos/paymentProfileRepository.js';
+import { PaymentMethodRepository } from '../repos/paymentMethodRepository.js';
+import { AutoRechargeSettingsRepository } from '../repos/autoRechargeSettingsRepository.js';
+import { PaymentAttemptRepository } from '../repos/paymentAttemptRepository.js';
+import { PaymentWebhookEventRepository } from '../repos/paymentWebhookEventRepository.js';
+import { PaymentOutcomeRepository } from '../repos/paymentOutcomeRepository.js';
 import { buildDefaultJobs } from '../jobs/registry.js';
 import { JobScheduler } from '../jobs/scheduler.js';
 import { KeyPool } from './keyPool.js';
@@ -37,6 +43,8 @@ import { PilotSessionService } from './pilot/pilotSessionService.js';
 import { PilotGithubAuthService } from './pilot/pilotGithubAuthService.js';
 import { PilotCutoverService } from './pilot/pilotCutoverService.js';
 import { WalletService } from './wallet/walletService.js';
+import { PaymentService } from './payments/paymentService.js';
+import { StripeClient } from './payments/stripeClient.js';
 import { assertRequiredEnv, readRequiredEnv } from '../utils/env.js';
 import { AppError } from '../utils/errors.js';
 
@@ -69,7 +77,13 @@ export const runtime = {
     requestLog: new RequestLogRepository(sql),
     pilotIdentity: new PilotIdentityRepository(sql),
     pilotAdmissionFreezes: new PilotAdmissionFreezeRepository(sql),
-    withdrawalRequests: new WithdrawalRequestRepository(sql)
+    withdrawalRequests: new WithdrawalRequestRepository(sql),
+    paymentProfiles: new PaymentProfileRepository(sql),
+    paymentMethods: new PaymentMethodRepository(sql),
+    autoRechargeSettings: new AutoRechargeSettingsRepository(sql),
+    paymentAttempts: new PaymentAttemptRepository(sql),
+    paymentWebhookEvents: new PaymentWebhookEventRepository(sql),
+    paymentOutcomes: new PaymentOutcomeRepository(sql)
   },
   services: {
     earningsProjector: undefined as unknown as EarningsProjectorService,
@@ -80,6 +94,7 @@ export const runtime = {
     pilotCutovers: undefined as unknown as PilotCutoverService,
     pilotGithubAuth: undefined as unknown as PilotGithubAuthService,
     pilotSessions: undefined as unknown as PilotSessionService,
+    payments: undefined as unknown as PaymentService,
     routerEngine: new RouterEngine(),
     routingService: undefined as unknown as RoutingService,
     tokenCredentials: undefined as unknown as TokenCredentialService,
@@ -142,11 +157,24 @@ runtime.services.tokenCredentials = new TokenCredentialService(
   runtime.repos.tokenCredentials,
   runtime.repos.auditLogs
 );
+runtime.services.payments = new PaymentService({
+  paymentProfiles: runtime.repos.paymentProfiles,
+  paymentMethods: runtime.repos.paymentMethods,
+  autoRechargeSettings: runtime.repos.autoRechargeSettings,
+  paymentAttempts: runtime.repos.paymentAttempts,
+  paymentOutcomes: runtime.repos.paymentOutcomes,
+  paymentWebhooks: runtime.repos.paymentWebhookEvents,
+  stripeClient: new StripeClient({
+    secretKey: process.env.STRIPE_SECRET_KEY || '',
+    webhookSecret: process.env.STRIPE_WEBHOOK_SECRET || ''
+  })
+});
 runtime.services.wallets = new WalletService({
   sql: runtime.sql,
   walletLedgerRepo: runtime.repos.walletLedger,
   canonicalMeteringRepo: runtime.repos.canonicalMetering,
-  meteringProjectorStateRepo: runtime.repos.meteringProjectorStates
+  meteringProjectorStateRepo: runtime.repos.meteringProjectorStates,
+  paymentsAdapter: runtime.services.payments
 });
 runtime.services.withdrawals = new WithdrawalService({
   sql: runtime.sql,

--- a/api/src/services/wallet/walletService.ts
+++ b/api/src/services/wallet/walletService.ts
@@ -1,5 +1,5 @@
 import { AppError } from '../../utils/errors.js';
-import type { SqlClient } from '../../repos/sqlClient.js';
+import type { SqlClient, TransactionContext } from '../../repos/sqlClient.js';
 import type {
   CanonicalMeteringEventRow,
   CanonicalMeteringRepository
@@ -16,8 +16,33 @@ import type {
 import { buildWalletProjectionEffects } from '../metering/ledgerProjectionContracts.js';
 import { walletIdForOrgId } from './walletBalance.js';
 import type { WalletEffectType } from '../../types/phase2Contracts.js';
+import type {
+  AutoRechargeAttemptResult,
+  AutoRechargeTrigger,
+  PaymentWalletEffectType
+} from '../payments/paymentTypes.js';
 
 export type WalletAdmissionTrigger = 'paid_team_capacity';
+
+type WalletPaymentsAdapter = {
+  attemptAutoRecharge(walletId: string, trigger: AutoRechargeTrigger): Promise<AutoRechargeAttemptResult>;
+  getNormalizedPaymentOutcome(input: {
+    processorEffectId: string;
+    effectType: PaymentWalletEffectType;
+  }): Promise<{
+    walletId: string;
+    ownerOrgId?: string;
+    processorEffectId: string;
+    effectType: PaymentWalletEffectType;
+    amountMinor: number;
+    currency: string;
+    metadata?: Record<string, unknown> | null;
+  } | null>;
+  markPaymentOutcomeRecorded(
+    processorEffectId: string,
+    db?: Pick<TransactionContext, 'query'>
+  ): Promise<void>;
+};
 
 export class WalletService {
   constructor(private readonly deps: {
@@ -25,6 +50,7 @@ export class WalletService {
     walletLedgerRepo: WalletLedgerRepository;
     canonicalMeteringRepo: CanonicalMeteringRepository;
     meteringProjectorStateRepo: MeteringProjectorStateRepository;
+    paymentsAdapter?: WalletPaymentsAdapter;
   }) {}
 
   async getWalletSnapshot(walletId: string): Promise<{
@@ -78,7 +104,31 @@ export class WalletService {
   }> {
     return this.deps.sql.transaction(async (tx) => {
       await tx.query('select pg_advisory_xact_lock(hashtext($1))', [input.walletId]);
-      const balance = await this.deps.walletLedgerRepo.readBalance(input.walletId, tx);
+      let balance = await this.readBalanceWithDb(input.walletId, tx);
+      if (balance.balanceMinor <= 0 && this.deps.paymentsAdapter) {
+        const recharge = await this.deps.paymentsAdapter.attemptAutoRecharge(input.walletId, 'admission_blocked');
+        if (recharge.kind === 'charge_succeeded') {
+          await this.recordPaymentOutcomeWithDb({
+            walletId: input.walletId,
+            processorEffectId: recharge.processorEffectId,
+            effectType: 'payment_credit'
+          }, tx);
+          balance = await this.readBalanceWithDb(input.walletId, tx);
+        } else if (recharge.kind === 'charge_failed' || recharge.kind === 'charge_pending' || recharge.kind === 'not_configured') {
+          throw new AppError(
+            'wallet_admission_denied',
+            402,
+            'Paid admission requires a positive wallet balance',
+            {
+              walletId: input.walletId,
+              balanceMinor: balance.balanceMinor,
+              trigger: input.trigger,
+              recharge
+            }
+          );
+        }
+      }
+
       if (balance.balanceMinor <= 0) {
         throw new AppError(
           'wallet_admission_denied',
@@ -115,14 +165,48 @@ export class WalletService {
       contributorEarningsMinor: event.contributor_earnings_minor
     });
 
-    for (const effect of effects) {
-      await this.deps.walletLedgerRepo.appendEntry(buildWalletProjectionInput(event, effect.effectType, effect.amountMinor));
-    }
+    await this.deps.sql.transaction(async (tx) => {
+      const walletId = walletIdForOrgId(event.consumer_org_id);
+      await tx.query('select pg_advisory_xact_lock(hashtext($1))', [walletId]);
+      const balanceBefore = await this.readBalanceWithDb(walletId, tx);
+
+      for (const effect of effects) {
+        await this.appendWalletEntryWithDb(
+          buildWalletProjectionInput(event, effect.effectType, effect.amountMinor),
+          tx
+        );
+      }
+
+      const balanceAfter = await this.readBalanceWithDb(walletId, tx);
+      if (
+        this.deps.paymentsAdapter
+        && effects.some((effect) => effect.effectType === 'buyer_debit')
+        && balanceBefore.balanceMinor >= 0
+        && balanceAfter.balanceMinor < 0
+      ) {
+        const recharge = await this.deps.paymentsAdapter.attemptAutoRecharge(walletId, 'post_finalization_negative');
+        if (recharge.kind === 'charge_succeeded') {
+          await this.recordPaymentOutcomeWithDb({
+            walletId,
+            processorEffectId: recharge.processorEffectId,
+            effectType: 'payment_credit'
+          }, tx);
+        }
+      }
+    });
 
     await this.deps.meteringProjectorStateRepo.markProjected({
       meteringEventId,
       projector: 'wallet'
     });
+  }
+
+  async recordPaymentOutcome(input: {
+    walletId: string;
+    processorEffectId: string;
+    effectType: PaymentWalletEffectType;
+  }): Promise<WalletLedgerRow> {
+    return this.recordPaymentOutcomeWithDb(input);
   }
 
   recordManualAdjustment(input: {
@@ -166,6 +250,73 @@ export class WalletService {
   walletIdForOrgId(orgId: string): string {
     return walletIdForOrgId(orgId);
   }
+
+  private async recordPaymentOutcomeWithDb(
+    input: {
+      walletId: string;
+      processorEffectId: string;
+      effectType: PaymentWalletEffectType;
+    },
+    tx?: Parameters<WalletLedgerRepository['appendEntryWithDb']>[1]
+  ): Promise<WalletLedgerRow> {
+    const paymentsAdapter = this.deps.paymentsAdapter;
+    if (!paymentsAdapter) {
+      throw new Error('payments adapter not configured');
+    }
+
+    const outcome = await paymentsAdapter.getNormalizedPaymentOutcome({
+      processorEffectId: input.processorEffectId,
+      effectType: input.effectType
+    });
+    if (!outcome) {
+      throw new AppError('payment_outcome_missing', 404, 'Normalized payment outcome not found', {
+        processorEffectId: input.processorEffectId,
+        effectType: input.effectType
+      });
+    }
+
+    const row = await this.appendWalletEntryWithDb({
+      walletId: input.walletId,
+      ownerOrgId: outcome.ownerOrgId ?? input.walletId,
+      effectType: outcome.effectType,
+      amountMinor: outcome.amountMinor,
+      currency: outcome.currency,
+      processorEffectId: outcome.processorEffectId,
+      metadata: outcome.metadata ?? undefined
+    }, tx);
+    await paymentsAdapter.markPaymentOutcomeRecorded(input.processorEffectId, tx);
+    return row;
+  }
+
+  private appendWalletEntryWithDb(
+    input: Parameters<WalletLedgerRepository['appendEntry']>[0],
+    tx?: Parameters<WalletLedgerRepository['appendEntryWithDb']>[1]
+  ): Promise<WalletLedgerRow> {
+    const repo = this.deps.walletLedgerRepo as WalletLedgerRepository & {
+      appendEntryWithDb?: (entry: Parameters<WalletLedgerRepository['appendEntry']>[0], db: Parameters<WalletLedgerRepository['appendEntryWithDb']>[1]) => Promise<WalletLedgerRow>;
+    };
+    if (tx && typeof repo.appendEntryWithDb === 'function') {
+      return repo.appendEntryWithDb(input, tx);
+    }
+    return repo.appendEntry(input);
+  }
+
+  private readBalanceWithDb(
+    walletId: string,
+    tx?: Parameters<WalletLedgerRepository['readBalance']>[1]
+  ): Promise<{ walletId: string; balanceMinor: number }> {
+    const repo = this.deps.walletLedgerRepo as WalletLedgerRepository & {
+      readBalance?: (walletId: string, db?: Parameters<WalletLedgerRepository['readBalance']>[1]) => Promise<{ walletId: string; balanceMinor: number }>;
+    };
+    if (typeof repo.readBalance === 'function') {
+      return repo.readBalance(walletId, tx);
+    }
+    return Promise.resolve({
+      walletId,
+      balanceMinor: 0
+    });
+  }
+
 }
 
 function buildWalletProjectionInput(

--- a/api/tests/darrynPaymentsRechargeMigrations.test.ts
+++ b/api/tests/darrynPaymentsRechargeMigrations.test.ts
@@ -1,0 +1,120 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const initMigrationPath = resolve(process.cwd(), '../docs/migrations/001_checkpoint1_init.sql');
+const hardCutoverMigrationPath = resolve(process.cwd(), '../docs/migrations/005_hard_cutover_in_prefix.sql');
+const foundationMigrationPath = resolve(process.cwd(), '../docs/migrations/017_darryn_foundation_contracts.sql');
+const cutoverAccessMigrationPath = resolve(process.cwd(), '../docs/migrations/018_darryn_cutover_access.sql');
+const routingMigrationPath = resolve(process.cwd(), '../docs/migrations/019_darryn_routing_metering.sql');
+const attributionMigrationPath = resolve(process.cwd(), '../docs/migrations/020_darryn_api_key_attribution.sql');
+const migrationPath = resolve(process.cwd(), '../docs/migrations/021_darryn_payments_recharge.sql');
+
+const initNoExtensionsMigrationPath = resolve(process.cwd(), '../docs/migrations/001_checkpoint1_init_no_extensions.sql');
+const hardCutoverNoExtensionsMigrationPath = resolve(process.cwd(), '../docs/migrations/005_hard_cutover_in_prefix_no_extensions.sql');
+const foundationNoExtensionsMigrationPath = resolve(process.cwd(), '../docs/migrations/017_darryn_foundation_contracts_no_extensions.sql');
+const cutoverAccessNoExtensionsMigrationPath = resolve(process.cwd(), '../docs/migrations/018_darryn_cutover_access_no_extensions.sql');
+const routingNoExtensionsMigrationPath = resolve(process.cwd(), '../docs/migrations/019_darryn_routing_metering_no_extensions.sql');
+const attributionNoExtensionsMigrationPath = resolve(process.cwd(), '../docs/migrations/020_darryn_api_key_attribution_no_extensions.sql');
+const noExtensionsMigrationPath = resolve(process.cwd(), '../docs/migrations/021_darryn_payments_recharge_no_extensions.sql');
+
+describe('darryn payments recharge migrations', () => {
+  it('adds the payment profile, method, auto-recharge, attempt, webhook, and outcome tables in the primary migration', () => {
+    const sql = readFileSync(migrationPath, 'utf8');
+
+    expect(sql).toContain('CREATE TABLE IF NOT EXISTS in_payment_profiles');
+    expect(sql).toContain('CREATE TABLE IF NOT EXISTS in_payment_methods');
+    expect(sql).toContain('CREATE TABLE IF NOT EXISTS in_auto_recharge_settings');
+    expect(sql).toContain('CREATE TABLE IF NOT EXISTS in_payment_attempts');
+    expect(sql).toContain('CREATE TABLE IF NOT EXISTS in_payment_webhook_events');
+    expect(sql).toContain('CREATE TABLE IF NOT EXISTS in_payment_outcomes');
+    expect(sql).toContain('idempotency_key text');
+    expect(sql).toContain('wallet_recorded_at timestamptz');
+    expect(sql).toContain("CHECK (effect_type IN ('payment_credit', 'payment_reversal'))");
+    expect(sql).toContain('CREATE UNIQUE INDEX IF NOT EXISTS uq_in_payment_attempts_wallet_pending_auto_recharge');
+    expect(sql).toContain('CREATE UNIQUE INDEX IF NOT EXISTS uq_in_payment_attempts_wallet_manual_topup_idempotency');
+  });
+
+  it('keeps the no-extensions migration aligned with the primary payment tables', () => {
+    const sql = readFileSync(noExtensionsMigrationPath, 'utf8');
+
+    expect(sql).toContain('CREATE TABLE IF NOT EXISTS in_payment_profiles');
+    expect(sql).toContain('CREATE TABLE IF NOT EXISTS in_payment_methods');
+    expect(sql).toContain('CREATE TABLE IF NOT EXISTS in_auto_recharge_settings');
+    expect(sql).toContain('CREATE TABLE IF NOT EXISTS in_payment_attempts');
+    expect(sql).toContain('CREATE TABLE IF NOT EXISTS in_payment_webhook_events');
+    expect(sql).toContain('CREATE TABLE IF NOT EXISTS in_payment_outcomes');
+    expect(sql).toContain('idempotency_key text');
+    expect(sql).toContain('wallet_recorded_at timestamptz');
+    expect(sql).toContain('CREATE UNIQUE INDEX IF NOT EXISTS uq_in_payment_attempts_wallet_manual_topup_idempotency');
+  });
+
+  it('references only tables that already exist in schema history or are created in the migration', () => {
+    const priorSql = [
+      readFileSync(initMigrationPath, 'utf8'),
+      readFileSync(hardCutoverMigrationPath, 'utf8'),
+      readFileSync(foundationMigrationPath, 'utf8'),
+      readFileSync(cutoverAccessMigrationPath, 'utf8'),
+      readFileSync(routingMigrationPath, 'utf8'),
+      readFileSync(attributionMigrationPath, 'utf8')
+    ].join('\n');
+    const sql = readFileSync(migrationPath, 'utf8');
+
+    expect(findUnresolvedTableDependencies(priorSql, sql)).toEqual([]);
+  });
+
+  it('keeps the no-extensions migration on the same dependency graph', () => {
+    const priorSql = [
+      readFileSync(initNoExtensionsMigrationPath, 'utf8'),
+      readFileSync(hardCutoverNoExtensionsMigrationPath, 'utf8'),
+      readFileSync(foundationNoExtensionsMigrationPath, 'utf8'),
+      readFileSync(cutoverAccessNoExtensionsMigrationPath, 'utf8'),
+      readFileSync(routingNoExtensionsMigrationPath, 'utf8'),
+      readFileSync(attributionNoExtensionsMigrationPath, 'utf8')
+    ].join('\n');
+    const sql = readFileSync(noExtensionsMigrationPath, 'utf8');
+
+    expect(findUnresolvedTableDependencies(priorSql, sql)).toEqual([]);
+  });
+});
+
+function findUnresolvedTableDependencies(priorSql: string, currentSql: string): string[] {
+  const availableTables = new Set<string>([
+    ...extractCreatedTables(priorSql),
+    ...extractRenamedTables(priorSql),
+    ...extractCreatedTables(currentSql)
+  ]);
+
+  const requiredTables = new Set<string>([
+    ...extractReferencedTables(currentSql),
+    ...extractAlteredTables(currentSql)
+  ]);
+
+  return Array.from(requiredTables)
+    .filter((table) => !availableTables.has(table))
+    .sort();
+}
+
+function extractCreatedTables(sql: string): string[] {
+  return extractMatches(sql, /CREATE TABLE IF NOT EXISTS ([a-z0-9_]+)/gi);
+}
+
+function extractRenamedTables(sql: string): string[] {
+  return extractMatches(sql, /ALTER TABLE IF EXISTS [a-z0-9_]+ RENAME TO ([a-z0-9_]+)/gi);
+}
+
+function extractReferencedTables(sql: string): string[] {
+  return extractMatches(sql, /REFERENCES ([a-z0-9_]+)\s*\(/gi);
+}
+
+function extractAlteredTables(sql: string): string[] {
+  return extractMatches(sql, /ALTER TABLE ([a-z0-9_]+)/gi);
+}
+
+function extractMatches(sql: string, pattern: RegExp): string[] {
+  const matches: string[] = [];
+  for (const match of sql.matchAll(pattern)) {
+    matches.push(match[1]);
+  }
+  return matches;
+}

--- a/api/tests/paymentMethodRepository.test.ts
+++ b/api/tests/paymentMethodRepository.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { PaymentMethodRepository } from '../src/repos/paymentMethodRepository.js';
+import { MockSqlClient } from './testHelpers.js';
+
+describe('PaymentMethodRepository', () => {
+  it('only selects active default payment methods', async () => {
+    const db = new MockSqlClient({
+      rows: [],
+      rowCount: 0
+    });
+    const repo = new PaymentMethodRepository(db);
+
+    await repo.findDefaultByWalletId('wallet_1');
+
+    expect(db.queries[0].sql).toContain("method.status = 'active'");
+  });
+});

--- a/api/tests/paymentOutcomeRepository.test.ts
+++ b/api/tests/paymentOutcomeRepository.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { PaymentOutcomeRepository } from '../src/repos/paymentOutcomeRepository.js';
+import { SequenceSqlClient } from './testHelpers.js';
+
+describe('PaymentOutcomeRepository', () => {
+  it('accepts webhook reconciliation when only processor event metadata differs from a sync placeholder row', async () => {
+    const db = new SequenceSqlClient([
+      { rows: [], rowCount: 0 },
+      {
+        rows: [{
+          id: 'payment_outcome_existing',
+          wallet_id: 'org_fnf',
+          owner_org_id: 'org_fnf',
+          payment_attempt_id: 'payment_attempt_1',
+          processor: 'stripe',
+          processor_event_id: 'sync:pi_1',
+          processor_effect_id: 'stripe:payment_intent:pi_1',
+          effect_type: 'payment_credit',
+          amount_minor: 2500,
+          currency: 'USD',
+          metadata: {
+            trigger: 'admission_blocked',
+            source: 'sync_auto_recharge'
+          },
+          created_at: '2026-03-20T10:31:00.000Z'
+        }],
+        rowCount: 1
+      }
+    ]);
+    const repo = new PaymentOutcomeRepository(db, () => 'payment_outcome_new');
+
+    const row = await repo.upsertOutcome({
+      walletId: 'org_fnf',
+      ownerOrgId: 'org_fnf',
+      paymentAttemptId: 'payment_attempt_1',
+      processorEventId: 'evt_1',
+      processorEffectId: 'stripe:payment_intent:pi_1',
+      effectType: 'payment_credit',
+      amountMinor: 2500,
+      currency: 'USD',
+      metadata: {
+        eventType: 'payment_intent.succeeded'
+      }
+    });
+
+    expect(row.id).toBe('payment_outcome_existing');
+  });
+});

--- a/api/tests/paymentProfileRepository.test.ts
+++ b/api/tests/paymentProfileRepository.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { PaymentProfileRepository } from '../src/repos/paymentProfileRepository.js';
+import { MockSqlClient } from './testHelpers.js';
+
+describe('PaymentProfileRepository', () => {
+  it('preserves the existing processor customer on wallet conflict', async () => {
+    const db = new MockSqlClient({
+      rows: [{
+        id: 'payment_profile_1',
+        wallet_id: 'wallet_1',
+        owner_org_id: 'org_fnf',
+        processor: 'stripe',
+        processor_customer_id: 'cus_existing',
+        default_payment_method_id: null,
+        created_at: '2026-03-21T12:00:00.000Z',
+        updated_at: '2026-03-21T12:00:00.000Z'
+      }],
+      rowCount: 1
+    });
+    const repo = new PaymentProfileRepository(db, () => 'payment_profile_1');
+
+    await repo.ensureProfile({
+      walletId: 'wallet_1',
+      ownerOrgId: 'org_fnf',
+      processorCustomerId: 'cus_new'
+    });
+
+    expect(db.queries[0].sql).not.toContain('processor_customer_id = excluded.processor_customer_id');
+  });
+});

--- a/api/tests/paymentService.test.ts
+++ b/api/tests/paymentService.test.ts
@@ -1,0 +1,983 @@
+import { describe, expect, it, vi } from 'vitest';
+import { PaymentService } from '../src/services/payments/paymentService.js';
+import { MockSqlClient } from './testHelpers.js';
+
+describe('PaymentService', () => {
+  it('returns not_configured when auto-recharge is disabled or no active stored method exists', async () => {
+    const service = new PaymentService({
+      sql: new MockSqlClient(),
+      paymentProfiles: {
+        findByWalletId: vi.fn().mockResolvedValue({
+          wallet_id: 'org_fnf',
+          owner_org_id: 'org_fnf',
+          processor_customer_id: 'cus_1',
+          default_payment_method_id: null
+        })
+      } as any,
+      paymentMethods: {
+        findDefaultByWalletId: vi.fn().mockResolvedValue(null)
+      } as any,
+      autoRechargeSettings: {
+        findByWalletId: vi.fn().mockResolvedValue({
+          wallet_id: 'org_fnf',
+          enabled: false,
+          amount_minor: 2500,
+          currency: 'USD'
+        })
+      } as any,
+      paymentAttempts: {} as any,
+      paymentOutcomes: {
+        findLatestUnrecordedAutoRechargeCreditByWalletId: vi.fn().mockResolvedValue(null)
+      } as any,
+      paymentWebhooks: {} as any,
+      stripeClient: {} as any
+    });
+
+    await expect(service.attemptAutoRecharge('org_fnf', 'admission_blocked')).resolves.toEqual({
+      kind: 'not_configured'
+    });
+  });
+
+  it('returns an existing pending attempt instead of starting a second auto-recharge', async () => {
+    const createOffSessionCharge = vi.fn();
+    const service = new PaymentService({
+      sql: new MockSqlClient(),
+      paymentProfiles: {
+        findByWalletId: vi.fn().mockResolvedValue({
+          wallet_id: 'org_fnf',
+          owner_org_id: 'org_fnf',
+          processor_customer_id: 'cus_1',
+          default_payment_method_id: 'paymeth_local_1'
+        })
+      } as any,
+      paymentMethods: {
+        findDefaultByWalletId: vi.fn().mockResolvedValue({
+          id: 'paymeth_local_1',
+          wallet_id: 'org_fnf',
+          processor_payment_method_id: 'pm_1',
+          status: 'active'
+        })
+      } as any,
+      autoRechargeSettings: {
+        findByWalletId: vi.fn().mockResolvedValue({
+          wallet_id: 'org_fnf',
+          enabled: true,
+          amount_minor: 2500,
+          currency: 'USD'
+        })
+      } as any,
+      paymentAttempts: {
+        findPendingAutoRechargeByWalletId: vi.fn().mockResolvedValue({
+          id: 'payment_attempt_pending'
+        })
+      } as any,
+      paymentOutcomes: {
+        findLatestUnrecordedAutoRechargeCreditByWalletId: vi.fn().mockResolvedValue(null)
+      } as any,
+      paymentWebhooks: {} as any,
+      stripeClient: {
+        createOffSessionCharge
+      } as any
+    });
+
+    await expect(service.attemptAutoRecharge('org_fnf', 'admission_blocked')).resolves.toEqual({
+      kind: 'charge_pending',
+      paymentAttemptId: 'payment_attempt_pending'
+    });
+    expect(createOffSessionCharge).not.toHaveBeenCalled();
+  });
+
+  it('reuses a succeeded auto-recharge outcome that is still waiting on wallet recording', async () => {
+    const createAttempt = vi.fn().mockResolvedValue({
+      id: 'payment_attempt_new'
+    });
+    const createOffSessionCharge = vi.fn().mockResolvedValue({
+      kind: 'succeeded',
+      paymentIntentId: 'pi_new'
+    });
+    const service = new PaymentService({
+      sql: new MockSqlClient(),
+      paymentProfiles: {} as any,
+      paymentMethods: {
+        findDefaultByWalletId: vi.fn().mockResolvedValue({
+          id: 'paymeth_local_1',
+          wallet_id: 'org_fnf',
+          processor_customer_id: 'cus_1',
+          processor_payment_method_id: 'pm_1',
+          status: 'active'
+        })
+      } as any,
+      autoRechargeSettings: {
+        findByWalletId: vi.fn().mockResolvedValue({
+          wallet_id: 'org_fnf',
+          owner_org_id: 'org_fnf',
+          enabled: true,
+          amount_minor: 2500,
+          currency: 'USD'
+        })
+      } as any,
+      paymentAttempts: {
+        findPendingAutoRechargeByWalletId: vi.fn().mockResolvedValue(null),
+        createAttempt
+      } as any,
+      paymentOutcomes: {
+        findLatestUnrecordedAutoRechargeCreditByWalletId: vi.fn().mockResolvedValue({
+          id: 'payment_outcome_1',
+          wallet_id: 'org_fnf',
+          owner_org_id: 'org_fnf',
+          payment_attempt_id: 'payment_attempt_existing',
+          processor: 'stripe',
+          processor_event_id: 'sync:pi_existing',
+          processor_effect_id: 'stripe:payment_intent:pi_existing',
+          effect_type: 'payment_credit',
+          amount_minor: 2500,
+          currency: 'USD',
+          metadata: {
+            source: 'sync_auto_recharge'
+          },
+          created_at: '2026-03-21T10:31:00.000Z'
+        })
+      } as any,
+      paymentWebhooks: {} as any,
+      stripeClient: {
+        createOffSessionCharge
+      } as any
+    });
+
+    await expect(service.attemptAutoRecharge('org_fnf', 'admission_blocked')).resolves.toEqual({
+      kind: 'charge_succeeded',
+      processorEffectId: 'stripe:payment_intent:pi_existing'
+    });
+    expect(createAttempt).not.toHaveBeenCalled();
+    expect(createOffSessionCharge).not.toHaveBeenCalled();
+  });
+
+  it('reuses the existing manual top-up attempt when the same idempotency key races', async () => {
+    const createAttempt = vi.fn().mockRejectedValueOnce(Object.assign(new Error('duplicate key'), {
+      code: '23505'
+    }));
+    const findManualTopUpByIdempotencyKey = vi.fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        id: 'payment_attempt_topup_existing',
+        wallet_id: 'org_fnf',
+        owner_org_id: 'org_fnf',
+        payment_method_id: null,
+        processor: 'stripe',
+        kind: 'manual_topup',
+        trigger: null,
+        status: 'pending',
+        amount_minor: 5000,
+        currency: 'USD',
+        processor_checkout_session_id: null,
+        processor_payment_intent_id: null,
+        processor_effect_id: null,
+        initiated_by_user_id: 'user_darryn',
+        last_error_code: null,
+        last_error_message: null,
+        metadata: {
+          source: 'pilot_dashboard',
+          returnTo: '/pilot'
+        },
+        created_at: '2026-03-21T12:00:00.000Z',
+        updated_at: '2026-03-21T12:00:00.000Z'
+      });
+    const createPaymentSession = vi.fn().mockResolvedValue({
+      id: 'cs_topup_existing',
+      url: 'https://checkout.stripe.test/topup-existing'
+    });
+    const markProcessing = vi.fn().mockResolvedValue(undefined);
+
+    const service = new PaymentService({
+      sql: new MockSqlClient(),
+      paymentProfiles: {
+        findByWalletId: vi.fn().mockResolvedValue({
+          id: 'payment_profile_1',
+          wallet_id: 'org_fnf',
+          owner_org_id: 'org_fnf',
+          processor_customer_id: 'cus_1',
+          default_payment_method_id: 'paymeth_local_1'
+        })
+      } as any,
+      paymentMethods: {} as any,
+      autoRechargeSettings: {} as any,
+      paymentAttempts: {
+        findManualTopUpByIdempotencyKey,
+        createAttempt,
+        markProcessing
+      } as any,
+      paymentOutcomes: {} as any,
+      paymentWebhooks: {} as any,
+      stripeClient: {
+        createPaymentSession
+      } as any
+    });
+
+    await expect(service.createTopUpSession({
+      walletId: 'org_fnf',
+      ownerOrgId: 'org_fnf',
+      requestedByUserId: 'user_darryn',
+      amountMinor: 5000,
+      returnTo: '/pilot',
+      idempotencyKey: 'manual-topup-idempotency-key-0001'
+    } as any)).resolves.toEqual({
+      checkoutUrl: 'https://checkout.stripe.test/topup-existing'
+    });
+
+    expect(createAttempt).toHaveBeenCalledTimes(1);
+    expect(findManualTopUpByIdempotencyKey).toHaveBeenCalledTimes(2);
+    expect(createPaymentSession).toHaveBeenCalledWith(expect.objectContaining({
+      customerId: 'cus_1',
+      amountMinor: 5000,
+      idempotencyKey: 'manual-topup-idempotency-key-0001',
+      metadata: expect.objectContaining({
+        wallet_id: 'org_fnf',
+        owner_org_id: 'org_fnf',
+        payment_attempt_id: 'payment_attempt_topup_existing'
+      })
+    }));
+    expect(markProcessing).toHaveBeenCalledWith({
+      attemptId: 'payment_attempt_topup_existing',
+      processorCheckoutSessionId: 'cs_topup_existing'
+    });
+  });
+
+  it('falls back to /pilot checkout URLs when returnTo uses a slash-backslash host bypass', async () => {
+    const createSetupSession = vi.fn().mockResolvedValue({
+      id: 'seti_1',
+      url: 'https://checkout.stripe.test/setup'
+    });
+    const service = new PaymentService({
+      sql: new MockSqlClient(),
+      paymentProfiles: {
+        findByWalletId: vi.fn().mockResolvedValue({
+          id: 'payment_profile_1',
+          wallet_id: 'org_fnf',
+          owner_org_id: 'org_fnf',
+          processor: 'stripe',
+          processor_customer_id: 'cus_1',
+          default_payment_method_id: null,
+          created_at: '2026-03-21T12:00:00.000Z',
+          updated_at: '2026-03-21T12:00:00.000Z'
+        })
+      } as any,
+      paymentMethods: {} as any,
+      autoRechargeSettings: {} as any,
+      paymentAttempts: {} as any,
+      paymentOutcomes: {} as any,
+      paymentWebhooks: {} as any,
+      stripeClient: {
+        createSetupSession
+      } as any
+    });
+
+    await service.createSetupSession({
+      walletId: 'org_fnf',
+      ownerOrgId: 'org_fnf',
+      requestedByUserId: 'user_darryn',
+      returnTo: '/\\evil.example.com'
+    });
+
+    expect(createSetupSession).toHaveBeenCalledWith(expect.objectContaining({
+      successUrl: 'http://localhost:3000/pilot',
+      cancelUrl: 'http://localhost:3000/pilot'
+    }));
+  });
+
+  it('rejects setup-intent webhooks whose customer id does not match the wallet payment profile', async () => {
+    const retrievePaymentMethod = vi.fn();
+    const upsertMethod = vi.fn();
+    const setDefaultPaymentMethod = vi.fn();
+    const service = new PaymentService({
+      sql: new MockSqlClient(),
+      paymentProfiles: {
+        findByWalletId: vi.fn().mockResolvedValue({
+          id: 'payment_profile_1',
+          wallet_id: 'org_fnf',
+          owner_org_id: 'org_fnf',
+          processor: 'stripe',
+          processor_customer_id: 'cus_canonical',
+          default_payment_method_id: null,
+          created_at: '2026-03-21T12:00:00.000Z',
+          updated_at: '2026-03-21T12:00:00.000Z'
+        }),
+        ensureProfile: vi.fn(),
+        setDefaultPaymentMethod
+      } as any,
+      paymentMethods: {
+        upsertMethod
+      } as any,
+      autoRechargeSettings: {
+        findByWalletId: vi.fn().mockResolvedValue(null)
+      } as any,
+      paymentAttempts: {} as any,
+      paymentOutcomes: {} as any,
+      paymentWebhooks: {
+        claimEvent: vi.fn().mockResolvedValue({
+          state: 'claimed',
+          processorEventId: 'evt_setup_wrong_customer'
+        }),
+        markProcessed: vi.fn().mockResolvedValue(undefined)
+      } as any,
+      stripeClient: {
+        constructWebhookEvent: vi.fn().mockReturnValue({
+          id: 'evt_setup_wrong_customer',
+          type: 'setup_intent.succeeded',
+          data: {
+            object: {
+              id: 'seti_1',
+              customer: 'cus_other',
+              payment_method: 'pm_1',
+              metadata: {
+                wallet_id: 'org_fnf',
+                owner_org_id: 'org_fnf'
+              }
+            }
+          }
+        }),
+        retrievePaymentMethod
+      } as any
+    });
+
+    await expect(service.processWebhook({
+      signatureHeader: 'stripe-signature',
+      rawBody: '{"id":"evt_setup_wrong_customer"}'
+    })).rejects.toThrow('payment profile customer mismatch');
+
+    expect(retrievePaymentMethod).not.toHaveBeenCalled();
+    expect(upsertMethod).not.toHaveBeenCalled();
+    expect(setDefaultPaymentMethod).not.toHaveBeenCalled();
+  });
+
+  it('omits detached default payment methods from funding state', async () => {
+    const service = new PaymentService({
+      sql: new MockSqlClient(),
+      paymentProfiles: {} as any,
+      paymentMethods: {
+        findDefaultByWalletId: vi.fn().mockResolvedValue({
+          id: 'paymeth_detached',
+          wallet_id: 'org_fnf',
+          owner_org_id: 'org_fnf',
+          payment_profile_id: 'payment_profile_1',
+          processor: 'stripe',
+          processor_payment_method_id: 'pm_detached',
+          processor_customer_id: 'cus_1',
+          brand: 'visa',
+          last4: '4242',
+          exp_month: 12,
+          exp_year: 2031,
+          funding: 'credit',
+          status: 'detached',
+          created_at: '2026-03-21T12:00:00.000Z',
+          updated_at: '2026-03-21T12:00:00.000Z',
+          detached_at: '2026-03-21T12:05:00.000Z'
+        })
+      } as any,
+      autoRechargeSettings: {
+        findByWalletId: vi.fn().mockResolvedValue(null)
+      } as any,
+      paymentAttempts: {
+        listRecentByWalletId: vi.fn().mockResolvedValue([])
+      } as any,
+      paymentOutcomes: {} as any,
+      paymentWebhooks: {} as any,
+      stripeClient: {} as any
+    });
+
+    await expect(service.getFundingState({
+      walletId: 'org_fnf',
+      ownerOrgId: 'org_fnf'
+    })).resolves.toEqual({
+      paymentMethod: null,
+      autoRecharge: {
+        enabled: false,
+        amountMinor: 2500,
+        currency: 'USD'
+      },
+      attempts: []
+    });
+  });
+
+  it('treats detached default methods as not configured for auto-recharge attempts', async () => {
+    const createOffSessionCharge = vi.fn();
+    const service = new PaymentService({
+      sql: new MockSqlClient(),
+      paymentProfiles: {
+        findByWalletId: vi.fn().mockResolvedValue({
+          wallet_id: 'org_fnf',
+          owner_org_id: 'org_fnf',
+          processor_customer_id: 'cus_1',
+          default_payment_method_id: 'paymeth_detached'
+        })
+      } as any,
+      paymentMethods: {
+        findDefaultByWalletId: vi.fn().mockResolvedValue({
+          id: 'paymeth_detached',
+          wallet_id: 'org_fnf',
+          payment_profile_id: 'payment_profile_1',
+          owner_org_id: 'org_fnf',
+          processor_payment_method_id: 'pm_detached',
+          processor_customer_id: 'cus_1',
+          brand: 'visa',
+          last4: '4242',
+          exp_month: 12,
+          exp_year: 2031,
+          funding: 'credit',
+          status: 'detached'
+        })
+      } as any,
+      autoRechargeSettings: {
+        findByWalletId: vi.fn().mockResolvedValue({
+          wallet_id: 'org_fnf',
+          owner_org_id: 'org_fnf',
+          enabled: true,
+          amount_minor: 2500,
+          currency: 'USD'
+        })
+      } as any,
+      paymentAttempts: {
+        findPendingAutoRechargeByWalletId: vi.fn().mockResolvedValue(null)
+      } as any,
+      paymentOutcomes: {
+        findLatestUnrecordedAutoRechargeCreditByWalletId: vi.fn().mockResolvedValue(null)
+      } as any,
+      paymentWebhooks: {} as any,
+      stripeClient: {
+        createOffSessionCharge
+      } as any
+    });
+
+    await expect(service.attemptAutoRecharge('org_fnf', 'admission_blocked')).resolves.toEqual({
+      kind: 'not_configured'
+    });
+    expect(createOffSessionCharge).not.toHaveBeenCalled();
+  });
+
+  it('reuses an unrecorded auto-recharge credit before stale settings or pending attempts can mask it', async () => {
+    const findDefaultByWalletId = vi.fn();
+    const findPendingAutoRechargeByWalletId = vi.fn();
+    const service = new PaymentService({
+      sql: new MockSqlClient(),
+      paymentProfiles: {} as any,
+      paymentMethods: {
+        findDefaultByWalletId
+      } as any,
+      autoRechargeSettings: {
+        findByWalletId: vi.fn().mockResolvedValue({
+          wallet_id: 'org_fnf',
+          owner_org_id: 'org_fnf',
+          enabled: false,
+          amount_minor: 2500,
+          currency: 'USD'
+        })
+      } as any,
+      paymentAttempts: {
+        findPendingAutoRechargeByWalletId
+      } as any,
+      paymentOutcomes: {
+        findLatestUnrecordedAutoRechargeCreditByWalletId: vi.fn().mockResolvedValue({
+          id: 'payment_outcome_1',
+          wallet_id: 'org_fnf',
+          owner_org_id: 'org_fnf',
+          payment_attempt_id: 'payment_attempt_1',
+          processor: 'stripe',
+          processor_event_id: 'sync:pi_existing',
+          processor_effect_id: 'stripe:payment_intent:pi_existing',
+          effect_type: 'payment_credit',
+          amount_minor: 2500,
+          currency: 'USD',
+          metadata: {
+            source: 'sync_auto_recharge'
+          },
+          wallet_recorded_at: null,
+          created_at: '2026-03-21T12:00:00.000Z'
+        })
+      } as any,
+      paymentWebhooks: {} as any,
+      stripeClient: {} as any
+    });
+
+    await expect(service.attemptAutoRecharge('org_fnf', 'admission_blocked')).resolves.toEqual({
+      kind: 'charge_succeeded',
+      processorEffectId: 'stripe:payment_intent:pi_existing'
+    });
+    expect(findDefaultByWalletId).not.toHaveBeenCalled();
+    expect(findPendingAutoRechargeByWalletId).not.toHaveBeenCalled();
+  });
+
+  it('normalizes a succeeded payment-intent webhook into a wallet payment credit outcome', async () => {
+    const recordOutcome = vi.fn().mockResolvedValue({
+      id: 'payment_outcome_1',
+      wallet_id: 'org_fnf',
+      owner_org_id: 'org_fnf',
+      payment_attempt_id: 'payment_attempt_1',
+      processor: 'stripe',
+      processor_event_id: 'evt_1',
+      processor_effect_id: 'stripe:payment_intent:pi_1',
+      effect_type: 'payment_credit',
+      amount_minor: 2500,
+      currency: 'USD',
+      metadata: {
+        eventType: 'payment_intent.succeeded'
+      },
+      created_at: '2026-03-20T10:31:00.000Z'
+    });
+    const markSucceeded = vi.fn().mockResolvedValue(undefined);
+    const service = new PaymentService({
+      sql: new MockSqlClient(),
+      paymentProfiles: {} as any,
+      paymentMethods: {} as any,
+      autoRechargeSettings: {} as any,
+      paymentAttempts: {
+        markSucceeded
+      } as any,
+      paymentOutcomes: {
+        upsertOutcome: recordOutcome
+      } as any,
+      paymentWebhooks: {
+        claimEvent: vi.fn().mockResolvedValue({
+          state: 'claimed',
+          processorEventId: 'evt_1'
+        }),
+        markProcessed: vi.fn().mockResolvedValue(undefined)
+      } as any,
+      stripeClient: {
+        constructWebhookEvent: vi.fn().mockReturnValue({
+          id: 'evt_1',
+          type: 'payment_intent.succeeded',
+          data: {
+            object: {
+              id: 'pi_1',
+              amount: 2500,
+              currency: 'usd',
+              metadata: {
+                wallet_id: 'org_fnf',
+                payment_attempt_id: 'payment_attempt_1'
+              }
+            }
+          }
+        })
+      } as any
+    });
+
+    const result = await service.processWebhook({
+      signatureHeader: 'stripe-signature',
+      rawBody: '{"id":"evt_1"}'
+    });
+
+    expect(recordOutcome).toHaveBeenCalledWith(expect.objectContaining({
+      walletId: 'org_fnf',
+      processorEffectId: 'stripe:payment_intent:pi_1',
+      effectType: 'payment_credit',
+      amountMinor: 2500,
+      currency: 'USD',
+      paymentAttemptId: 'payment_attempt_1',
+      processorEventId: 'evt_1'
+    }));
+    expect(markSucceeded).toHaveBeenCalledWith(expect.objectContaining({
+      attemptId: 'payment_attempt_1',
+      processorEffectId: 'stripe:payment_intent:pi_1'
+    }));
+    expect(result).toEqual({
+      accepted: true,
+      processorEventId: 'evt_1',
+      outcomes: [expect.objectContaining({
+        walletId: 'org_fnf',
+        processorEffectId: 'stripe:payment_intent:pi_1',
+        effectType: 'payment_credit'
+      })]
+    });
+  });
+
+  it('reprocesses an existing unprocessed webhook event instead of swallowing the retry', async () => {
+    const recordOutcome = vi.fn().mockResolvedValue({
+      id: 'payment_outcome_1',
+      wallet_id: 'org_fnf',
+      owner_org_id: 'org_fnf',
+      payment_attempt_id: 'payment_attempt_1',
+      processor: 'stripe',
+      processor_event_id: 'evt_retry',
+      processor_effect_id: 'stripe:payment_intent:pi_retry',
+      effect_type: 'payment_credit',
+      amount_minor: 2500,
+      currency: 'USD',
+      metadata: {
+        eventType: 'payment_intent.succeeded'
+      },
+      created_at: '2026-03-20T10:31:00.000Z'
+    });
+    const service = new PaymentService({
+      sql: new MockSqlClient(),
+      paymentProfiles: {} as any,
+      paymentMethods: {} as any,
+      autoRechargeSettings: {} as any,
+      paymentAttempts: {
+        markSucceeded: vi.fn().mockResolvedValue(undefined)
+      } as any,
+      paymentOutcomes: {
+        upsertOutcome: recordOutcome
+      } as any,
+      paymentWebhooks: {
+        claimEvent: vi.fn().mockResolvedValue({
+          state: 'pending_retry',
+          processorEventId: 'evt_retry'
+        }),
+        markProcessed: vi.fn().mockResolvedValue(undefined)
+      } as any,
+      stripeClient: {
+        constructWebhookEvent: vi.fn().mockReturnValue({
+          id: 'evt_retry',
+          type: 'payment_intent.succeeded',
+          data: {
+            object: {
+              id: 'pi_retry',
+              amount: 2500,
+              currency: 'usd',
+              metadata: {
+                wallet_id: 'org_fnf',
+                payment_attempt_id: 'payment_attempt_1'
+              }
+            }
+          }
+        })
+      } as any
+    });
+
+    const result = await service.processWebhook({
+      signatureHeader: 'stripe-signature',
+      rawBody: '{"id":"evt_retry"}'
+    });
+
+    expect(recordOutcome).toHaveBeenCalledTimes(1);
+    expect(result.processorEventId).toBe('evt_retry');
+    expect(result.outcomes).toHaveLength(1);
+  });
+
+  it('records partial refund deltas instead of the charge cumulative refunded total', async () => {
+    const recordOutcome = vi.fn().mockResolvedValue({
+      id: 'payment_outcome_refund',
+      wallet_id: 'org_fnf',
+      owner_org_id: 'org_fnf',
+      payment_attempt_id: 'payment_attempt_1',
+      processor: 'stripe',
+      processor_event_id: 'evt_refund',
+      processor_effect_id: 'stripe:refund:re_2',
+      effect_type: 'payment_reversal',
+      amount_minor: 100,
+      currency: 'USD',
+      metadata: {
+        eventType: 'charge.refunded'
+      },
+      created_at: '2026-03-20T10:31:00.000Z'
+    });
+    const service = new PaymentService({
+      sql: new MockSqlClient(),
+      paymentProfiles: {} as any,
+      paymentMethods: {} as any,
+      autoRechargeSettings: {} as any,
+      paymentAttempts: {} as any,
+      paymentOutcomes: {
+        upsertOutcome: recordOutcome,
+        findByProcessorEffectId: vi.fn().mockResolvedValue({
+          id: 'payment_outcome_credit',
+          wallet_id: 'org_fnf',
+          owner_org_id: 'org_fnf',
+          payment_attempt_id: 'payment_attempt_1',
+          processor: 'stripe',
+          processor_event_id: 'evt_credit',
+          processor_effect_id: 'stripe:payment_intent:pi_1',
+          effect_type: 'payment_credit',
+          amount_minor: 200,
+          currency: 'USD',
+          metadata: null,
+          created_at: '2026-03-20T10:00:00.000Z'
+        })
+      } as any,
+      paymentWebhooks: {
+        claimEvent: vi.fn().mockResolvedValue({
+          state: 'claimed',
+          processorEventId: 'evt_refund'
+        }),
+        markProcessed: vi.fn().mockResolvedValue(undefined)
+      } as any,
+      stripeClient: {
+        constructWebhookEvent: vi.fn().mockReturnValue({
+          id: 'evt_refund',
+          type: 'charge.refunded',
+          data: {
+            object: {
+              id: 'ch_1',
+              payment_intent: 'pi_1',
+              amount_refunded: 200,
+              currency: 'usd',
+              refunds: {
+                data: [
+                  { id: 're_2', amount: 100 },
+                  { id: 're_1', amount: 100 }
+                ]
+              }
+            }
+          }
+        })
+      } as any
+    });
+
+    await service.processWebhook({
+      signatureHeader: 'stripe-signature',
+      rawBody: '{"id":"evt_refund"}'
+    });
+
+    expect(recordOutcome).toHaveBeenCalledWith(expect.objectContaining({
+      processorEffectId: 'stripe:refund:re_2',
+      amountMinor: 100
+    }));
+  });
+
+  it('normalizes refund.created webhooks from the refund object instead of charge refund list ordering', async () => {
+    const recordOutcome = vi.fn().mockResolvedValue({
+      id: 'payment_outcome_refund',
+      wallet_id: 'org_fnf',
+      owner_org_id: 'org_fnf',
+      payment_attempt_id: 'payment_attempt_1',
+      processor: 'stripe',
+      processor_event_id: 'evt_refund_created',
+      processor_effect_id: 'stripe:refund:re_2',
+      effect_type: 'payment_reversal',
+      amount_minor: 100,
+      currency: 'USD',
+      metadata: {
+        eventType: 'refund.created'
+      },
+      created_at: '2026-03-20T10:31:00.000Z'
+    });
+    const service = new PaymentService({
+      sql: new MockSqlClient(),
+      paymentProfiles: {} as any,
+      paymentMethods: {} as any,
+      autoRechargeSettings: {} as any,
+      paymentAttempts: {} as any,
+      paymentOutcomes: {
+        upsertOutcome: recordOutcome,
+        findByProcessorEffectId: vi.fn().mockResolvedValue({
+          id: 'payment_outcome_credit',
+          wallet_id: 'org_fnf',
+          owner_org_id: 'org_fnf',
+          payment_attempt_id: 'payment_attempt_1',
+          processor: 'stripe',
+          processor_event_id: 'evt_credit',
+          processor_effect_id: 'stripe:payment_intent:pi_1',
+          effect_type: 'payment_credit',
+          amount_minor: 200,
+          currency: 'USD',
+          metadata: null,
+          created_at: '2026-03-20T10:00:00.000Z'
+        })
+      } as any,
+      paymentWebhooks: {
+        claimEvent: vi.fn().mockResolvedValue({
+          state: 'claimed',
+          processorEventId: 'evt_refund_created'
+        }),
+        markProcessed: vi.fn().mockResolvedValue(undefined)
+      } as any,
+      stripeClient: {
+        constructWebhookEvent: vi.fn().mockReturnValue({
+          id: 'evt_refund_created',
+          type: 'refund.created',
+          data: {
+            object: {
+              id: 're_2',
+              payment_intent: 'pi_1',
+              amount: 100,
+              currency: 'usd'
+            }
+          }
+        })
+      } as any
+    });
+
+    await service.processWebhook({
+      signatureHeader: 'stripe-signature',
+      rawBody: '{"id":"evt_refund_created"}'
+    });
+
+    expect(recordOutcome).toHaveBeenCalledWith(expect.objectContaining({
+      processorEventId: 'evt_refund_created',
+      processorEffectId: 'stripe:refund:re_2',
+      amountMinor: 100,
+      effectType: 'payment_reversal'
+    }));
+  });
+
+  it('does not acknowledge charge.refunded before the original payment credit exists', async () => {
+    const service = new PaymentService({
+      sql: new MockSqlClient(),
+      paymentProfiles: {} as any,
+      paymentMethods: {} as any,
+      autoRechargeSettings: {} as any,
+      paymentAttempts: {} as any,
+      paymentOutcomes: {
+        findByProcessorEffectId: vi.fn().mockResolvedValue(null)
+      } as any,
+      paymentWebhooks: {
+        claimEvent: vi.fn().mockResolvedValue({
+          state: 'claimed',
+          processorEventId: 'evt_refund_pending_credit'
+        }),
+        markProcessed: vi.fn().mockResolvedValue(undefined)
+      } as any,
+      stripeClient: {
+        constructWebhookEvent: vi.fn().mockReturnValue({
+          id: 'evt_refund_pending_credit',
+          type: 'charge.refunded',
+          data: {
+            object: {
+              id: 'ch_1',
+              payment_intent: 'pi_missing',
+              amount_refunded: 100,
+              currency: 'usd',
+              refunds: {
+                data: [
+                  { id: 're_1', amount: 100 }
+                ]
+              }
+            }
+          }
+        })
+      } as any
+    });
+
+    await expect(service.processWebhook({
+      signatureHeader: 'stripe-signature',
+      rawBody: '{"id":"evt_refund_pending_credit"}'
+    })).rejects.toThrow('original payment credit outcome not found');
+  });
+
+  it('does not acknowledge dispute reversals before the original payment credit exists', async () => {
+    const service = new PaymentService({
+      sql: new MockSqlClient(),
+      paymentProfiles: {} as any,
+      paymentMethods: {} as any,
+      autoRechargeSettings: {} as any,
+      paymentAttempts: {} as any,
+      paymentOutcomes: {
+        findByProcessorEffectId: vi.fn().mockResolvedValue(null)
+      } as any,
+      paymentWebhooks: {
+        claimEvent: vi.fn().mockResolvedValue({
+          state: 'claimed',
+          processorEventId: 'evt_dispute_pending_credit'
+        }),
+        markProcessed: vi.fn().mockResolvedValue(undefined)
+      } as any,
+      stripeClient: {
+        constructWebhookEvent: vi.fn().mockReturnValue({
+          id: 'evt_dispute_pending_credit',
+          type: 'charge.dispute.funds_withdrawn',
+          data: {
+            object: {
+              id: 'dp_1',
+              payment_intent: 'pi_missing',
+              amount: 2500,
+              currency: 'usd'
+            }
+          }
+        })
+      } as any
+    });
+
+    await expect(service.processWebhook({
+      signatureHeader: 'stripe-signature',
+      rawBody: '{"id":"evt_dispute_pending_credit"}'
+    })).rejects.toThrow('original payment credit outcome not found');
+  });
+
+  it('keeps the active default method and auto-recharge settings when Stripe detaches a non-default card', async () => {
+    const markDetached = vi.fn().mockResolvedValue(undefined);
+    const setDefaultPaymentMethod = vi.fn().mockResolvedValue(undefined);
+    const upsertSettings = vi.fn().mockResolvedValue(undefined);
+    const service = new PaymentService({
+      sql: new MockSqlClient(),
+      paymentProfiles: {
+        findByWalletId: vi.fn().mockResolvedValue({
+          id: 'payment_profile_1',
+          wallet_id: 'org_fnf',
+          owner_org_id: 'org_fnf',
+          processor: 'stripe',
+          processor_customer_id: 'cus_1',
+          default_payment_method_id: 'paymeth_default',
+          created_at: '2026-03-21T12:00:00.000Z',
+          updated_at: '2026-03-21T12:00:00.000Z'
+        }),
+        setDefaultPaymentMethod
+      } as any,
+      paymentMethods: {
+        findByProcessorPaymentMethodId: vi.fn().mockResolvedValue({
+          id: 'paymeth_old',
+          wallet_id: 'org_fnf',
+          owner_org_id: 'org_fnf',
+          payment_profile_id: 'payment_profile_1',
+          processor: 'stripe',
+          processor_payment_method_id: 'pm_old',
+          processor_customer_id: 'cus_1',
+          brand: 'visa',
+          last4: '4242',
+          exp_month: 12,
+          exp_year: 2031,
+          funding: 'credit',
+          status: 'active',
+          created_at: '2026-03-21T12:00:00.000Z',
+          updated_at: '2026-03-21T12:00:00.000Z',
+          detached_at: null
+        }),
+        markDetached
+      } as any,
+      autoRechargeSettings: {
+        findByWalletId: vi.fn().mockResolvedValue({
+          wallet_id: 'org_fnf',
+          owner_org_id: 'org_fnf',
+          enabled: true,
+          amount_minor: 2500,
+          currency: 'USD',
+          payment_method_id: 'paymeth_default',
+          updated_by_user_id: 'user_darryn',
+          created_at: '2026-03-21T12:00:00.000Z',
+          updated_at: '2026-03-21T12:00:00.000Z'
+        }),
+        upsertSettings
+      } as any,
+      paymentAttempts: {} as any,
+      paymentOutcomes: {} as any,
+      paymentWebhooks: {
+        claimEvent: vi.fn().mockResolvedValue({
+          state: 'claimed',
+          processorEventId: 'evt_pm_detached'
+        }),
+        markProcessed: vi.fn().mockResolvedValue(undefined)
+      } as any,
+      stripeClient: {
+        constructWebhookEvent: vi.fn().mockReturnValue({
+          id: 'evt_pm_detached',
+          type: 'payment_method.detached',
+          data: {
+            object: {
+              id: 'pm_old'
+            }
+          }
+        })
+      } as any
+    });
+
+    await service.processWebhook({
+      signatureHeader: 'stripe-signature',
+      rawBody: '{"id":"evt_pm_detached"}'
+    });
+
+    expect(markDetached).toHaveBeenCalledWith({
+      walletId: 'org_fnf',
+      paymentMethodId: 'paymeth_old'
+    });
+    expect(setDefaultPaymentMethod).not.toHaveBeenCalled();
+    expect(upsertSettings).not.toHaveBeenCalled();
+  });
+});

--- a/api/tests/payments.route.test.ts
+++ b/api/tests/payments.route.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { AppError } from '../src/utils/errors.js';
+
+type RuntimeModule = typeof import('../src/services/runtime.js');
+type PaymentsRouteModule = typeof import('../src/routes/payments.js');
+
+type MockReq = {
+  method: string;
+  path: string;
+  originalUrl: string;
+  body: unknown;
+  header: (name: string) => string | undefined;
+  inniesRawBodyText?: string;
+};
+
+type MockRes = {
+  statusCode: number;
+  body: unknown;
+  headersSent: boolean;
+  writableEnded: boolean;
+  status: (code: number) => MockRes;
+  json: (payload: unknown) => void;
+  send: (payload: unknown) => void;
+};
+
+function createMockReq(input: {
+  method: string;
+  path: string;
+  headers?: Record<string, string>;
+  rawBody?: string;
+}): MockReq {
+  const lower = Object.fromEntries(
+    Object.entries(input.headers ?? {}).map(([k, v]) => [k.toLowerCase(), v])
+  );
+  return {
+    method: input.method.toUpperCase(),
+    path: input.path,
+    originalUrl: input.path,
+    body: {},
+    inniesRawBodyText: input.rawBody,
+    header: (name: string) => lower[name.toLowerCase()]
+  };
+}
+
+function createMockRes(): MockRes {
+  return {
+    statusCode: 200,
+    body: undefined,
+    headersSent: false,
+    writableEnded: false,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      this.headersSent = true;
+      this.writableEnded = true;
+    },
+    send(payload: unknown) {
+      this.body = payload;
+      this.headersSent = true;
+      this.writableEnded = true;
+    }
+  };
+}
+
+function applyError(err: unknown, res: MockRes): void {
+  if (err instanceof z.ZodError) {
+    res.status(400).json({ code: 'invalid_request', message: 'Invalid request', issues: err.issues });
+    return;
+  }
+  if (err instanceof AppError) {
+    res.status(err.status).json({ code: err.code, message: err.message, details: err.details });
+    return;
+  }
+  const message = err instanceof Error ? err.message : 'Unexpected error';
+  res.status(500).json({ code: 'internal_error', message });
+}
+
+async function invoke(handle: (req: any, res: any, next: (error?: unknown) => void) => unknown, req: MockReq, res: MockRes): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    let nextCalled = false;
+    const next = (error?: unknown) => {
+      nextCalled = true;
+      if (error) {
+        applyError(error, res);
+      }
+      resolve();
+    };
+
+    Promise.resolve(handle(req, res, next))
+      .then(() => {
+        if (!nextCalled) resolve();
+      })
+      .catch(reject);
+  });
+}
+
+function getRouteHandlers(router: any, routePath: string, method: 'post'): Array<(req: any, res: any, next: (error?: unknown) => void) => unknown> {
+  const layer = router.stack.find((entry: any) => entry?.route?.path === routePath && entry?.route?.methods?.[method]);
+  if (!layer) throw new Error(`route not found: ${routePath}`);
+  return layer.route.stack.map((s: any) => s.handle);
+}
+
+describe('payments routes', () => {
+  let runtimeModule: RuntimeModule;
+  let webhookHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+
+  beforeAll(async () => {
+    process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgres://postgres:postgres@127.0.0.1:5432/innies_test';
+    process.env.SELLER_SECRET_ENC_KEY_B64 = process.env.SELLER_SECRET_ENC_KEY_B64 || Buffer.alloc(32, 7).toString('base64');
+    runtimeModule = await import('../src/services/runtime.js');
+    const mod = await import('../src/routes/payments.js') as PaymentsRouteModule;
+    webhookHandlers = getRouteHandlers(mod.default as any, '/v1/payments/webhooks/stripe', 'post');
+  });
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(runtimeModule.runtime.services.payments, 'processWebhook').mockResolvedValue({
+      accepted: true,
+      processorEventId: 'evt_1',
+      outcomes: [{
+        walletId: 'org_fnf',
+        processorEffectId: 'stripe:payment_intent:pi_1',
+        effectType: 'payment_credit'
+      }]
+    } as any);
+    vi.spyOn(runtimeModule.runtime.services.payments, 'markWebhookProcessed').mockResolvedValue(undefined);
+    vi.spyOn(runtimeModule.runtime.services.wallets, 'recordPaymentOutcome').mockResolvedValue({
+      id: 'wallet_entry_1'
+    } as any);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('normalizes Stripe webhooks and records wallet outcomes through the wallet-owned seam', async () => {
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/payments/webhooks/stripe',
+      headers: {
+        'stripe-signature': 't=1,v1=abc'
+      },
+      rawBody: '{"id":"evt_1"}'
+    });
+    const res = createMockRes();
+
+    await invoke(webhookHandlers[0], req, res);
+
+    expect(runtimeModule.runtime.services.payments.processWebhook).toHaveBeenCalledWith({
+      signatureHeader: 't=1,v1=abc',
+      rawBody: '{"id":"evt_1"}'
+    });
+    expect(runtimeModule.runtime.services.wallets.recordPaymentOutcome).toHaveBeenCalledWith({
+      walletId: 'org_fnf',
+      processorEffectId: 'stripe:payment_intent:pi_1',
+      effectType: 'payment_credit'
+    });
+    expect(runtimeModule.runtime.services.payments.markWebhookProcessed).toHaveBeenCalledWith('evt_1');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      accepted: true,
+      recordedOutcomes: 1
+    });
+  });
+
+  it('does not mark the webhook processed when wallet recording fails', async () => {
+    vi.mocked(runtimeModule.runtime.services.wallets.recordPaymentOutcome).mockRejectedValueOnce(
+      new AppError('wallet_write_failed', 500, 'wallet write failed')
+    );
+
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/payments/webhooks/stripe',
+      headers: {
+        'stripe-signature': 't=1,v1=abc'
+      },
+      rawBody: '{"id":"evt_1"}'
+    });
+    const res = createMockRes();
+
+    await invoke(webhookHandlers[0], req, res);
+
+    expect(runtimeModule.runtime.services.payments.markWebhookProcessed).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(500);
+  });
+});

--- a/api/tests/pilot.route.test.ts
+++ b/api/tests/pilot.route.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import { AppError } from '../src/utils/errors.js';
+import { sha256Hex, stableJson } from '../src/utils/hash.js';
 
 type RuntimeModule = typeof import('../src/services/runtime.js');
 type PilotRouteModule = typeof import('../src/routes/pilot.js');
@@ -135,6 +136,11 @@ describe('pilot routes', () => {
   let authStartHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
   let authCallbackHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
   let logoutHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+  let paymentsStateHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+  let paymentsSetupHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+  let paymentsTopUpHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+  let paymentsRemoveHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
+  let paymentsAutoRechargeHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
   let earningsSummaryHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
   let earningsHistoryHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
   let withdrawalsListHandlers: Array<(req: any, res: any, next: (error?: unknown) => void) => unknown>;
@@ -153,6 +159,11 @@ describe('pilot routes', () => {
     authStartHandlers = getRouteHandlers(mod.default as any, '/v1/pilot/auth/github/start', 'get');
     authCallbackHandlers = getRouteHandlers(mod.default as any, '/v1/pilot/auth/github/callback', 'get');
     logoutHandlers = getRouteHandlers(mod.default as any, '/v1/pilot/session/logout', 'post');
+    paymentsStateHandlers = getRouteHandlers(mod.default as any, '/v1/pilot/payments', 'get');
+    paymentsSetupHandlers = getRouteHandlers(mod.default as any, '/v1/pilot/payments/setup-session', 'post');
+    paymentsTopUpHandlers = getRouteHandlers(mod.default as any, '/v1/pilot/payments/top-up-session', 'post');
+    paymentsRemoveHandlers = getRouteHandlers(mod.default as any, '/v1/pilot/payments/payment-method/remove', 'post');
+    paymentsAutoRechargeHandlers = getRouteHandlers(mod.default as any, '/v1/pilot/payments/auto-recharge', 'post');
     earningsSummaryHandlers = getRouteHandlers(mod.default as any, '/v1/pilot/earnings/summary', 'get');
     earningsHistoryHandlers = getRouteHandlers(mod.default as any, '/v1/pilot/earnings/history', 'get');
     withdrawalsListHandlers = getRouteHandlers(mod.default as any, '/v1/pilot/withdrawals', 'get');
@@ -184,6 +195,48 @@ describe('pilot routes', () => {
       settledMinor: 120,
       adjustedMinor: -10
     });
+    vi.spyOn(runtimeModule.runtime.services.payments, 'getFundingState').mockResolvedValue({
+      paymentMethod: {
+        id: 'paymeth_local_1',
+        processor: 'stripe',
+        brand: 'visa',
+        last4: '4242',
+        expMonth: 8,
+        expYear: 2030,
+        status: 'active'
+      },
+      autoRecharge: {
+        enabled: true,
+        amountMinor: 2500,
+        currency: 'USD'
+      },
+      attempts: [{
+        id: 'payment_attempt_1',
+        kind: 'auto_recharge',
+        trigger: 'admission_blocked',
+        status: 'succeeded',
+        amountMinor: 2500,
+        currency: 'USD',
+        createdAt: '2026-03-20T10:30:00.000Z',
+        updatedAt: '2026-03-20T10:30:10.000Z',
+        lastErrorCode: null,
+        lastErrorMessage: null
+      }]
+    } as any);
+    vi.spyOn(runtimeModule.runtime.services.payments, 'createSetupSession').mockResolvedValue({
+      checkoutUrl: 'https://checkout.stripe.test/setup'
+    } as any);
+    vi.spyOn(runtimeModule.runtime.services.payments, 'createTopUpSession').mockResolvedValue({
+      checkoutUrl: 'https://checkout.stripe.test/topup'
+    } as any);
+    vi.spyOn(runtimeModule.runtime.services.payments, 'removeStoredPaymentMethod').mockResolvedValue({
+      removed: true
+    } as any);
+    vi.spyOn(runtimeModule.runtime.services.payments, 'updateAutoRechargeSettings').mockResolvedValue({
+      enabled: true,
+      amountMinor: 2500,
+      currency: 'USD'
+    } as any);
     vi.spyOn(runtimeModule.runtime.services.withdrawals, 'listContributorHistory').mockResolvedValue([]);
     vi.spyOn(runtimeModule.runtime.services.withdrawals, 'listContributorWithdrawals').mockResolvedValue([]);
     vi.spyOn(runtimeModule.runtime.services.withdrawals, 'createWithdrawalRequest').mockResolvedValue({
@@ -528,6 +581,268 @@ describe('pilot routes', () => {
     }));
   });
 
+  it('returns payment-method, auto-recharge, and recent attempt state for the effective wallet', async () => {
+    const req = createMockReq({
+      method: 'GET',
+      path: '/v1/pilot/payments',
+      headers: {
+        authorization: 'Bearer pilot-token'
+      }
+    });
+    const res = createMockRes();
+
+    await invoke(paymentsStateHandlers[0], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      funding: expect.objectContaining({
+        paymentMethod: expect.objectContaining({
+          id: 'paymeth_local_1',
+          brand: 'visa',
+          last4: '4242'
+        }),
+        autoRecharge: expect.objectContaining({
+          enabled: true,
+          amountMinor: 2500
+        }),
+        attempts: [expect.objectContaining({
+          id: 'payment_attempt_1',
+          kind: 'auto_recharge',
+          status: 'succeeded'
+        })]
+      })
+    });
+    expect(runtimeModule.runtime.services.payments.getFundingState).toHaveBeenCalledWith({
+      walletId: 'org_fnf',
+      ownerOrgId: 'org_fnf'
+    });
+  });
+
+  it('creates a setup session for adding a stored payment method', async () => {
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/pilot/payments/setup-session',
+      headers: {
+        authorization: 'Bearer pilot-token',
+        'content-type': 'application/json'
+      }
+    });
+    req.body = {
+      returnTo: '/pilot'
+    };
+    const res = createMockRes();
+
+    await invoke(paymentsSetupHandlers[0], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      checkoutUrl: 'https://checkout.stripe.test/setup'
+    });
+    expect(runtimeModule.runtime.services.payments.createSetupSession).toHaveBeenCalledWith({
+      walletId: 'org_fnf',
+      ownerOrgId: 'org_fnf',
+      requestedByUserId: 'user_darryn',
+      returnTo: '/pilot'
+    });
+  });
+
+  it('creates a manual top-up session against the effective pilot wallet', async () => {
+    const idemSession = {
+      replay: false,
+      input: {
+        scope: 'pilot_payment_topup_session_v1',
+        tenantScope: 'org_fnf',
+        idempotencyKey: 'abcdefghijklmnopqrstuvwxyz123456',
+        requestHash: sha256Hex(stableJson({
+          effectiveOrgId: 'org_fnf',
+          requestedByUserId: 'user_darryn',
+          amountMinor: 5000,
+          returnTo: '/pilot'
+        }))
+      }
+    } as any;
+    const startSpy = vi.spyOn(runtimeModule.runtime.services.idempotency, 'start').mockResolvedValue(idemSession);
+    const commitSpy = vi.spyOn(runtimeModule.runtime.services.idempotency, 'commit').mockResolvedValue(undefined);
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/pilot/payments/top-up-session',
+      headers: {
+        authorization: 'Bearer pilot-token',
+        'content-type': 'application/json',
+        'idempotency-key': 'abcdefghijklmnopqrstuvwxyz123456'
+      }
+    });
+    req.body = {
+      amountMinor: 5000,
+      returnTo: '/pilot'
+    };
+    const res = createMockRes();
+
+    await invoke(paymentsTopUpHandlers[0], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      checkoutUrl: 'https://checkout.stripe.test/topup'
+    });
+    expect(runtimeModule.runtime.services.payments.createTopUpSession).toHaveBeenCalledWith({
+      walletId: 'org_fnf',
+      ownerOrgId: 'org_fnf',
+      requestedByUserId: 'user_darryn',
+      amountMinor: 5000,
+      returnTo: '/pilot',
+      idempotencyKey: 'abcdefghijklmnopqrstuvwxyz123456'
+    });
+    expect(startSpy).toHaveBeenCalledWith({
+      scope: 'pilot_payment_topup_session_v1',
+      tenantScope: 'org_fnf',
+      idempotencyKey: 'abcdefghijklmnopqrstuvwxyz123456',
+      requestHash: sha256Hex(stableJson({
+        effectiveOrgId: 'org_fnf',
+        requestedByUserId: 'user_darryn',
+        amountMinor: 5000,
+        returnTo: '/pilot'
+      }))
+    });
+    expect(commitSpy).toHaveBeenCalledWith(idemSession, {
+      responseCode: 200,
+      responseBody: {
+        ok: true,
+        checkoutUrl: 'https://checkout.stripe.test/topup'
+      },
+      responseDigest: sha256Hex(stableJson({
+        ok: true,
+        checkoutUrl: 'https://checkout.stripe.test/topup'
+      })),
+      responseRef: 'org_fnf'
+    });
+  });
+
+  it('replays a manual top-up session without creating a second checkout session', async () => {
+    vi.spyOn(runtimeModule.runtime.services.idempotency, 'start').mockResolvedValue({
+      replay: true,
+      responseCode: 200,
+      responseBody: {
+        ok: true,
+        checkoutUrl: 'https://checkout.stripe.test/topup-replay'
+      }
+    } as any);
+    const commitSpy = vi.spyOn(runtimeModule.runtime.services.idempotency, 'commit').mockResolvedValue(undefined);
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/pilot/payments/top-up-session',
+      headers: {
+        authorization: 'Bearer pilot-token',
+        'content-type': 'application/json',
+        'idempotency-key': 'abcdefghijklmnopqrstuvwxyz123456'
+      }
+    });
+    req.body = {
+      amountMinor: 5000,
+      returnTo: '/pilot'
+    };
+    const res = createMockRes();
+
+    await invoke(paymentsTopUpHandlers[0], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['x-idempotent-replay']).toBe('true');
+    expect(res.body).toEqual({
+      ok: true,
+      checkoutUrl: 'https://checkout.stripe.test/topup-replay'
+    });
+    expect(runtimeModule.runtime.services.payments.createTopUpSession).not.toHaveBeenCalled();
+    expect(commitSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects manual top-up session creation without an idempotency key header', async () => {
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/pilot/payments/top-up-session',
+      headers: {
+        authorization: 'Bearer pilot-token',
+        'content-type': 'application/json'
+      }
+    });
+    req.body = {
+      amountMinor: 5000,
+      returnTo: '/pilot'
+    };
+    const res = createMockRes();
+
+    await invoke(paymentsTopUpHandlers[0], req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      code: 'invalid_request',
+      message: 'Missing Idempotency-Key header',
+      details: undefined
+    });
+    expect(runtimeModule.runtime.services.payments.createTopUpSession).not.toHaveBeenCalled();
+  });
+
+  it('removes the stored payment method through the payment service', async () => {
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/pilot/payments/payment-method/remove',
+      headers: {
+        authorization: 'Bearer pilot-token',
+        'content-type': 'application/json'
+      }
+    });
+    req.body = {};
+    const res = createMockRes();
+
+    await invoke(paymentsRemoveHandlers[0], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      removed: true
+    });
+    expect(runtimeModule.runtime.services.payments.removeStoredPaymentMethod).toHaveBeenCalledWith({
+      walletId: 'org_fnf',
+      ownerOrgId: 'org_fnf'
+    });
+  });
+
+  it('updates auto-recharge settings for the effective pilot wallet', async () => {
+    const req = createMockReq({
+      method: 'POST',
+      path: '/v1/pilot/payments/auto-recharge',
+      headers: {
+        authorization: 'Bearer pilot-token',
+        'content-type': 'application/json'
+      }
+    });
+    req.body = {
+      enabled: true,
+      amountMinor: 2500
+    };
+    const res = createMockRes();
+
+    await invoke(paymentsAutoRechargeHandlers[0], req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      autoRecharge: {
+        enabled: true,
+        amountMinor: 2500,
+        currency: 'USD'
+      }
+    });
+    expect(runtimeModule.runtime.services.payments.updateAutoRechargeSettings).toHaveBeenCalledWith({
+      walletId: 'org_fnf',
+      ownerOrgId: 'org_fnf',
+      enabled: true,
+      amountMinor: 2500,
+      updatedByUserId: 'user_darryn'
+    });
+  });
+
   it('redirects to GitHub auth with a signed state token', async () => {
     const buildAuthorizationUrl = vi.spyOn(runtimeModule.runtime.services.pilotGithubAuth, 'buildAuthorizationUrl')
       .mockReturnValue('https://github.com/login/oauth/authorize?state=signed');
@@ -554,6 +869,23 @@ describe('pilot routes', () => {
       method: 'GET',
       path: '/v1/pilot/auth/github/start',
       query: { returnTo: 'https://evil.example.com/phish' }
+    });
+    const res = createMockRes();
+
+    await invoke(authStartHandlers[0], req, res);
+
+    expect(res.statusCode).toBe(302);
+    expect(buildAuthorizationUrl).toHaveBeenCalledWith({ returnTo: undefined });
+  });
+
+  it('drops slash-backslash returnTo values before starting GitHub auth', async () => {
+    const buildAuthorizationUrl = vi.spyOn(runtimeModule.runtime.services.pilotGithubAuth, 'buildAuthorizationUrl')
+      .mockReturnValue('https://github.com/login/oauth/authorize?state=signed');
+
+    const req = createMockReq({
+      method: 'GET',
+      path: '/v1/pilot/auth/github/start',
+      query: { returnTo: '/\\evil.example.com' }
     });
     const res = createMockRes();
 
@@ -595,6 +927,32 @@ describe('pilot routes', () => {
     vi.spyOn(runtimeModule.runtime.services.pilotGithubAuth, 'finishOauthCallback').mockResolvedValue({
       sessionToken: 'signed-session-token',
       returnTo: 'https://evil.example.com/phish',
+      session: {
+        sessionKind: 'darryn_self',
+        actorUserId: 'user_darryn',
+        effectiveOrgId: 'org_fnf',
+        githubLogin: 'darryn',
+        userEmail: 'darryn@example.com'
+      }
+    } as any);
+
+    const req = createMockReq({
+      method: 'GET',
+      path: '/v1/pilot/auth/github/callback',
+      query: { code: 'oauth-code', state: 'oauth-state' }
+    });
+    const res = createMockRes();
+
+    await invoke(authCallbackHandlers[0], req, res);
+
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toBe('/pilot');
+  });
+
+  it('falls back to /pilot when the callback returnTo uses slash-backslash host bypass', async () => {
+    vi.spyOn(runtimeModule.runtime.services.pilotGithubAuth, 'finishOauthCallback').mockResolvedValue({
+      sessionToken: 'signed-session-token',
+      returnTo: '/\\evil.example.com',
       session: {
         sessionKind: 'darryn_self',
         actorUserId: 'user_darryn',

--- a/api/tests/stripeClient.test.ts
+++ b/api/tests/stripeClient.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { StripeClient } from '../src/services/payments/stripeClient.js';
+
+describe('StripeClient', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('creates setup checkout sessions with an explicit card-only payment method type', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      id: 'cs_test_123',
+      url: 'https://checkout.stripe.test/session'
+    }), {
+      status: 200,
+      headers: {
+        'content-type': 'application/json'
+      }
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = new StripeClient({
+      secretKey: 'sk_test_123',
+      webhookSecret: 'whsec_test_123'
+    });
+
+    await expect(client.createSetupSession({
+      customerId: 'cus_123',
+      successUrl: 'http://localhost:3000/pilot',
+      cancelUrl: 'http://localhost:3000/pilot',
+      metadata: {
+        wallet_id: 'org_fnf'
+      }
+    })).resolves.toEqual({
+      id: 'cs_test_123',
+      url: 'https://checkout.stripe.test/session'
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, request] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const form = new URLSearchParams(String(request.body ?? ''));
+
+    expect(form.get('mode')).toBe('setup');
+    expect(form.get('customer')).toBe('cus_123');
+    expect(form.get('payment_method_types[0]')).toBe('card');
+    expect(form.has('currency')).toBe(false);
+    expect(form.get('setup_intent_data[metadata][wallet_id]')).toBe('org_fnf');
+  });
+});

--- a/api/tests/walletLedgerRepository.test.ts
+++ b/api/tests/walletLedgerRepository.test.ts
@@ -61,6 +61,43 @@ describe('WalletLedgerRepository', () => {
     expect(db.queries[0].params).toContain('processor_evt_1');
   });
 
+  it('builds the insert when appendEntryWithDb receives only a transaction handle', async () => {
+    const tx = new MockSqlClient({
+      rows: [{
+        id: 'wallet_entry_tx',
+        wallet_id: 'wallet_1',
+        owner_org_id: 'org_fnf',
+        buyer_key_id: 'buyer_1',
+        metering_event_id: 'meter_tx',
+        effect_type: 'buyer_debit',
+        amount_minor: 450,
+        currency: 'USD',
+        actor_user_id: null,
+        reason: null,
+        processor_effect_id: null,
+        metadata: null,
+        created_at: '2026-03-21T12:00:00.000Z'
+      }],
+      rowCount: 1
+    });
+    const repo = new WalletLedgerRepository(new MockSqlClient(), () => 'wallet_entry_tx');
+
+    const row = await repo.appendEntryWithDb({
+      walletId: 'wallet_1',
+      ownerOrgId: 'org_fnf',
+      buyerKeyId: 'buyer_1',
+      meteringEventId: 'meter_tx',
+      effectType: 'buyer_debit',
+      amountMinor: 450,
+      currency: 'USD'
+    }, tx);
+
+    expect(row.id).toBe('wallet_entry_tx');
+    expect(tx.queries[0].sql).toContain('insert into in_wallet_ledger');
+    expect(tx.queries[0].params).toContain('wallet_1');
+    expect(tx.queries[0].params).toContain('meter_tx');
+  });
+
   it('returns the existing metering-derived row on duplicate projection keys', async () => {
     const db = new SequenceSqlClient([
       { rows: [], rowCount: 0 },

--- a/api/tests/walletService.test.ts
+++ b/api/tests/walletService.test.ts
@@ -179,4 +179,161 @@ describe('WalletService', () => {
       amountMinor: 250
     }));
   });
+
+  it('serializes post-finalization auto-recharge attempts on the wallet advisory lock', async () => {
+    const sql = new MockSqlClient();
+    const paymentsAdapter = {
+      attemptAutoRecharge: vi.fn().mockResolvedValue({
+        kind: 'charge_pending',
+        paymentAttemptId: 'payment_attempt_1'
+      })
+    };
+    const service = new WalletService({
+      sql,
+      walletLedgerRepo: {
+        appendEntry: vi.fn().mockResolvedValue({ id: 'wallet_entry_negative' }),
+        readBalance: vi.fn()
+          .mockResolvedValueOnce({
+            walletId: 'org_fnf',
+            balanceMinor: 25
+          })
+          .mockResolvedValueOnce({
+            walletId: 'org_fnf',
+            balanceMinor: -225
+          })
+      } as any,
+      canonicalMeteringRepo: {
+        findById: vi.fn().mockResolvedValue({
+          id: 'meter_negative',
+          finalization_kind: 'served_request',
+          consumer_org_id: 'org_fnf',
+          buyer_key_id: 'buyer_1',
+          buyer_debit_minor: 250,
+          contributor_earnings_minor: 0,
+          currency: 'USD'
+        })
+      } as any,
+      meteringProjectorStateRepo: {
+        markProjected: vi.fn().mockResolvedValue(undefined)
+      } as any,
+      paymentsAdapter: paymentsAdapter as any
+    });
+
+    await service.projectMeteringEvent('meter_negative');
+
+    expect(sql.queries[0]?.sql).toContain('pg_advisory_xact_lock');
+    expect(paymentsAdapter.attemptAutoRecharge).toHaveBeenCalledWith('org_fnf', 'post_finalization_negative');
+  });
+
+  it('tries admission-time auto-recharge before denying paid admission', async () => {
+    const sql = new MockSqlClient();
+    const appendEntry = vi.fn().mockResolvedValue({ id: 'wallet_entry_payment' });
+    const readBalance = vi.fn()
+      .mockResolvedValueOnce({
+        walletId: 'org_fnf',
+        balanceMinor: 0
+      })
+      .mockResolvedValueOnce({
+        walletId: 'org_fnf',
+        balanceMinor: 2500
+      });
+    const paymentsAdapter = {
+      attemptAutoRecharge: vi.fn().mockResolvedValue({
+        kind: 'charge_succeeded',
+        processorEffectId: 'stripe:payment_intent:pi_1'
+      }),
+      getNormalizedPaymentOutcome: vi.fn().mockResolvedValue({
+        walletId: 'org_fnf',
+        processorEffectId: 'stripe:payment_intent:pi_1',
+        effectType: 'payment_credit',
+        amountMinor: 2500,
+        currency: 'USD',
+        metadata: {
+          trigger: 'admission_blocked'
+        }
+      }),
+      markPaymentOutcomeRecorded: vi.fn().mockResolvedValue(undefined)
+    };
+    const service = new WalletService({
+      sql,
+      walletLedgerRepo: {
+        appendEntry,
+        readBalance
+      } as any,
+      canonicalMeteringRepo: {} as any,
+      meteringProjectorStateRepo: {} as any,
+      paymentsAdapter: paymentsAdapter as any
+    });
+
+    const result = await service.ensurePaidAdmissionEligible({
+      walletId: 'org_fnf',
+      trigger: 'paid_team_capacity'
+    });
+
+    expect(paymentsAdapter.attemptAutoRecharge).toHaveBeenCalledWith('org_fnf', 'admission_blocked');
+    expect(appendEntry).toHaveBeenCalledWith(expect.objectContaining({
+      walletId: 'org_fnf',
+      ownerOrgId: 'org_fnf',
+      effectType: 'payment_credit',
+      amountMinor: 2500,
+      processorEffectId: 'stripe:payment_intent:pi_1'
+    }));
+    expect(paymentsAdapter.markPaymentOutcomeRecorded).toHaveBeenCalledWith(
+      'stripe:payment_intent:pi_1',
+      expect.anything()
+    );
+    expect(result).toEqual({
+      walletId: 'org_fnf',
+      balanceMinor: 2500,
+      eligible: true
+    });
+  });
+
+  it('records normalized payment reversals through wallet-owned ledger writes', async () => {
+    const appendEntry = vi.fn().mockResolvedValue({ id: 'wallet_entry_reversal' });
+    const paymentsAdapter = {
+      getNormalizedPaymentOutcome: vi.fn().mockResolvedValue({
+        walletId: 'org_fnf',
+        processorEffectId: 'stripe:refund:re_1',
+        effectType: 'payment_reversal',
+        amountMinor: 900,
+        currency: 'USD',
+        metadata: {
+          processorEventId: 'evt_refund_1'
+        }
+      }),
+      markPaymentOutcomeRecorded: vi.fn().mockResolvedValue(undefined)
+    };
+    const service = new WalletService({
+      sql: new MockSqlClient(),
+      walletLedgerRepo: {
+        appendEntry
+      } as any,
+      canonicalMeteringRepo: {} as any,
+      meteringProjectorStateRepo: {} as any,
+      paymentsAdapter: paymentsAdapter as any
+    });
+
+    await service.recordPaymentOutcome({
+      walletId: 'org_fnf',
+      processorEffectId: 'stripe:refund:re_1',
+      effectType: 'payment_reversal'
+    });
+
+    expect(paymentsAdapter.getNormalizedPaymentOutcome).toHaveBeenCalledWith({
+      processorEffectId: 'stripe:refund:re_1',
+      effectType: 'payment_reversal'
+    });
+    expect(appendEntry).toHaveBeenCalledWith(expect.objectContaining({
+      walletId: 'org_fnf',
+      ownerOrgId: 'org_fnf',
+      effectType: 'payment_reversal',
+      amountMinor: 900,
+      processorEffectId: 'stripe:refund:re_1'
+    }));
+    expect(paymentsAdapter.markPaymentOutcomeRecorded).toHaveBeenCalledWith(
+      'stripe:refund:re_1',
+      undefined
+    );
+  });
 });

--- a/docs/migrations/021_darryn_payments_recharge.sql
+++ b/docs/migrations/021_darryn_payments_recharge.sql
@@ -1,0 +1,134 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS in_payment_profiles (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  wallet_id text NOT NULL UNIQUE,
+  owner_org_id uuid NOT NULL REFERENCES in_orgs(id) ON DELETE RESTRICT,
+  processor text NOT NULL DEFAULT 'stripe',
+  processor_customer_id text NOT NULL UNIQUE,
+  default_payment_method_id uuid,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS in_payment_methods (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  wallet_id text NOT NULL,
+  owner_org_id uuid NOT NULL REFERENCES in_orgs(id) ON DELETE RESTRICT,
+  payment_profile_id uuid NOT NULL REFERENCES in_payment_profiles(id) ON DELETE CASCADE,
+  processor text NOT NULL DEFAULT 'stripe',
+  processor_payment_method_id text NOT NULL UNIQUE,
+  processor_customer_id text NOT NULL,
+  brand text NOT NULL,
+  last4 char(4) NOT NULL,
+  exp_month integer NOT NULL,
+  exp_year integer NOT NULL,
+  funding text,
+  status text NOT NULL DEFAULT 'active',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  detached_at timestamptz
+);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.table_constraints
+    WHERE constraint_name = 'fk_in_payment_profiles_default_method'
+      AND table_name = 'in_payment_profiles'
+  ) THEN
+    ALTER TABLE in_payment_profiles
+      ADD CONSTRAINT fk_in_payment_profiles_default_method
+      FOREIGN KEY (default_payment_method_id)
+      REFERENCES in_payment_methods(id)
+      ON DELETE SET NULL;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_in_payment_methods_wallet_created
+  ON in_payment_methods (wallet_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS in_auto_recharge_settings (
+  wallet_id text PRIMARY KEY,
+  owner_org_id uuid NOT NULL REFERENCES in_orgs(id) ON DELETE RESTRICT,
+  enabled boolean NOT NULL DEFAULT false,
+  amount_minor bigint NOT NULL DEFAULT 0,
+  currency char(3) NOT NULL DEFAULT 'USD',
+  payment_method_id uuid REFERENCES in_payment_methods(id) ON DELETE SET NULL,
+  updated_by_user_id uuid REFERENCES in_users(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS in_payment_attempts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  wallet_id text NOT NULL,
+  owner_org_id uuid NOT NULL REFERENCES in_orgs(id) ON DELETE RESTRICT,
+  payment_method_id uuid REFERENCES in_payment_methods(id) ON DELETE SET NULL,
+  processor text NOT NULL DEFAULT 'stripe',
+  kind text NOT NULL,
+  trigger text,
+  status text NOT NULL,
+  amount_minor bigint NOT NULL,
+  currency char(3) NOT NULL DEFAULT 'USD',
+  processor_checkout_session_id text,
+  processor_payment_intent_id text,
+  processor_effect_id text,
+  idempotency_key text,
+  initiated_by_user_id uuid REFERENCES in_users(id) ON DELETE SET NULL,
+  last_error_code text,
+  last_error_message text,
+  metadata jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_in_payment_attempts_wallet_created
+  ON in_payment_attempts (wallet_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_in_payment_attempts_wallet_status
+  ON in_payment_attempts (wallet_id, status, created_at DESC);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_in_payment_attempts_wallet_pending_auto_recharge
+  ON in_payment_attempts (wallet_id)
+  WHERE kind = 'auto_recharge'
+    AND status IN ('pending', 'processing');
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_in_payment_attempts_wallet_manual_topup_idempotency
+  ON in_payment_attempts (wallet_id, idempotency_key)
+  WHERE kind = 'manual_topup'
+    AND idempotency_key IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS in_payment_webhook_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  processor text NOT NULL DEFAULT 'stripe',
+  processor_event_id text NOT NULL UNIQUE,
+  event_type text NOT NULL,
+  payload jsonb NOT NULL,
+  received_at timestamptz NOT NULL DEFAULT now(),
+  processed_at timestamptz
+);
+
+CREATE TABLE IF NOT EXISTS in_payment_outcomes (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  wallet_id text NOT NULL,
+  owner_org_id uuid NOT NULL REFERENCES in_orgs(id) ON DELETE RESTRICT,
+  payment_attempt_id uuid REFERENCES in_payment_attempts(id) ON DELETE SET NULL,
+  processor text NOT NULL DEFAULT 'stripe',
+  processor_event_id text NOT NULL,
+  processor_effect_id text NOT NULL UNIQUE,
+  effect_type in_wallet_effect_type NOT NULL,
+  amount_minor bigint NOT NULL,
+  currency char(3) NOT NULL DEFAULT 'USD',
+  metadata jsonb,
+  wallet_recorded_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT chk_in_payment_outcomes_effect_type
+    CHECK (effect_type IN ('payment_credit', 'payment_reversal'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_in_payment_outcomes_wallet_created
+  ON in_payment_outcomes (wallet_id, created_at DESC);
+
+COMMIT;

--- a/docs/migrations/021_darryn_payments_recharge_no_extensions.sql
+++ b/docs/migrations/021_darryn_payments_recharge_no_extensions.sql
@@ -1,0 +1,134 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS in_payment_profiles (
+  id uuid PRIMARY KEY,
+  wallet_id text NOT NULL UNIQUE,
+  owner_org_id uuid NOT NULL REFERENCES in_orgs(id) ON DELETE RESTRICT,
+  processor text NOT NULL DEFAULT 'stripe',
+  processor_customer_id text NOT NULL UNIQUE,
+  default_payment_method_id uuid,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS in_payment_methods (
+  id uuid PRIMARY KEY,
+  wallet_id text NOT NULL,
+  owner_org_id uuid NOT NULL REFERENCES in_orgs(id) ON DELETE RESTRICT,
+  payment_profile_id uuid NOT NULL REFERENCES in_payment_profiles(id) ON DELETE CASCADE,
+  processor text NOT NULL DEFAULT 'stripe',
+  processor_payment_method_id text NOT NULL UNIQUE,
+  processor_customer_id text NOT NULL,
+  brand text NOT NULL,
+  last4 char(4) NOT NULL,
+  exp_month integer NOT NULL,
+  exp_year integer NOT NULL,
+  funding text,
+  status text NOT NULL DEFAULT 'active',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  detached_at timestamptz
+);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.table_constraints
+    WHERE constraint_name = 'fk_in_payment_profiles_default_method'
+      AND table_name = 'in_payment_profiles'
+  ) THEN
+    ALTER TABLE in_payment_profiles
+      ADD CONSTRAINT fk_in_payment_profiles_default_method
+      FOREIGN KEY (default_payment_method_id)
+      REFERENCES in_payment_methods(id)
+      ON DELETE SET NULL;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_in_payment_methods_wallet_created
+  ON in_payment_methods (wallet_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS in_auto_recharge_settings (
+  wallet_id text PRIMARY KEY,
+  owner_org_id uuid NOT NULL REFERENCES in_orgs(id) ON DELETE RESTRICT,
+  enabled boolean NOT NULL DEFAULT false,
+  amount_minor bigint NOT NULL DEFAULT 0,
+  currency char(3) NOT NULL DEFAULT 'USD',
+  payment_method_id uuid REFERENCES in_payment_methods(id) ON DELETE SET NULL,
+  updated_by_user_id uuid REFERENCES in_users(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS in_payment_attempts (
+  id uuid PRIMARY KEY,
+  wallet_id text NOT NULL,
+  owner_org_id uuid NOT NULL REFERENCES in_orgs(id) ON DELETE RESTRICT,
+  payment_method_id uuid REFERENCES in_payment_methods(id) ON DELETE SET NULL,
+  processor text NOT NULL DEFAULT 'stripe',
+  kind text NOT NULL,
+  trigger text,
+  status text NOT NULL,
+  amount_minor bigint NOT NULL,
+  currency char(3) NOT NULL DEFAULT 'USD',
+  processor_checkout_session_id text,
+  processor_payment_intent_id text,
+  processor_effect_id text,
+  idempotency_key text,
+  initiated_by_user_id uuid REFERENCES in_users(id) ON DELETE SET NULL,
+  last_error_code text,
+  last_error_message text,
+  metadata jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_in_payment_attempts_wallet_created
+  ON in_payment_attempts (wallet_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_in_payment_attempts_wallet_status
+  ON in_payment_attempts (wallet_id, status, created_at DESC);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_in_payment_attempts_wallet_pending_auto_recharge
+  ON in_payment_attempts (wallet_id)
+  WHERE kind = 'auto_recharge'
+    AND status IN ('pending', 'processing');
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_in_payment_attempts_wallet_manual_topup_idempotency
+  ON in_payment_attempts (wallet_id, idempotency_key)
+  WHERE kind = 'manual_topup'
+    AND idempotency_key IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS in_payment_webhook_events (
+  id uuid PRIMARY KEY,
+  processor text NOT NULL DEFAULT 'stripe',
+  processor_event_id text NOT NULL UNIQUE,
+  event_type text NOT NULL,
+  payload jsonb NOT NULL,
+  received_at timestamptz NOT NULL DEFAULT now(),
+  processed_at timestamptz
+);
+
+CREATE TABLE IF NOT EXISTS in_payment_outcomes (
+  id uuid PRIMARY KEY,
+  wallet_id text NOT NULL,
+  owner_org_id uuid NOT NULL REFERENCES in_orgs(id) ON DELETE RESTRICT,
+  payment_attempt_id uuid REFERENCES in_payment_attempts(id) ON DELETE SET NULL,
+  processor text NOT NULL DEFAULT 'stripe',
+  processor_event_id text NOT NULL,
+  processor_effect_id text NOT NULL UNIQUE,
+  effect_type in_wallet_effect_type NOT NULL,
+  amount_minor bigint NOT NULL,
+  currency char(3) NOT NULL DEFAULT 'USD',
+  metadata jsonb,
+  wallet_recorded_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT chk_in_payment_outcomes_effect_type
+    CHECK (effect_type IN ('payment_credit', 'payment_reversal'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_in_payment_outcomes_wallet_created
+  ON in_payment_outcomes (wallet_id, created_at DESC);
+
+COMMIT;

--- a/ui/src/app/api/admin/pilot/impersonate/route.ts
+++ b/ui/src/app/api/admin/pilot/impersonate/route.ts
@@ -26,7 +26,7 @@ export async function POST(request: NextRequest) {
       }
     });
 
-    const redirect = NextResponse.redirect(new URL('/pilot', request.url));
+    const redirect = NextResponse.redirect(new URL('/pilot', request.url), { status: 303 });
     redirect.cookies.set('innies_pilot_session', response.sessionToken, {
       httpOnly: true,
       sameSite: 'lax',

--- a/ui/src/app/api/admin/pilot/withdrawals/[withdrawalRequestId]/route.ts
+++ b/ui/src/app/api/admin/pilot/withdrawals/[withdrawalRequestId]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { PilotServerError, fetchAdminJson } from '../../../../../../lib/pilot/server';
+import { normalizePilotReturnTo } from '../../../../../../lib/pilot/returnTo';
 
 export const dynamic = 'force-dynamic';
 
@@ -21,7 +22,7 @@ export async function POST(
   const { withdrawalRequestId } = await context.params;
   const formData = await request.formData();
   const action = readFormString(formData, 'action');
-  const returnTo = readFormString(formData, 'returnTo') || '/admin/pilot';
+  const returnTo = normalizePilotReturnTo(readFormString(formData, 'returnTo')) ?? '/admin/pilot';
   const reason = readFormString(formData, 'reason');
   const settlementReference = readFormString(formData, 'settlementReference');
   const adjustmentMinor = readOptionalInt(readFormString(formData, 'adjustmentMinor'));
@@ -70,7 +71,7 @@ export async function POST(
       method: 'POST',
       body
     });
-    return NextResponse.redirect(new URL(returnTo, request.url));
+    return NextResponse.redirect(new URL(returnTo, request.url), { status: 303 });
   } catch (error) {
     if (error instanceof PilotServerError) {
       return NextResponse.json({

--- a/ui/src/app/api/pilot/payments/auto-recharge/route.ts
+++ b/ui/src/app/api/pilot/payments/auto-recharge/route.ts
@@ -1,8 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { PilotServerError, fetchPilotJson } from '../../../../lib/pilot/server';
-import { normalizePilotReturnTo } from '../../../../lib/pilot/returnTo';
-
-export const dynamic = 'force-dynamic';
+import { PilotServerError, fetchPilotJson } from '../../../../../lib/pilot/server';
+import { normalizePilotReturnTo } from '../../../../../lib/pilot/returnTo';
 
 function readFormString(formData: FormData, key: string): string {
   const value = formData.get(key);
@@ -12,30 +10,24 @@ function readFormString(formData: FormData, key: string): string {
 export async function POST(request: NextRequest) {
   const formData = await request.formData();
   const returnTo = normalizePilotReturnTo(readFormString(formData, 'returnTo')) ?? '/pilot';
+  const enabled = readFormString(formData, 'enabled') === 'true';
   const amountMinor = Number(readFormString(formData, 'amountMinor'));
-  const destinationRail = readFormString(formData, 'destinationRail') || 'manual_usdc';
-  const destinationAddress = readFormString(formData, 'destinationAddress');
-  const note = readFormString(formData, 'note');
 
   try {
     await fetchPilotJson({
-      path: '/v1/pilot/withdrawals',
+      path: '/v1/pilot/payments/auto-recharge',
       method: 'POST',
       cookieHeader: request.headers.get('cookie'),
       body: {
-        amountMinor,
-        destination: {
-          rail: destinationRail,
-          address: destinationAddress
-        },
-        note: note || undefined
+        enabled,
+        amountMinor
       }
     });
     return NextResponse.redirect(new URL(returnTo, request.url), { status: 303 });
   } catch (error) {
     if (error instanceof PilotServerError) {
       return NextResponse.json({
-        code: 'pilot_withdrawal_error',
+        code: 'pilot_auto_recharge_error',
         message: error.message,
         details: error.details
       }, { status: error.status });

--- a/ui/src/app/api/pilot/payments/remove/route.ts
+++ b/ui/src/app/api/pilot/payments/remove/route.ts
@@ -1,8 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { PilotServerError, fetchPilotJson } from '../../../../lib/pilot/server';
-import { normalizePilotReturnTo } from '../../../../lib/pilot/returnTo';
-
-export const dynamic = 'force-dynamic';
+import { PilotServerError, fetchPilotJson } from '../../../../../lib/pilot/server';
+import { normalizePilotReturnTo } from '../../../../../lib/pilot/returnTo';
 
 function readFormString(formData: FormData, key: string): string {
   const value = formData.get(key);
@@ -12,30 +10,19 @@ function readFormString(formData: FormData, key: string): string {
 export async function POST(request: NextRequest) {
   const formData = await request.formData();
   const returnTo = normalizePilotReturnTo(readFormString(formData, 'returnTo')) ?? '/pilot';
-  const amountMinor = Number(readFormString(formData, 'amountMinor'));
-  const destinationRail = readFormString(formData, 'destinationRail') || 'manual_usdc';
-  const destinationAddress = readFormString(formData, 'destinationAddress');
-  const note = readFormString(formData, 'note');
 
   try {
     await fetchPilotJson({
-      path: '/v1/pilot/withdrawals',
+      path: '/v1/pilot/payments/payment-method/remove',
       method: 'POST',
       cookieHeader: request.headers.get('cookie'),
-      body: {
-        amountMinor,
-        destination: {
-          rail: destinationRail,
-          address: destinationAddress
-        },
-        note: note || undefined
-      }
+      body: {}
     });
     return NextResponse.redirect(new URL(returnTo, request.url), { status: 303 });
   } catch (error) {
     if (error instanceof PilotServerError) {
       return NextResponse.json({
-        code: 'pilot_withdrawal_error',
+        code: 'pilot_payments_remove_error',
         message: error.message,
         details: error.details
       }, { status: error.status });

--- a/ui/src/app/api/pilot/payments/setup/route.ts
+++ b/ui/src/app/api/pilot/payments/setup/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { PilotServerError, fetchPilotJson } from '../../../../../lib/pilot/server';
+import { normalizePilotReturnTo } from '../../../../../lib/pilot/returnTo';
+
+function readFormString(formData: FormData, key: string): string {
+  const value = formData.get(key);
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+export async function POST(request: NextRequest) {
+  const formData = await request.formData();
+  const returnTo = normalizePilotReturnTo(readFormString(formData, 'returnTo')) ?? '/pilot';
+
+  try {
+    const response = await fetchPilotJson<{ ok: true; checkoutUrl: string }>({
+      path: '/v1/pilot/payments/setup-session',
+      method: 'POST',
+      cookieHeader: request.headers.get('cookie'),
+      body: {
+        returnTo
+      }
+    });
+    return NextResponse.redirect(response.checkoutUrl, { status: 303 });
+  } catch (error) {
+    if (error instanceof PilotServerError) {
+      return NextResponse.json({
+        code: 'pilot_payments_setup_error',
+        message: error.message,
+        details: error.details
+      }, { status: error.status });
+    }
+    throw error;
+  }
+}

--- a/ui/src/app/api/pilot/payments/top-up/route.ts
+++ b/ui/src/app/api/pilot/payments/top-up/route.ts
@@ -1,8 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { PilotServerError, fetchPilotJson } from '../../../../lib/pilot/server';
-import { normalizePilotReturnTo } from '../../../../lib/pilot/returnTo';
-
-export const dynamic = 'force-dynamic';
+import { PilotServerError, fetchPilotJson } from '../../../../../lib/pilot/server';
+import { normalizePilotReturnTo } from '../../../../../lib/pilot/returnTo';
 
 function readFormString(formData: FormData, key: string): string {
   const value = formData.get(key);
@@ -13,29 +11,26 @@ export async function POST(request: NextRequest) {
   const formData = await request.formData();
   const returnTo = normalizePilotReturnTo(readFormString(formData, 'returnTo')) ?? '/pilot';
   const amountMinor = Number(readFormString(formData, 'amountMinor'));
-  const destinationRail = readFormString(formData, 'destinationRail') || 'manual_usdc';
-  const destinationAddress = readFormString(formData, 'destinationAddress');
-  const note = readFormString(formData, 'note');
+  const idempotencyKey = readFormString(formData, 'idempotencyKey');
 
   try {
-    await fetchPilotJson({
-      path: '/v1/pilot/withdrawals',
+    const response = await fetchPilotJson<{ ok: true; checkoutUrl: string }>({
+      path: '/v1/pilot/payments/top-up-session',
       method: 'POST',
       cookieHeader: request.headers.get('cookie'),
+      headers: {
+        'idempotency-key': idempotencyKey
+      },
       body: {
         amountMinor,
-        destination: {
-          rail: destinationRail,
-          address: destinationAddress
-        },
-        note: note || undefined
+        returnTo
       }
     });
-    return NextResponse.redirect(new URL(returnTo, request.url), { status: 303 });
+    return NextResponse.redirect(response.checkoutUrl, { status: 303 });
   } catch (error) {
     if (error instanceof PilotServerError) {
       return NextResponse.json({
-        code: 'pilot_withdrawal_error',
+        code: 'pilot_payments_topup_error',
         message: error.message,
         details: error.details
       }, { status: error.status });

--- a/ui/src/app/api/pilot/reserve-floors/route.ts
+++ b/ui/src/app/api/pilot/reserve-floors/route.ts
@@ -5,6 +5,7 @@ import {
   getPilotConnectedAccounts,
   getPilotSession
 } from '../../../../lib/pilot/server';
+import { normalizePilotReturnTo } from '../../../../lib/pilot/returnTo';
 
 export const dynamic = 'force-dynamic';
 
@@ -15,7 +16,7 @@ function readFormString(formData: FormData, key: string): string {
 
 export async function POST(request: NextRequest) {
   const formData = await request.formData();
-  const returnTo = readFormString(formData, 'returnTo') || '/pilot';
+  const returnTo = normalizePilotReturnTo(readFormString(formData, 'returnTo')) ?? '/pilot';
   const credentialId = readFormString(formData, 'credentialId');
   const fiveHourReservePercent = Number(readFormString(formData, 'fiveHourReservePercent'));
   const sevenDayReservePercent = Number(readFormString(formData, 'sevenDayReservePercent'));
@@ -24,7 +25,7 @@ export async function POST(request: NextRequest) {
   try {
     const session = await getPilotSession(cookieHeader);
     if (!session) {
-      return NextResponse.redirect(new URL('/pilot', request.url));
+      return NextResponse.redirect(new URL('/pilot', request.url), { status: 303 });
     }
 
     const accounts = await getPilotConnectedAccounts(cookieHeader);
@@ -45,7 +46,7 @@ export async function POST(request: NextRequest) {
       }
     });
 
-    return NextResponse.redirect(new URL(returnTo, request.url));
+    return NextResponse.redirect(new URL(returnTo, request.url), { status: 303 });
   } catch (error) {
     if (error instanceof PilotServerError) {
       return NextResponse.json({

--- a/ui/src/app/api/pilot/session/logout/route.ts
+++ b/ui/src/app/api/pilot/session/logout/route.ts
@@ -16,7 +16,7 @@ export async function POST(request: NextRequest) {
     }
   }
 
-  const response = NextResponse.redirect(new URL('/pilot', request.url));
+  const response = NextResponse.redirect(new URL('/pilot', request.url), { status: 303 });
   response.cookies.set('innies_pilot_session', '', {
     httpOnly: true,
     sameSite: 'lax',

--- a/ui/src/app/pilot/page.tsx
+++ b/ui/src/app/pilot/page.tsx
@@ -2,6 +2,7 @@ import {
   ConnectedAccountsSection,
   DashboardPage,
   EarningsSection,
+  PaymentFundingSection,
   PilotWithdrawalsSection,
   RequestHistorySection,
   WalletSection,
@@ -48,9 +49,10 @@ export default async function PilotPage() {
         { label: 'Withdrawable', value: formatUsdMinor(dashboard.earningsSummary.withdrawableMinor) },
         { label: 'Accounts', value: formatCount(dashboard.accounts.length) },
       ]}
-      sections={(
+        sections={(
         <>
           <WalletSection ledger={dashboard.walletLedger} wallet={dashboard.wallet} />
+          <PaymentFundingSection funding={dashboard.funding} returnTo="/pilot" />
           <RequestHistorySection orgId={dashboard.session.effectiveOrgId} requests={dashboard.requests} />
           <ConnectedAccountsSection accounts={dashboard.accounts} editable returnTo="/pilot" />
           <EarningsSection history={dashboard.earningsHistory} summary={dashboard.earningsSummary} />

--- a/ui/src/components/pilot/DashboardSections.tsx
+++ b/ui/src/components/pilot/DashboardSections.tsx
@@ -1,10 +1,15 @@
+import { randomBytes } from 'node:crypto';
 import Link from 'next/link';
 import styles from './dashboard.module.css';
 import {
   formatAccountHealth,
   formatCount,
+  formatPaymentAttemptKind,
+  formatPaymentAttemptStatus,
+  formatPaymentTrigger,
   formatPercentRatio,
   formatProvider,
+  formatStoredPaymentMethod,
   formatProviderUsageWarning,
   formatRoutingMode,
   formatTimestamp,
@@ -18,6 +23,7 @@ import type {
   ConnectedAccount,
   EarningsHistoryEntry,
   EarningsSummary,
+  PilotFundingState,
   PilotDashboardData,
   PilotIdentityDiscoveryEntry,
   RequestHistoryRow,
@@ -140,6 +146,146 @@ export function WalletSection(input: {
         </table>
       </div>
       {input.ledger.length === 0 ? <div className={styles.emptyState}>No wallet history yet.</div> : null}
+    </Section>
+  );
+}
+
+export function PaymentFundingSection(input: {
+  funding: PilotFundingState;
+  returnTo: string;
+}) {
+  const manualTopUpIdempotencyKey = randomBytes(24).toString('hex');
+
+  return (
+    <Section
+      title="Payments & Auto-Recharge"
+      hint="Stored card metadata, wallet top-up sessions, and auto-recharge controls stay aligned with processor state while wallet remains the single ledger writer."
+    >
+      <div className={styles.cardGrid}>
+        <article className={styles.identityCard}>
+          <div className={styles.cardTitleRow}>
+            <div>
+              <h3 className={styles.cardTitle}>Stored payment method</h3>
+              <p className={styles.cardMeta}>
+                {input.funding.paymentMethod
+                  ? `${formatStoredPaymentMethod(input.funding.paymentMethod)} · exp ${String(input.funding.paymentMethod.expMonth).padStart(2, '0')}/${input.funding.paymentMethod.expYear}`
+                  : 'No stored card on file yet.'}
+              </p>
+            </div>
+            <span className={input.funding.paymentMethod ? styles.goodPill : styles.pill}>
+              {input.funding.paymentMethod?.status || 'not_configured'}
+            </span>
+          </div>
+          <div className={styles.pillRow}>
+            <span className={styles.pill}>Processor Stripe</span>
+            <span className={styles.pill}>Funding {input.funding.paymentMethod?.funding || '--'}</span>
+          </div>
+          <div className={styles.formActions}>
+            <form action="/api/pilot/payments/setup" method="post">
+              <input name="returnTo" type="hidden" value={input.returnTo} />
+              <button className={styles.actionButton} type="submit">
+                {input.funding.paymentMethod ? 'Replace Card' : 'Add Card'}
+              </button>
+            </form>
+            {input.funding.paymentMethod ? (
+              <form action="/api/pilot/payments/remove" method="post">
+                <input name="returnTo" type="hidden" value={input.returnTo} />
+                <button className={styles.ghostButton} type="submit">Remove Card</button>
+              </form>
+            ) : null}
+          </div>
+          <form action="/api/pilot/payments/top-up" method="post">
+            <input name="idempotencyKey" type="hidden" value={manualTopUpIdempotencyKey} />
+            <input name="returnTo" type="hidden" value={input.returnTo} />
+            <div className={styles.formGrid}>
+              <label className={styles.fieldLabel}>
+                Manual top-up (minor units)
+                <input
+                  className={styles.input}
+                  defaultValue="5000"
+                  min="1"
+                  name="amountMinor"
+                  step="1"
+                  type="number"
+                />
+              </label>
+            </div>
+            <div className={styles.formActions}>
+              <button className={styles.actionButton} disabled={!input.funding.paymentMethod} type="submit">
+                Create Top-Up Session
+              </button>
+            </div>
+          </form>
+        </article>
+
+        <article className={styles.identityCard}>
+          <div className={styles.cardTitleRow}>
+            <div>
+              <h3 className={styles.cardTitle}>Auto-recharge</h3>
+              <p className={styles.cardMeta}>
+                Admission-time and post-finalization recharge attempts use the stored card only when this wallet setting is enabled.
+              </p>
+            </div>
+            <span className={input.funding.autoRecharge.enabled ? styles.goodPill : styles.warnPill}>
+              {input.funding.autoRecharge.enabled ? 'enabled' : 'disabled'}
+            </span>
+          </div>
+          <form action="/api/pilot/payments/auto-recharge" method="post">
+            <div className={styles.formGrid}>
+              <label className={styles.fieldLabel}>
+                Auto-recharge state
+                <select className={styles.select} defaultValue={input.funding.autoRecharge.enabled ? 'true' : 'false'} name="enabled">
+                  <option value="true">Enabled</option>
+                  <option value="false">Disabled</option>
+                </select>
+              </label>
+              <label className={styles.fieldLabel}>
+                Recharge amount (minor units)
+                <input
+                  className={styles.input}
+                  defaultValue={String(input.funding.autoRecharge.amountMinor)}
+                  min="1"
+                  name="amountMinor"
+                  step="1"
+                  type="number"
+                />
+              </label>
+            </div>
+            <div className={styles.formActions}>
+              <input name="returnTo" type="hidden" value={input.returnTo} />
+              <button className={styles.actionButton} type="submit">Save Auto-Recharge</button>
+            </div>
+          </form>
+        </article>
+      </div>
+
+      <div className={styles.tableWrap}>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>Attempt</th>
+              <th>Trigger</th>
+              <th>Amount</th>
+              <th>When</th>
+            </tr>
+          </thead>
+          <tbody>
+            {input.funding.attempts.map((attempt) => (
+              <tr key={attempt.id}>
+                <td>
+                  <strong>{formatPaymentAttemptKind(attempt)}</strong>
+                  <div className={styles.muted}>{formatPaymentAttemptStatus(attempt)}</div>
+                  {attempt.lastErrorMessage ? <div className={styles.muted}>{attempt.lastErrorMessage}</div> : null}
+                </td>
+                <td>{formatPaymentTrigger(attempt)}</td>
+                <td>{formatUsdMinor(attempt.amountMinor)}</td>
+                <td>{formatTimestamp(attempt.updatedAt || attempt.createdAt)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {input.funding.attempts.length === 0 ? <div className={styles.emptyState}>No payment attempts yet.</div> : null}
     </Section>
   );
 }

--- a/ui/src/lib/pilot/present.ts
+++ b/ui/src/lib/pilot/present.ts
@@ -1,5 +1,7 @@
 import type {
   ConnectedAccount,
+  PaymentAttempt,
+  StoredPaymentMethod,
   RequestHistoryRow,
   WalletLedgerEntry,
   Withdrawal,
@@ -129,4 +131,40 @@ export function formatAccountHealth(account: ConnectedAccount): string {
     account.providerUsageWarning ? formatProviderUsageWarning(account) : null
   ].filter((value): value is string => Boolean(value) && value !== '--');
   return pieces.join(' · ') || '--';
+}
+
+export function formatStoredPaymentMethod(paymentMethod: StoredPaymentMethod | null | undefined): string {
+  if (!paymentMethod) return '--';
+  const brand = paymentMethod.brand.trim().length > 0 ? paymentMethod.brand.toUpperCase() : 'Card';
+  return `${brand} •••• ${paymentMethod.last4}`;
+}
+
+export function formatPaymentAttemptKind(attempt: PaymentAttempt): string {
+  return attempt.kind === 'auto_recharge' ? 'Auto-recharge' : 'Manual top-up';
+}
+
+export function formatPaymentAttemptStatus(attempt: PaymentAttempt): string {
+  switch (attempt.status) {
+    case 'pending':
+      return 'Pending';
+    case 'processing':
+      return 'Processing';
+    case 'succeeded':
+      return 'Succeeded';
+    case 'failed':
+      return 'Failed';
+    default:
+      return attempt.status;
+  }
+}
+
+export function formatPaymentTrigger(attempt: PaymentAttempt): string {
+  switch (attempt.trigger) {
+    case 'admission_blocked':
+      return 'Admission blocked';
+    case 'post_finalization_negative':
+      return 'Post-finalization negative';
+    default:
+      return '--';
+  }
 }

--- a/ui/src/lib/pilot/returnTo.ts
+++ b/ui/src/lib/pilot/returnTo.ts
@@ -1,0 +1,8 @@
+export function normalizePilotReturnTo(value: string | null | undefined): string | null {
+  const normalized = value?.trim();
+  if (!normalized) return null;
+  if (!normalized.startsWith('/')) return null;
+  if (normalized.startsWith('//')) return null;
+  if (normalized.includes('\\')) return null;
+  return normalized;
+}

--- a/ui/src/lib/pilot/server.ts
+++ b/ui/src/lib/pilot/server.ts
@@ -6,6 +6,7 @@ import type {
   ConnectedAccount,
   EarningsHistoryEntry,
   EarningsSummary,
+  PilotFundingState,
   PilotDashboardData,
   PilotIdentityDiscoveryEntry,
   PilotSession,
@@ -149,6 +150,7 @@ export async function fetchPilotJson<T>(input: {
   method?: string;
   body?: unknown;
   query?: Record<string, string | undefined>;
+  headers?: Record<string, string>;
 }): Promise<T> {
   const config = readBaseApiConfig();
   const cookieHeader = input.cookieHeader ?? await readCurrentCookieHeader();
@@ -160,7 +162,8 @@ export async function fetchPilotJson<T>(input: {
     query: input.query,
     headers: {
       ...(cookieHeader ? { cookie: cookieHeader } : {}),
-      ...(input.sessionToken ? { authorization: `Bearer ${input.sessionToken}` } : {})
+      ...(input.sessionToken ? { authorization: `Bearer ${input.sessionToken}` } : {}),
+      ...(input.headers ?? {})
     }
   });
 }
@@ -242,7 +245,7 @@ export async function getPilotDashboardData(cookieHeader?: string | null): Promi
   const session = await getPilotSession(cookieHeader);
   if (!session) return null;
 
-  const [wallet, walletLedger, accounts, earningsSummary, earningsHistory, withdrawals, requests] = await Promise.all([
+  const [wallet, walletLedger, funding, accounts, earningsSummary, earningsHistory, withdrawals, requests] = await Promise.all([
     fetchPilotJson<{ ok: true; wallet: WalletSnapshot }>({
       path: '/v1/pilot/wallet',
       cookieHeader
@@ -252,6 +255,10 @@ export async function getPilotDashboardData(cookieHeader?: string | null): Promi
       cookieHeader,
       query: { limit: '50' }
     }).then((response) => response.ledger),
+    fetchPilotJson<{ ok: true; funding: PilotFundingState }>({
+      path: '/v1/pilot/payments',
+      cookieHeader
+    }).then((response) => response.funding),
     getPilotConnectedAccounts(cookieHeader),
     fetchPilotJson<{ ok: true; summary: EarningsSummary }>({
       path: '/v1/pilot/earnings/summary',
@@ -278,6 +285,7 @@ export async function getPilotDashboardData(cookieHeader?: string | null): Promi
     session,
     wallet,
     walletLedger,
+    funding,
     requests,
     accounts,
     earningsSummary,

--- a/ui/src/lib/pilot/types.ts
+++ b/ui/src/lib/pilot/types.ts
@@ -131,6 +131,42 @@ export type Withdrawal = {
   settlement_failure_reason?: string | null;
 };
 
+export type StoredPaymentMethod = {
+  id: string;
+  processor: 'stripe';
+  brand: string;
+  last4: string;
+  expMonth: number;
+  expYear: number;
+  funding: string | null;
+  status: 'active' | 'detached';
+};
+
+export type AutoRechargeSettings = {
+  enabled: boolean;
+  amountMinor: number;
+  currency: string;
+};
+
+export type PaymentAttempt = {
+  id: string;
+  kind: 'manual_topup' | 'auto_recharge';
+  trigger: 'admission_blocked' | 'post_finalization_negative' | null;
+  status: 'pending' | 'processing' | 'succeeded' | 'failed';
+  amountMinor: number;
+  currency: string;
+  createdAt: string;
+  updatedAt: string;
+  lastErrorCode: string | null;
+  lastErrorMessage: string | null;
+};
+
+export type PilotFundingState = {
+  paymentMethod: StoredPaymentMethod | null;
+  autoRecharge: AutoRechargeSettings;
+  attempts: PaymentAttempt[];
+};
+
 export type PilotIdentityDiscoveryEntry = {
   targetUserId: string;
   targetOrgId: string;
@@ -145,6 +181,7 @@ export type PilotDashboardData = {
   session: PilotSession;
   wallet: WalletSnapshot;
   walletLedger: WalletLedgerEntry[];
+  funding: PilotFundingState;
   requests: RequestHistoryRow[];
   accounts: ConnectedAccount[];
   earningsSummary: EarningsSummary;

--- a/ui/tests/pilotDashboard.test.mjs
+++ b/ui/tests/pilotDashboard.test.mjs
@@ -57,6 +57,45 @@ test('pilot page includes the required Darryn dashboard sections', () => {
   assert.ok(sharedSource.includes('Withdrawals'));
 });
 
+test('manual top-up form renders and forwards a stable idempotency key', () => {
+  const sharedSource = readSource('src/components/pilot/DashboardSections.tsx');
+  const routeSource = readSource('src/app/api/pilot/payments/top-up/route.ts');
+  const serverSource = readSource('src/lib/pilot/server.ts');
+
+  assert.ok(sharedSource.includes('randomUUID') || sharedSource.includes('randomBytes'));
+  assert.ok(sharedSource.includes('manualTopUpIdempotencyKey'));
+  assert.ok(sharedSource.includes('name="idempotencyKey"'));
+  assert.ok(routeSource.includes("readFormString(formData, 'idempotencyKey')"));
+  assert.ok(routeSource.includes("'idempotency-key': idempotencyKey"));
+  assert.ok(serverSource.includes('headers?: Record<string, string>'));
+  assert.ok(serverSource.includes('...(input.headers ?? {})'));
+});
+
+test('payment redirect routes sanitize returnTo before redirecting', async () => {
+  const { normalizePilotReturnTo } = await import('../src/lib/pilot/returnTo.ts');
+  const removeRouteSource = readSource('src/app/api/pilot/payments/remove/route.ts');
+  const autoRechargeRouteSource = readSource('src/app/api/pilot/payments/auto-recharge/route.ts');
+
+  assert.equal(normalizePilotReturnTo(' /pilot?tab=funding '), '/pilot?tab=funding');
+  assert.equal(normalizePilotReturnTo('//attacker.example'), null);
+  assert.equal(normalizePilotReturnTo('/\\attacker.example'), null);
+  assert.equal(normalizePilotReturnTo('https://attacker.example/pilot'), null);
+  assert.ok(removeRouteSource.includes('normalizePilotReturnTo'));
+  assert.ok(autoRechargeRouteSource.includes('normalizePilotReturnTo'));
+});
+
+test('payment POST routes use 303 redirects after successful submission', () => {
+  const setupRouteSource = readSource('src/app/api/pilot/payments/setup/route.ts');
+  const topUpRouteSource = readSource('src/app/api/pilot/payments/top-up/route.ts');
+  const removeRouteSource = readSource('src/app/api/pilot/payments/remove/route.ts');
+  const autoRechargeRouteSource = readSource('src/app/api/pilot/payments/auto-recharge/route.ts');
+
+  assert.ok(setupRouteSource.includes('status: 303'));
+  assert.ok(topUpRouteSource.includes('status: 303'));
+  assert.ok(removeRouteSource.includes('status: 303'));
+  assert.ok(autoRechargeRouteSource.includes('status: 303'));
+});
+
 test('admin pilot entry page includes identity discovery and impersonation entry UI', () => {
   const pageSource = readSource('src/app/admin/pilot/page.tsx');
   const sharedSource = readSource('src/components/pilot/DashboardSections.tsx');


### PR DESCRIPTION
## Summary
- add the Phase 2 payments domain for stored payment methods, processor setup/payment flows, webhook normalization, and wallet-owned recharge recording seams
- add Darryn dashboard payment method and auto-recharge UI/actions on the merged pilot surfaces, plus safe `returnTo` handling and POST redirect hardening
- cover idempotent webhook replay, refund/reversal handling, auto-recharge serialization, and payment repository behavior with focused API and UI tests

## Test Plan
- `cd api && npm test -- paymentMethodRepository.test.ts paymentProfileRepository.test.ts paymentService.test.ts paymentOutcomeRepository.test.ts payments.route.test.ts darrynPaymentsRechargeMigrations.test.ts walletService.test.ts walletLedgerRepository.test.ts pilot.route.test.ts stripeClient.test.ts`
- `cd api && npm run build`
- `node --test ui/tests/*.test.mjs ui/tests/*.test.js`
- `cd ui && npm run build`
- `cd api && npm test` *(still fails only in the existing unrelated `api/tests/anthropicCompat.route.test.ts` bucket: latest run 18 failed / 553 passed)*
