### PR TITLE
fix: repair pilot auth redirect flow

### DIFF
--- a/api/src/routes/admin.ts
+++ b/api/src/routes/admin.ts
@@ -9,6 +9,7 @@ import {
   readClaudeContributionCapProviderExhaustionHold,
   readClaudeContributionCapSnapshotState
 } from '../services/claudeContributionCapState.js';
+import { buildPilotSessionCookie } from '../services/pilot/pilotSessionCookie.js';
 import {
   type AnthropicOauthUsageRefreshOutcome,
   isAnthropicOauthTokenCredential,
@@ -396,7 +397,7 @@ router.post('/v1/admin/pilot/session', requireApiKey(runtime.repos.apiKeys, ['ad
       };
 
     const sessionToken = runtime.services.pilotSessions.issueSession(session);
-    res.setHeader('set-cookie', `innies_pilot_session=${sessionToken}; Path=/; HttpOnly; SameSite=Lax`);
+    res.setHeader('set-cookie', buildPilotSessionCookie(sessionToken));
     res.status(200).json({
       ok: true,
       sessionToken,

--- a/api/src/routes/pilot.ts
+++ b/api/src/routes/pilot.ts
@@ -4,6 +4,11 @@ import { Router } from 'express';
 import { z } from 'zod';
 import { runtime } from '../services/runtime.js';
 import { buildConnectedAccountInventory } from '../services/pilot/pilotConnectedAccountInventory.js';
+import {
+  buildClearedPilotSessionCookie,
+  buildPilotSessionCookie,
+  buildPilotUiRedirectUrl
+} from '../services/pilot/pilotSessionCookie.js';
 import { AppError } from '../utils/errors.js';
 import { sha256Hex, stableJson } from '../utils/hash.js';
 import { readAndValidateIdempotencyKey } from '../utils/idempotencyKey.js';
@@ -352,7 +357,7 @@ router.get('/v1/pilot/auth/github/callback', async (req, res, next) => {
     });
 
     res.setHeader('set-cookie', buildPilotSessionCookie(result.sessionToken));
-    res.redirect(302, normalizePilotReturnTo(result.returnTo) ?? '/pilot');
+    res.redirect(302, buildPilotUiRedirectUrl(normalizePilotReturnTo(result.returnTo) ?? '/pilot'));
   } catch (error) {
     next(error);
   }
@@ -427,13 +432,5 @@ router.post('/v1/pilot/withdrawals', async (req, res, next) => {
     next(error);
   }
 });
-
-export function buildPilotSessionCookie(token: string): string {
-  return `innies_pilot_session=${token}; Path=/; HttpOnly; SameSite=Lax`;
-}
-
-export function buildClearedPilotSessionCookie(): string {
-  return 'innies_pilot_session=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0';
-}
 
 export default router;

--- a/api/src/services/pilot/pilotSessionCookie.ts
+++ b/api/src/services/pilot/pilotSessionCookie.ts
@@ -1,0 +1,120 @@
+function readBaseUrl(value: string | null | undefined): string | null {
+  const normalized = value?.trim();
+  if (!normalized) return null;
+  try {
+    return new URL(normalized).origin;
+  } catch {
+    return null;
+  }
+}
+
+function readHostname(value: string | null | undefined): string | null {
+  const baseUrl = readBaseUrl(value);
+  if (!baseUrl) return null;
+  try {
+    return new URL(baseUrl).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+function readProtocol(value: string | null | undefined): string | null {
+  const baseUrl = readBaseUrl(value);
+  if (!baseUrl) return null;
+  try {
+    return new URL(baseUrl).protocol;
+  } catch {
+    return null;
+  }
+}
+
+function sharedDomainSuffix(leftHost: string | null, rightHost: string | null): string | null {
+  if (!leftHost || !rightHost) return null;
+
+  const leftLabels = leftHost.split('.').filter(Boolean);
+  const rightLabels = rightHost.split('.').filter(Boolean);
+  const shared: string[] = [];
+
+  while (
+    shared.length < leftLabels.length
+    && shared.length < rightLabels.length
+    && leftLabels[leftLabels.length - 1 - shared.length] === rightLabels[rightLabels.length - 1 - shared.length]
+  ) {
+    shared.unshift(leftLabels[leftLabels.length - 1 - shared.length]);
+  }
+
+  if (shared.length < 2) return null;
+  const suffix = shared.join('.');
+
+  if (/^\d+\.\d+\.\d+\.\d+$/.test(suffix) || suffix.includes(':')) {
+    return null;
+  }
+
+  return suffix;
+}
+
+function readPilotUiBaseUrl(): string {
+  return readBaseUrl(process.env.PILOT_UI_BASE_URL ?? process.env.UI_BASE_URL) ?? 'https://www.innies.computer';
+}
+
+function readPilotApiBaseUrl(): string | null {
+  return readBaseUrl(process.env.PILOT_GITHUB_CALLBACK_URL);
+}
+
+function readPilotSessionCookieDomain(): string | null {
+  return sharedDomainSuffix(
+    readHostname(readPilotUiBaseUrl()),
+    readHostname(readPilotApiBaseUrl())
+  );
+}
+
+function shouldUseSecureCookies(): boolean {
+  return [readPilotUiBaseUrl(), readPilotApiBaseUrl()]
+    .some((value) => readProtocol(value) === 'https:');
+}
+
+export function buildPilotUiRedirectUrl(returnTo: string | null | undefined): string {
+  const normalized = returnTo?.trim();
+  const safeReturnTo = normalized
+    && normalized.startsWith('/')
+    && !normalized.startsWith('//')
+    && !normalized.includes('\\')
+    ? normalized
+    : '/pilot';
+  return new URL(safeReturnTo, `${readPilotUiBaseUrl()}/`).toString();
+}
+
+export function buildPilotSessionCookie(token: string): string {
+  const parts = [
+    `innies_pilot_session=${token}`,
+    'Path=/',
+    'HttpOnly',
+    'SameSite=Lax'
+  ];
+  const domain = readPilotSessionCookieDomain();
+  if (domain) {
+    parts.push(`Domain=${domain}`);
+  }
+  if (shouldUseSecureCookies()) {
+    parts.push('Secure');
+  }
+  return parts.join('; ');
+}
+
+export function buildClearedPilotSessionCookie(): string {
+  const parts = [
+    'innies_pilot_session=',
+    'Path=/',
+    'HttpOnly',
+    'SameSite=Lax',
+    'Max-Age=0'
+  ];
+  const domain = readPilotSessionCookieDomain();
+  if (domain) {
+    parts.push(`Domain=${domain}`);
+  }
+  if (shouldUseSecureCookies()) {
+    parts.push('Secure');
+  }
+  return parts.join('; ');
+}

--- a/api/tests/pilot.route.test.ts
+++ b/api/tests/pilot.route.test.ts
@@ -172,6 +172,9 @@ describe('pilot routes', () => {
 
   beforeEach(() => {
     const now = Date.now();
+    delete process.env.PILOT_UI_BASE_URL;
+    delete process.env.UI_BASE_URL;
+    delete process.env.PILOT_GITHUB_CALLBACK_URL;
     vi.restoreAllMocks();
     vi.spyOn(runtimeModule.runtime.services.pilotSessions, 'readTokenFromRequest').mockReturnValue('pilot-token');
     vi.spyOn(runtimeModule.runtime.services.pilotSessions, 'readSession').mockReturnValue({
@@ -896,6 +899,8 @@ describe('pilot routes', () => {
   });
 
   it('handles the GitHub callback by setting the pilot session cookie and redirecting', async () => {
+    process.env.PILOT_UI_BASE_URL = 'https://www.innies.computer';
+    process.env.PILOT_GITHUB_CALLBACK_URL = 'https://api.innies.computer/v1/pilot/auth/github/callback';
     vi.spyOn(runtimeModule.runtime.services.pilotGithubAuth, 'finishOauthCallback').mockResolvedValue({
       sessionToken: 'signed-session-token',
       returnTo: '/pilot',
@@ -918,12 +923,43 @@ describe('pilot routes', () => {
     await invoke(authCallbackHandlers[0], req, res);
 
     expect(res.statusCode).toBe(302);
-    expect(res.headers.location).toBe('/pilot');
+    expect(res.headers.location).toBe('https://www.innies.computer/pilot');
     expect(res.headers['set-cookie']).toContain('innies_pilot_session=signed-session-token');
+    expect(res.headers['set-cookie']).toContain('Domain=innies.computer');
     expect(res.headers['set-cookie']).toContain('HttpOnly');
   });
 
+  it('defaults the GitHub callback redirect to the canonical prod UI host when no pilot UI env is set', async () => {
+    process.env.PILOT_GITHUB_CALLBACK_URL = 'https://api.innies.computer/v1/pilot/auth/github/callback';
+    vi.spyOn(runtimeModule.runtime.services.pilotGithubAuth, 'finishOauthCallback').mockResolvedValue({
+      sessionToken: 'signed-session-token',
+      returnTo: '/pilot',
+      session: {
+        sessionKind: 'darryn_self',
+        actorUserId: 'user_darryn',
+        effectiveOrgId: 'org_fnf',
+        githubLogin: 'darryn',
+        userEmail: 'darryn@example.com'
+      }
+    } as any);
+
+    const req = createMockReq({
+      method: 'GET',
+      path: '/v1/pilot/auth/github/callback',
+      query: { code: 'oauth-code', state: 'oauth-state' }
+    });
+    const res = createMockRes();
+
+    await invoke(authCallbackHandlers[0], req, res);
+
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toBe('https://www.innies.computer/pilot');
+    expect(res.headers['set-cookie']).toContain('Domain=innies.computer');
+  });
+
   it('falls back to /pilot when the callback returnTo is unsafe', async () => {
+    process.env.PILOT_UI_BASE_URL = 'https://www.innies.computer';
+    process.env.PILOT_GITHUB_CALLBACK_URL = 'https://api.innies.computer/v1/pilot/auth/github/callback';
     vi.spyOn(runtimeModule.runtime.services.pilotGithubAuth, 'finishOauthCallback').mockResolvedValue({
       sessionToken: 'signed-session-token',
       returnTo: 'https://evil.example.com/phish',
@@ -946,10 +982,12 @@ describe('pilot routes', () => {
     await invoke(authCallbackHandlers[0], req, res);
 
     expect(res.statusCode).toBe(302);
-    expect(res.headers.location).toBe('/pilot');
+    expect(res.headers.location).toBe('https://www.innies.computer/pilot');
   });
 
   it('falls back to /pilot when the callback returnTo uses slash-backslash host bypass', async () => {
+    process.env.PILOT_UI_BASE_URL = 'https://www.innies.computer';
+    process.env.PILOT_GITHUB_CALLBACK_URL = 'https://api.innies.computer/v1/pilot/auth/github/callback';
     vi.spyOn(runtimeModule.runtime.services.pilotGithubAuth, 'finishOauthCallback').mockResolvedValue({
       sessionToken: 'signed-session-token',
       returnTo: '/\\evil.example.com',
@@ -972,7 +1010,7 @@ describe('pilot routes', () => {
     await invoke(authCallbackHandlers[0], req, res);
 
     expect(res.statusCode).toBe(302);
-    expect(res.headers.location).toBe('/pilot');
+    expect(res.headers.location).toBe('https://www.innies.computer/pilot');
   });
 
   it('clears the pilot session cookie on logout', async () => {

--- a/ui/src/app/api/admin/pilot/impersonate/route.ts
+++ b/ui/src/app/api/admin/pilot/impersonate/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { PilotServerError, fetchAdminJson } from '../../../../../lib/pilot/server';
+import { pilotSessionCookieOptions } from '../../../../../lib/pilot/sessionCookie';
 
 export const dynamic = 'force-dynamic';
 
@@ -27,11 +28,7 @@ export async function POST(request: NextRequest) {
     });
 
     const redirect = NextResponse.redirect(new URL('/pilot', request.url), { status: 303 });
-    redirect.cookies.set('innies_pilot_session', response.sessionToken, {
-      httpOnly: true,
-      sameSite: 'lax',
-      path: '/'
-    });
+    redirect.cookies.set('innies_pilot_session', response.sessionToken, pilotSessionCookieOptions(request.url));
     return redirect;
   } catch (error) {
     if (error instanceof PilotServerError) {

--- a/ui/src/app/api/pilot/session/logout/route.ts
+++ b/ui/src/app/api/pilot/session/logout/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { PilotServerError, fetchPilotJson } from '../../../../../lib/pilot/server';
+import { pilotSessionCookieOptions } from '../../../../../lib/pilot/sessionCookie';
 
 export const dynamic = 'force-dynamic';
 
@@ -17,11 +18,6 @@ export async function POST(request: NextRequest) {
   }
 
   const response = NextResponse.redirect(new URL('/pilot', request.url), { status: 303 });
-  response.cookies.set('innies_pilot_session', '', {
-    httpOnly: true,
-    sameSite: 'lax',
-    path: '/',
-    maxAge: 0
-  });
+  response.cookies.set('innies_pilot_session', '', pilotSessionCookieOptions(request.url, { maxAge: 0 }));
   return response;
 }

--- a/ui/src/lib/pilot/sessionCookie.ts
+++ b/ui/src/lib/pilot/sessionCookie.ts
@@ -1,0 +1,54 @@
+function normalizeUrl(value: string | null | undefined): URL | null {
+  const normalized = value?.trim();
+  if (!normalized) return null;
+  try {
+    return new URL(normalized);
+  } catch {
+    return null;
+  }
+}
+
+export function resolvePilotSessionCookieDomain(
+  uiUrl: string,
+  apiBaseUrl: string | null | undefined
+): string | null {
+  const uiHost = normalizeUrl(uiUrl)?.hostname.toLowerCase() ?? null;
+  const apiHost = normalizeUrl(apiBaseUrl)?.hostname.toLowerCase() ?? null;
+  if (!uiHost || !apiHost) return null;
+
+  const uiLabels = uiHost.split('.').filter(Boolean);
+  const apiLabels = apiHost.split('.').filter(Boolean);
+  const shared: string[] = [];
+
+  while (
+    shared.length < uiLabels.length
+    && shared.length < apiLabels.length
+    && uiLabels[uiLabels.length - 1 - shared.length] === apiLabels[apiLabels.length - 1 - shared.length]
+  ) {
+    shared.unshift(uiLabels[uiLabels.length - 1 - shared.length]);
+  }
+
+  if (shared.length < 2) return null;
+  const domain = shared.join('.');
+  if (/^\d+\.\d+\.\d+\.\d+$/.test(domain) || domain.includes(':')) {
+    return null;
+  }
+  return domain;
+}
+
+export function pilotSessionCookieOptions(requestUrl: string, input?: { maxAge?: number }) {
+  const domain = resolvePilotSessionCookieDomain(
+    requestUrl,
+    process.env.INNIES_API_BASE_URL?.trim() || process.env.INNIES_BASE_URL?.trim() || null
+  );
+  const isSecure = normalizeUrl(requestUrl)?.protocol === 'https:';
+
+  return {
+    httpOnly: true,
+    sameSite: 'lax' as const,
+    path: '/',
+    ...(domain ? { domain } : {}),
+    ...(isSecure ? { secure: true } : {}),
+    ...(input?.maxAge === undefined ? {} : { maxAge: input.maxAge })
+  };
+}

--- a/ui/tests/pilotDashboard.test.mjs
+++ b/ui/tests/pilotDashboard.test.mjs
@@ -84,6 +84,23 @@ test('payment redirect routes sanitize returnTo before redirecting', async () =>
   assert.ok(autoRechargeRouteSource.includes('normalizePilotReturnTo'));
 });
 
+test('pilot auth cookie helpers derive a shared parent domain for api/ui siblings', async () => {
+  const { resolvePilotSessionCookieDomain } = await import('../src/lib/pilot/sessionCookie.ts');
+  const impersonateRouteSource = readSource('src/app/api/admin/pilot/impersonate/route.ts');
+  const logoutRouteSource = readSource('src/app/api/pilot/session/logout/route.ts');
+
+  assert.equal(
+    resolvePilotSessionCookieDomain('https://www.innies.computer/pilot', 'https://api.innies.computer'),
+    'innies.computer'
+  );
+  assert.equal(
+    resolvePilotSessionCookieDomain('http://localhost:3000/pilot', 'http://localhost:4010'),
+    null
+  );
+  assert.ok(impersonateRouteSource.includes('pilotSessionCookieOptions'));
+  assert.ok(logoutRouteSource.includes('pilotSessionCookieOptions'));
+});
+
 test('payment POST routes use 303 redirects after successful submission', () => {
   const setupRouteSource = readSource('src/app/api/pilot/payments/setup/route.ts');
   const topUpRouteSource = readSource('src/app/api/pilot/payments/top-up/route.ts');


### PR DESCRIPTION
## Summary
- redirect pilot GitHub OAuth callbacks to the canonical UI host instead of relative `/pilot`
- scope the pilot session cookie for the shared `innies.computer` domain so auth works across `api` and `www`
- align admin impersonation and logout with the same shared cookie behavior, while defaulting prod to `https://www.innies.computer` without requiring a new API env

## Test Plan
- [x] `cd api && npm test -- pilot.route.test.ts admin.pilot.route.test.ts`
- [x] `node --test ui/tests/pilotDashboard.test.mjs`
- [x] `cd api && npm run build`
- [x] `cd ui && npm run build`