### PR TITLE
fix: harden pilot prod url fallbacks

### DIFF
--- a/api/src/services/payments/paymentService.ts
+++ b/api/src/services/payments/paymentService.ts
@@ -14,6 +14,7 @@ import {
   type PaymentWalletEffectType
 } from './paymentTypes.js';
 import type { StripeClient, StripeWebhookEvent } from './stripeClient.js';
+import { readPilotUiBaseUrl } from '../pilot/pilotUrlConfig.js';
 
 export class PaymentService {
   constructor(private readonly deps: {
@@ -662,11 +663,10 @@ function buildCheckoutUrls(returnTo: string | null | undefined): {
   successUrl: string;
   cancelUrl: string;
 } {
-  const baseUrl = (process.env.PILOT_UI_BASE_URL ?? process.env.UI_BASE_URL ?? 'http://localhost:3000').replace(/\/+$/, '');
   const safeReturnTo = normalizeReturnTo(returnTo) ?? '/pilot';
   return {
-    successUrl: `${baseUrl}${safeReturnTo}`,
-    cancelUrl: `${baseUrl}${safeReturnTo}`
+    successUrl: new URL(safeReturnTo, `${readPilotUiBaseUrl()}/`).toString(),
+    cancelUrl: new URL(safeReturnTo, `${readPilotUiBaseUrl()}/`).toString()
   };
 }
 

--- a/api/src/services/pilot/pilotSessionCookie.ts
+++ b/api/src/services/pilot/pilotSessionCookie.ts
@@ -1,3 +1,8 @@
+import {
+  readPilotApiBaseUrl,
+  readPilotUiBaseUrl
+} from './pilotUrlConfig.js';
+
 function readBaseUrl(value: string | null | undefined): string | null {
   const normalized = value?.trim();
   if (!normalized) return null;
@@ -51,14 +56,6 @@ function sharedDomainSuffix(leftHost: string | null, rightHost: string | null): 
   }
 
   return suffix;
-}
-
-function readPilotUiBaseUrl(): string {
-  return readBaseUrl(process.env.PILOT_UI_BASE_URL ?? process.env.UI_BASE_URL) ?? 'https://www.innies.computer';
-}
-
-function readPilotApiBaseUrl(): string | null {
-  return readBaseUrl(process.env.PILOT_GITHUB_CALLBACK_URL);
 }
 
 function readPilotSessionCookieDomain(): string | null {

--- a/api/src/services/pilot/pilotUrlConfig.ts
+++ b/api/src/services/pilot/pilotUrlConfig.ts
@@ -1,0 +1,55 @@
+const DEFAULT_PILOT_UI_BASE_URL = 'https://www.innies.computer';
+const DEFAULT_LOCAL_PILOT_API_BASE_URL = 'http://localhost:4010';
+const PILOT_GITHUB_CALLBACK_PATH = '/v1/pilot/auth/github/callback';
+
+function readAbsoluteUrl(value: string | null | undefined): string | null {
+  const normalized = value?.trim();
+  if (!normalized) return null;
+
+  try {
+    return new URL(normalized).toString();
+  } catch {
+    return null;
+  }
+}
+
+function readBaseUrl(value: string | null | undefined): string | null {
+  const absoluteUrl = readAbsoluteUrl(value);
+  if (!absoluteUrl) return null;
+
+  try {
+    return new URL(absoluteUrl).origin;
+  } catch {
+    return null;
+  }
+}
+
+function isLocalFallbackAllowed(): boolean {
+  return process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'development';
+}
+
+export function readPilotUiBaseUrl(): string {
+  return readBaseUrl(process.env.PILOT_UI_BASE_URL ?? process.env.UI_BASE_URL) ?? DEFAULT_PILOT_UI_BASE_URL;
+}
+
+export function readPilotApiBaseUrl(): string | null {
+  return readBaseUrl(process.env.PILOT_GITHUB_CALLBACK_URL) ?? readBaseUrl(process.env.INNIES_BASE_URL);
+}
+
+export function readPilotGithubCallbackUrl(): string {
+  const configuredCallbackUrl = readAbsoluteUrl(process.env.PILOT_GITHUB_CALLBACK_URL);
+  if (configuredCallbackUrl) {
+    return configuredCallbackUrl;
+  }
+
+  const apiBaseUrl = readPilotApiBaseUrl();
+  if (apiBaseUrl) {
+    return new URL(PILOT_GITHUB_CALLBACK_PATH, `${apiBaseUrl}/`).toString();
+  }
+
+  if (isLocalFallbackAllowed()) {
+    return new URL(PILOT_GITHUB_CALLBACK_PATH, `${DEFAULT_LOCAL_PILOT_API_BASE_URL}/`).toString();
+  }
+
+  throw new Error('Missing pilot GitHub callback configuration. Set PILOT_GITHUB_CALLBACK_URL or INNIES_BASE_URL.');
+}

--- a/api/src/services/runtime.ts
+++ b/api/src/services/runtime.ts
@@ -45,6 +45,7 @@ import { PilotCutoverService } from './pilot/pilotCutoverService.js';
 import { WalletService } from './wallet/walletService.js';
 import { PaymentService } from './payments/paymentService.js';
 import { StripeClient } from './payments/stripeClient.js';
+import { readPilotGithubCallbackUrl } from './pilot/pilotUrlConfig.js';
 import { assertRequiredEnv, readRequiredEnv } from '../utils/env.js';
 import { AppError } from '../utils/errors.js';
 
@@ -127,7 +128,7 @@ runtime.services.pilotSessions = new PilotSessionService({
 runtime.services.pilotGithubAuth = new PilotGithubAuthService({
   clientId: process.env.PILOT_GITHUB_CLIENT_ID || '',
   clientSecret: process.env.PILOT_GITHUB_CLIENT_SECRET || '',
-  callbackUrl: process.env.PILOT_GITHUB_CALLBACK_URL || 'http://localhost:4010/v1/pilot/auth/github/callback',
+  callbackUrl: readPilotGithubCallbackUrl(),
   allowlistedLogins: (process.env.PILOT_GITHUB_ALLOWLIST_LOGINS || '').split(',').map((value) => value.trim()).filter(Boolean),
   allowlistedEmails: (process.env.PILOT_GITHUB_ALLOWLIST_EMAILS || '').split(',').map((value) => value.trim()).filter(Boolean),
   identityRepository: runtime.repos.pilotIdentity,

--- a/api/tests/paymentService.test.ts
+++ b/api/tests/paymentService.test.ts
@@ -242,7 +242,7 @@ describe('PaymentService', () => {
     });
   });
 
-  it('falls back to /pilot checkout URLs when returnTo uses a slash-backslash host bypass', async () => {
+  it('falls back to the canonical prod /pilot checkout URLs when returnTo uses a slash-backslash host bypass', async () => {
     const createSetupSession = vi.fn().mockResolvedValue({
       id: 'seti_1',
       url: 'https://checkout.stripe.test/setup'
@@ -279,8 +279,8 @@ describe('PaymentService', () => {
     });
 
     expect(createSetupSession).toHaveBeenCalledWith(expect.objectContaining({
-      successUrl: 'http://localhost:3000/pilot',
-      cancelUrl: 'http://localhost:3000/pilot'
+      successUrl: 'https://www.innies.computer/pilot',
+      cancelUrl: 'https://www.innies.computer/pilot'
     }));
   });
 

--- a/api/tests/pilotUrlConfig.test.ts
+++ b/api/tests/pilotUrlConfig.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  readPilotApiBaseUrl,
+  readPilotGithubCallbackUrl,
+  readPilotUiBaseUrl
+} from '../src/services/pilot/pilotUrlConfig.js';
+
+const originalEnv = {
+  INNIES_BASE_URL: process.env.INNIES_BASE_URL,
+  NODE_ENV: process.env.NODE_ENV,
+  PILOT_GITHUB_CALLBACK_URL: process.env.PILOT_GITHUB_CALLBACK_URL,
+  PILOT_UI_BASE_URL: process.env.PILOT_UI_BASE_URL,
+  UI_BASE_URL: process.env.UI_BASE_URL
+};
+
+afterEach(() => {
+  restoreEnv('INNIES_BASE_URL', originalEnv.INNIES_BASE_URL);
+  restoreEnv('NODE_ENV', originalEnv.NODE_ENV);
+  restoreEnv('PILOT_GITHUB_CALLBACK_URL', originalEnv.PILOT_GITHUB_CALLBACK_URL);
+  restoreEnv('PILOT_UI_BASE_URL', originalEnv.PILOT_UI_BASE_URL);
+  restoreEnv('UI_BASE_URL', originalEnv.UI_BASE_URL);
+});
+
+describe('pilotUrlConfig', () => {
+  it('falls back to the canonical prod UI host when no UI env is set', () => {
+    delete process.env.PILOT_UI_BASE_URL;
+    delete process.env.UI_BASE_URL;
+
+    expect(readPilotUiBaseUrl()).toBe('https://www.innies.computer');
+  });
+
+  it('derives the pilot GitHub callback URL from INNIES_BASE_URL when not explicitly set', () => {
+    delete process.env.PILOT_GITHUB_CALLBACK_URL;
+    process.env.INNIES_BASE_URL = 'https://api.innies.computer/';
+
+    expect(readPilotApiBaseUrl()).toBe('https://api.innies.computer');
+    expect(readPilotGithubCallbackUrl()).toBe('https://api.innies.computer/v1/pilot/auth/github/callback');
+  });
+
+  it('fails closed in production when no pilot callback base URL is configured', () => {
+    delete process.env.INNIES_BASE_URL;
+    delete process.env.PILOT_GITHUB_CALLBACK_URL;
+    process.env.NODE_ENV = 'production';
+
+    expect(() => readPilotGithubCallbackUrl()).toThrow(
+      'Missing pilot GitHub callback configuration. Set PILOT_GITHUB_CALLBACK_URL or INNIES_BASE_URL.'
+    );
+  });
+});
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}


### PR DESCRIPTION
## Summary
- centralize prod-facing pilot UI and GitHub callback URL resolution in a shared config helper
- keep Stripe setup/top-up redirects on the canonical prod UI host instead of silently falling back to localhost
- fail closed on missing pilot GitHub callback configuration outside development/test

## Verification
- cd api && npm test -- pilotUrlConfig.test.ts
- cd api && npm test -- paymentService.test.ts
- cd api && npm test -- pilot.route.test.ts admin.pilot.route.test.ts
- cd api && npm run build
