### PR TITLE
Fail pilot cutover closed on partial reassignment

### DIFF
--- a/api/src/services/pilot/pilotCutoverService.ts
+++ b/api/src/services/pilot/pilotCutoverService.ts
@@ -117,14 +117,17 @@ export class PilotCutoverService {
           role: 'buyer'
         });
 
-        await identityRepository.reassignBuyerKeysToOrg({
+        const reassignedBuyerKeyIds = await identityRepository.reassignBuyerKeysToOrg({
           apiKeyIds: input.buyerKeyIds,
           targetOrgId: org.id
         });
-        await identityRepository.reassignTokenCredentialsToOrg({
+        this.assertExactReassignment('buyer key', input.buyerKeyIds, reassignedBuyerKeyIds);
+
+        const reassignedTokenCredentialIds = await identityRepository.reassignTokenCredentialsToOrg({
           tokenCredentialIds: input.tokenCredentialIds,
           targetOrgId: org.id
         });
+        this.assertExactReassignment('token credential', input.tokenCredentialIds, reassignedTokenCredentialIds);
 
         await Promise.all(input.buyerKeyIds.map((apiKeyId) => fnfOwnershipRepository.upsertBuyerKeyOwnership({
           apiKeyId,
@@ -204,14 +207,17 @@ export class PilotCutoverService {
         const pilotCutoverRepository = this.createPilotCutoverRepository(tx);
         const transactionalFreezeRepository = this.createFreezeRepository(tx);
 
-        await identityRepository.reassignBuyerKeysToOrg({
+        const reassignedBuyerKeyIds = await identityRepository.reassignBuyerKeysToOrg({
           apiKeyIds: input.buyerKeyIds,
           targetOrgId: input.targetOrgId
         });
-        await identityRepository.reassignTokenCredentialsToOrg({
+        this.assertExactReassignment('buyer key', input.buyerKeyIds, reassignedBuyerKeyIds);
+
+        const reassignedTokenCredentialIds = await identityRepository.reassignTokenCredentialsToOrg({
           tokenCredentialIds: input.tokenCredentialIds,
           targetOrgId: input.targetOrgId
         });
+        this.assertExactReassignment('token credential', input.tokenCredentialIds, reassignedTokenCredentialIds);
 
         await Promise.all(input.buyerKeyIds.map((apiKeyId) => fnfOwnershipRepository.upsertBuyerKeyOwnership({
           apiKeyId,
@@ -295,5 +301,16 @@ export class PilotCutoverService {
       resourceId: freeze.resourceId,
       errorMessage: message
     })));
+  }
+
+  private assertExactReassignment(resourceLabel: string, requestedIds: string[], updatedIds: string[]): void {
+    const uniqueRequestedIds = [...new Set(requestedIds)];
+    const updatedSet = new Set(updatedIds);
+    if (uniqueRequestedIds.every((id) => updatedSet.has(id))) {
+      return;
+    }
+
+    const missingIds = uniqueRequestedIds.filter((id) => !updatedSet.has(id));
+    throw new Error(`pilot ${resourceLabel} base ownership reassignment mismatch: missing ${missingIds.join(', ')}`);
   }
 }

--- a/api/tests/pilotCutoverService.test.ts
+++ b/api/tests/pilotCutoverService.test.ts
@@ -163,6 +163,80 @@ describe('PilotCutoverService', () => {
     expect(freezeRepository.releaseFreeze).not.toHaveBeenCalled();
   });
 
+  it('fails cutover closed when a requested buyer key base row is not reassigned', async () => {
+    const {
+      service,
+      freezeRepository,
+      identityRepository,
+      fnfOwnershipRepository,
+      cutoverRepository,
+      reserveFloorMigration
+    } = createService();
+    identityRepository.reassignBuyerKeysToOrg.mockResolvedValue([]);
+
+    await expect(service.cutover({
+      sourceOrgId: 'org_innies',
+      targetOrgSlug: 'fnf',
+      targetOrgName: 'Friends & Family',
+      targetUserEmail: 'darryn@example.com',
+      targetUserDisplayName: 'Darryn',
+      buyerKeyIds: ['buyer_1'],
+      tokenCredentialIds: ['cred_1']
+    } as any)).rejects.toThrow(/buyer key/i);
+
+    expect(fnfOwnershipRepository.upsertBuyerKeyOwnership).not.toHaveBeenCalled();
+    expect(cutoverRepository.createCutoverRecord).not.toHaveBeenCalled();
+    expect(reserveFloorMigration.migrateReserveFloors).not.toHaveBeenCalled();
+    expect(freezeRepository.recordFailure).toHaveBeenCalledTimes(2);
+  });
+
+  it('fails rollback closed when a requested token credential base row is not reassigned', async () => {
+    const {
+      service,
+      freezeRepository,
+      identityRepository,
+      fnfOwnershipRepository,
+      cutoverRepository
+    } = createService();
+    identityRepository.reassignTokenCredentialsToOrg.mockResolvedValue([]);
+
+    await expect(service.rollback({
+      sourceCutoverId: 'cut_1',
+      targetOrgId: 'org_innies',
+      buyerKeyIds: ['buyer_1'],
+      tokenCredentialIds: ['cred_1']
+    } as any)).rejects.toThrow(/token credential/i);
+
+    expect(fnfOwnershipRepository.upsertTokenCredentialOwnership).not.toHaveBeenCalled();
+    expect(cutoverRepository.createRollbackRecord).not.toHaveBeenCalled();
+    expect(freezeRepository.recordFailure).toHaveBeenCalledTimes(2);
+  });
+
+  it('accepts duplicate requested ids when the unique base rows were reassigned', async () => {
+    const {
+      service,
+      cutoverRepository,
+      fnfOwnershipRepository,
+      reserveFloorMigration
+    } = createService();
+
+    const result = await service.cutover({
+      sourceOrgId: 'org_innies',
+      targetOrgSlug: 'fnf',
+      targetOrgName: 'Friends & Family',
+      targetUserEmail: 'darryn@example.com',
+      targetUserDisplayName: 'Darryn',
+      buyerKeyIds: ['buyer_1', 'buyer_1'],
+      tokenCredentialIds: ['cred_1', 'cred_1']
+    } as any);
+
+    expect(fnfOwnershipRepository.upsertBuyerKeyOwnership).toHaveBeenCalledTimes(2);
+    expect(fnfOwnershipRepository.upsertTokenCredentialOwnership).toHaveBeenCalledTimes(2);
+    expect(cutoverRepository.createCutoverRecord).toHaveBeenCalledTimes(1);
+    expect(reserveFloorMigration.migrateReserveFloors).toHaveBeenCalledTimes(1);
+    expect(result.cutoverRecord.id).toBe('cut_1');
+  });
+
   it('cuts over buyer keys and token credentials, then releases freezes after reserve-floor migration succeeds', async () => {
     const {
       service,


### PR DESCRIPTION
## Summary
- fail pilot cutover and rollback before writing ownership or marker rows when requested buyer-key or token-credential base rows were not actually reassigned
- cover the missing-row seam and duplicate-id edge case in PilotCutoverService tests
- preserve the sacrificial prod evidence that current cutover/request/rollback now resolves to fnf correctly

## Test Plan
- npm test -- pilotCutoverService.test.ts admin.pilot.route.test.ts
- npm run build
- sacrificial prod verification: cutover `e8c6a55d-2e25-4378-9edc-2e9de9464b1f`, request `req_17742859553N_fnfverify`, rollback `daf798bd-95d0-42cd-af82-5e42fd714252`