### PR TITLE
feat: add archive retention and gate raw_request writes

### DIFF
--- a/api/src/jobs/registry.ts
+++ b/api/src/jobs/registry.ts
@@ -7,6 +7,7 @@ import { AdminSessionProjectionOutboxRepository } from '../repos/adminSessionPro
 import { AdminSessionRepository } from '../repos/adminSessionRepository.js';
 import { IdempotencyRepository } from '../repos/idempotencyRepository.js';
 import { ReconciliationRepository } from '../repos/reconciliationRepository.js';
+import { RequestArchiveRetentionRepository } from '../repos/requestArchiveRetentionRepository.js';
 import { RequestLogRepository } from '../repos/requestLogRepository.js';
 import { SellerKeyRepository } from '../repos/sellerKeyRepository.js';
 import { TokenCredentialRepository } from '../repos/tokenCredentialRepository.js';
@@ -33,6 +34,7 @@ import { createEarningsProjectorJob } from './earningsProjectorJob.js';
 import { createIdempotencyPurgeJob } from './idempotencyPurgeJob.js';
 import { createKeyHealthCheckJob } from './keyHealthJob.js';
 import { createLiveLaneProjectorJob } from './liveLaneProjectorJob.js';
+import { createRequestArchiveRetentionJob } from './requestArchiveRetentionJob.js';
 import {
   createRequestLogRetentionJob,
   readRequestLogRetentionDays
@@ -57,6 +59,7 @@ export function buildDefaultJobs(db: SqlClient, source: ReconciliationDataSource
   const meteringProjectorStateRepo = new MeteringProjectorStateRepository(db);
   const reconciliationRepo = new ReconciliationRepository(db);
   const requestLogRepo = new RequestLogRepository(db);
+  const requestArchiveRetentionRepo = new RequestArchiveRetentionRepository(db);
   const liveLaneProjectionOutboxRepo = new LiveLaneProjectionOutboxRepository(db);
   const sellerKeysRepo = new SellerKeyRepository(db);
   const tokenCredentialsRepo = new TokenCredentialRepository(db);
@@ -113,6 +116,7 @@ export function buildDefaultJobs(db: SqlClient, source: ReconciliationDataSource
     createTokenCredentialHealthJob(tokenCredentialsRepo),
     createDailyAggregatesIncrementalJob(aggregatesRepo),
     createDailyAggregatesCompactionJob(aggregatesRepo),
+    createRequestArchiveRetentionJob(requestArchiveRetentionRepo),
     createReconciliationJob(reconciliationRepo, source)
   ];
 

--- a/api/src/jobs/requestArchiveRetentionJob.ts
+++ b/api/src/jobs/requestArchiveRetentionJob.ts
@@ -1,0 +1,168 @@
+import type {
+  RetentionBatchResult,
+  RetentionCutoffInput,
+  RetentionSweepInput
+} from '../repos/requestArchiveRetentionRepository.js';
+import type { JobDefinition, JobRunContext } from './types.js';
+
+const HOUR_MS = 60 * 60 * 1000;
+const DEFAULT_ARCHIVE_RETENTION_DAYS = 30;
+const DEFAULT_OUTBOX_RETENTION_DAYS = 7;
+const DEFAULT_BATCH_SIZE = 5000;
+const DEFAULT_MAX_BATCHES_PER_PHASE = 10;
+
+export type RequestArchiveRetentionRepo = {
+  deleteArchivesOlderThan(input: RetentionCutoffInput): Promise<RetentionBatchResult>;
+  sweepOrphanedRawBlobs(input: RetentionSweepInput): Promise<RetentionBatchResult>;
+  sweepOrphanedMessageBlobs(input: RetentionSweepInput): Promise<RetentionBatchResult>;
+  purgeProjectedSessionOutbox(input: RetentionCutoffInput): Promise<RetentionBatchResult>;
+  purgeProjectedAnalysisOutbox(input: RetentionCutoffInput): Promise<RetentionBatchResult>;
+};
+
+export type RequestArchiveRetentionJobOptions = {
+  batchSize?: number;
+  maxBatchesPerPhase?: number;
+};
+
+function readPositiveIntEnv(key: string, fallback: number): number {
+  const raw = process.env[key];
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return Math.floor(parsed);
+}
+
+function subtractDays(now: Date, days: number): Date {
+  const result = new Date(now.getTime());
+  result.setUTCDate(result.getUTCDate() - days);
+  return result;
+}
+
+async function runCutoffPhase(
+  phase: string,
+  cutoff: Date,
+  batchSize: number,
+  maxBatches: number,
+  logger: JobRunContext['logger'],
+  run: (input: RetentionCutoffInput) => Promise<RetentionBatchResult>
+): Promise<number> {
+  let total = 0;
+  for (let i = 0; i < maxBatches; i += 1) {
+    const batch = await run({ cutoff, batchSize });
+    total += batch.deletedCount;
+    if (batch.deletedCount < batchSize) {
+      return total;
+    }
+  }
+  logger.info('request archive retention phase hit batch cap', {
+    phase,
+    totalDeleted: total,
+    maxBatches,
+    batchSize
+  });
+  return total;
+}
+
+async function runSweepPhase(
+  phase: string,
+  batchSize: number,
+  maxBatches: number,
+  logger: JobRunContext['logger'],
+  run: (input: RetentionSweepInput) => Promise<RetentionBatchResult>
+): Promise<number> {
+  let total = 0;
+  for (let i = 0; i < maxBatches; i += 1) {
+    const batch = await run({ batchSize });
+    total += batch.deletedCount;
+    if (batch.deletedCount < batchSize) {
+      return total;
+    }
+  }
+  logger.info('request archive retention phase hit batch cap', {
+    phase,
+    totalDeleted: total,
+    maxBatches,
+    batchSize
+  });
+  return total;
+}
+
+export function createRequestArchiveRetentionJob(
+  repo: RequestArchiveRetentionRepo,
+  options: RequestArchiveRetentionJobOptions = {}
+): JobDefinition {
+  const batchSize = options.batchSize ?? DEFAULT_BATCH_SIZE;
+  const maxBatches = options.maxBatchesPerPhase ?? DEFAULT_MAX_BATCHES_PER_PHASE;
+
+  return {
+    name: 'request-archive-retention-hourly',
+    scheduleMs: HOUR_MS,
+    async run(ctx) {
+      const archiveDays = readPositiveIntEnv(
+        'REQUEST_ARCHIVE_RETENTION_DAYS',
+        DEFAULT_ARCHIVE_RETENTION_DAYS
+      );
+      const outboxDays = readPositiveIntEnv(
+        'REQUEST_ARCHIVE_OUTBOX_RETENTION_DAYS',
+        DEFAULT_OUTBOX_RETENTION_DAYS
+      );
+      const archiveCutoff = subtractDays(ctx.now, archiveDays);
+      const outboxCutoff = subtractDays(ctx.now, outboxDays);
+
+      // Order matters: delete archives first so cascading link rows free up
+      // raw/message blob references, then sweep orphans. Outbox purges are
+      // independent and can run last.
+      const deletedArchives = await runCutoffPhase(
+        'deleteArchivesOlderThan',
+        archiveCutoff,
+        batchSize,
+        maxBatches,
+        ctx.logger,
+        (input) => repo.deleteArchivesOlderThan(input)
+      );
+      const deletedRawOrphans = await runSweepPhase(
+        'sweepOrphanedRawBlobs',
+        batchSize,
+        maxBatches,
+        ctx.logger,
+        (input) => repo.sweepOrphanedRawBlobs(input)
+      );
+      const deletedMessageOrphans = await runSweepPhase(
+        'sweepOrphanedMessageBlobs',
+        batchSize,
+        maxBatches,
+        ctx.logger,
+        (input) => repo.sweepOrphanedMessageBlobs(input)
+      );
+      const deletedSessionOutbox = await runCutoffPhase(
+        'purgeProjectedSessionOutbox',
+        outboxCutoff,
+        batchSize,
+        maxBatches,
+        ctx.logger,
+        (input) => repo.purgeProjectedSessionOutbox(input)
+      );
+      const deletedAnalysisOutbox = await runCutoffPhase(
+        'purgeProjectedAnalysisOutbox',
+        outboxCutoff,
+        batchSize,
+        maxBatches,
+        ctx.logger,
+        (input) => repo.purgeProjectedAnalysisOutbox(input)
+      );
+
+      ctx.logger.info('request archive retention complete', {
+        archiveRetentionDays: archiveDays,
+        outboxRetentionDays: outboxDays,
+        archiveCutoff: archiveCutoff.toISOString(),
+        outboxCutoff: outboxCutoff.toISOString(),
+        deletedArchives,
+        deletedRawOrphans,
+        deletedMessageOrphans,
+        deletedSessionOutbox,
+        deletedAnalysisOutbox,
+        asOf: ctx.now.toISOString()
+      });
+    }
+  };
+}

--- a/api/src/repos/requestArchiveRetentionRepository.ts
+++ b/api/src/repos/requestArchiveRetentionRepository.ts
@@ -1,0 +1,124 @@
+import type { SqlClient, SqlValue } from './sqlClient.js';
+import { TABLES } from './tableNames.js';
+
+export type RetentionBatchResult = {
+  deletedCount: number;
+};
+
+export type RetentionCutoffInput = {
+  cutoff: Date;
+  batchSize: number;
+};
+
+export type RetentionSweepInput = {
+  batchSize: number;
+};
+
+function clampBatchSize(batchSize: number): number {
+  if (!Number.isFinite(batchSize)) return 1;
+  return Math.max(1, Math.floor(batchSize));
+}
+
+/**
+ * Retention + orphan-sweep queries for the prompt-archive storage introduced
+ * in migration 024 (in_request_attempt_archives, in_raw_blobs, in_message_blobs).
+ *
+ * Deletes are batched so the retention job can bound its transaction size and
+ * yield between batches. Orphan sweeps are separate from the archive delete
+ * because in_raw_blobs and in_message_blobs use ON DELETE RESTRICT from the
+ * link tables, so the parent archive delete cascades the joins but cannot
+ * reach the blob rows directly.
+ */
+export class RequestArchiveRetentionRepository {
+  constructor(private readonly db: SqlClient) {}
+
+  async deleteArchivesOlderThan(input: RetentionCutoffInput): Promise<RetentionBatchResult> {
+    const sql = `
+      delete from ${TABLES.requestAttemptArchives}
+      where id in (
+        select id
+        from ${TABLES.requestAttemptArchives}
+        where created_at < $1
+        order by created_at asc
+        limit $2
+      )
+    `;
+    const params: SqlValue[] = [input.cutoff, clampBatchSize(input.batchSize)];
+    const result = await this.db.query(sql, params);
+    return { deletedCount: result.rowCount };
+  }
+
+  async sweepOrphanedRawBlobs(input: RetentionSweepInput): Promise<RetentionBatchResult> {
+    const sql = `
+      delete from ${TABLES.rawBlobs}
+      where id in (
+        select rb.id
+        from ${TABLES.rawBlobs} rb
+        where not exists (
+          select 1
+          from ${TABLES.requestAttemptRawBlobs} link
+          where link.raw_blob_id = rb.id
+        )
+        limit $1
+      )
+    `;
+    const params: SqlValue[] = [clampBatchSize(input.batchSize)];
+    const result = await this.db.query(sql, params);
+    return { deletedCount: result.rowCount };
+  }
+
+  async sweepOrphanedMessageBlobs(input: RetentionSweepInput): Promise<RetentionBatchResult> {
+    const sql = `
+      delete from ${TABLES.messageBlobs}
+      where id in (
+        select mb.id
+        from ${TABLES.messageBlobs} mb
+        where not exists (
+          select 1
+          from ${TABLES.requestAttemptMessages} link
+          where link.message_blob_id = mb.id
+        )
+        limit $1
+      )
+    `;
+    const params: SqlValue[] = [clampBatchSize(input.batchSize)];
+    const result = await this.db.query(sql, params);
+    return { deletedCount: result.rowCount };
+  }
+
+  async purgeProjectedSessionOutbox(input: RetentionCutoffInput): Promise<RetentionBatchResult> {
+    const sql = `
+      delete from ${TABLES.adminSessionProjectionOutbox}
+      where id in (
+        select id
+        from ${TABLES.adminSessionProjectionOutbox}
+        where projection_state = 'projected'
+          and processed_at is not null
+          and processed_at < $1
+        order by processed_at asc
+        limit $2
+      )
+    `;
+    const params: SqlValue[] = [input.cutoff, clampBatchSize(input.batchSize)];
+    const result = await this.db.query(sql, params);
+    return { deletedCount: result.rowCount };
+  }
+
+  async purgeProjectedAnalysisOutbox(input: RetentionCutoffInput): Promise<RetentionBatchResult> {
+    const sql = `
+      delete from ${TABLES.adminAnalysisProjectionOutbox}
+      where id in (
+        select id
+        from ${TABLES.adminAnalysisProjectionOutbox}
+        where projection_state = 'projected'
+          and processed_at is not null
+          and processed_at < $1
+        order by processed_at asc
+        limit $2
+      )
+    `;
+    const params: SqlValue[] = [input.cutoff, clampBatchSize(input.batchSize)];
+    const result = await this.db.query(sql, params);
+    return { deletedCount: result.rowCount };
+  }
+}

--- a/api/src/services/archive/requestArchiveService.ts
+++ b/api/src/services/archive/requestArchiveService.ts
@@ -169,10 +169,18 @@ export class RequestArchiveService {
   }
 }
 
+function isRawRequestArchivingEnabled(): boolean {
+  // Opt-in: raw_request is the cumulative conversation on multi-turn agent
+  // traffic and blows up storage (no cross-turn dedup). The structured
+  // request content is already captured per-message in in_message_blobs
+  // with content-hash dedup, so keep raw_request off by default.
+  return process.env.ARCHIVE_RAW_REQUEST_ENABLED === 'true';
+}
+
 function prepareRawBlobs(input: ArchiveAttemptInput): ArchivePreparedRawBlob[] {
   const rawBlobs: ArchivePreparedRawBlob[] = [];
 
-  if (input.rawRequest != null) {
+  if (isRawRequestArchivingEnabled() && input.rawRequest != null) {
     const encoded = encodeArchiveRawBlob(input.rawRequest);
     rawBlobs.push({
       blobRole: 'request',

--- a/api/tests/jobs.test.ts
+++ b/api/tests/jobs.test.ts
@@ -75,4 +75,10 @@ describe('jobs', () => {
 
     expect(jobs.map((job) => job.name)).toContain('admin-analysis-projector');
   });
+
+  it('registers the request archive retention job by default', () => {
+    const jobs = buildDefaultJobs(new MockSqlClient());
+
+    expect(jobs.map((job) => job.name)).toContain('request-archive-retention-hourly');
+  });
 });

--- a/api/tests/requestArchiveRetentionJob.test.ts
+++ b/api/tests/requestArchiveRetentionJob.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createRequestArchiveRetentionJob,
+  type RequestArchiveRetentionRepo
+} from '../src/jobs/requestArchiveRetentionJob.js';
+import { createLoggerSpy } from './testHelpers.js';
+
+type CallLog = {
+  name: string;
+  args: unknown;
+};
+
+function createRepoSpy(batchResults: Record<string, number[]>): {
+  repo: RequestArchiveRetentionRepo;
+  calls: CallLog[];
+} {
+  const calls: CallLog[] = [];
+  const pop = (key: string): number => {
+    const next = batchResults[key]?.shift();
+    return typeof next === 'number' ? next : 0;
+  };
+  const repo: RequestArchiveRetentionRepo = {
+    async deleteArchivesOlderThan(input) {
+      calls.push({ name: 'deleteArchivesOlderThan', args: input });
+      return { deletedCount: pop('deleteArchivesOlderThan') };
+    },
+    async sweepOrphanedRawBlobs(input) {
+      calls.push({ name: 'sweepOrphanedRawBlobs', args: input });
+      return { deletedCount: pop('sweepOrphanedRawBlobs') };
+    },
+    async sweepOrphanedMessageBlobs(input) {
+      calls.push({ name: 'sweepOrphanedMessageBlobs', args: input });
+      return { deletedCount: pop('sweepOrphanedMessageBlobs') };
+    },
+    async purgeProjectedSessionOutbox(input) {
+      calls.push({ name: 'purgeProjectedSessionOutbox', args: input });
+      return { deletedCount: pop('purgeProjectedSessionOutbox') };
+    },
+    async purgeProjectedAnalysisOutbox(input) {
+      calls.push({ name: 'purgeProjectedAnalysisOutbox', args: input });
+      return { deletedCount: pop('purgeProjectedAnalysisOutbox') };
+    }
+  };
+  return { repo, calls };
+}
+
+function withEnv<T>(values: Record<string, string | undefined>, run: () => T): T {
+  const prev: Record<string, string | undefined> = {};
+  for (const [key, value] of Object.entries(values)) {
+    prev[key] = process.env[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  try {
+    return run();
+  } finally {
+    for (const [key, prior] of Object.entries(prev)) {
+      if (prior === undefined) delete process.env[key];
+      else process.env[key] = prior;
+    }
+  }
+}
+
+describe('createRequestArchiveRetentionJob', () => {
+  it('runs hourly with the correct job name', () => {
+    const { repo } = createRepoSpy({});
+    const job = createRequestArchiveRetentionJob(repo);
+
+    expect(job.name).toBe('request-archive-retention-hourly');
+    expect(job.scheduleMs).toBe(60 * 60 * 1000);
+  });
+
+  it('defaults retention to 30 days for archives and 7 days for projected outboxes', async () => {
+    const { repo, calls } = createRepoSpy({
+      deleteArchivesOlderThan: [0],
+      sweepOrphanedRawBlobs: [0],
+      sweepOrphanedMessageBlobs: [0],
+      purgeProjectedSessionOutbox: [0],
+      purgeProjectedAnalysisOutbox: [0]
+    });
+    const job = createRequestArchiveRetentionJob(repo);
+    const { logger, infoCalls } = createLoggerSpy();
+    const now = new Date('2026-04-17T21:00:00Z');
+
+    await withEnv(
+      {
+        REQUEST_ARCHIVE_RETENTION_DAYS: undefined,
+        REQUEST_ARCHIVE_OUTBOX_RETENTION_DAYS: undefined
+      },
+      () => job.run({ now, logger })
+    );
+
+    const archiveCall = calls.find((c) => c.name === 'deleteArchivesOlderThan');
+    expect(archiveCall).toBeDefined();
+    const archiveCutoff = (archiveCall!.args as { cutoff: Date }).cutoff;
+    expect(archiveCutoff.toISOString()).toBe('2026-03-18T21:00:00.000Z');
+
+    const sessionCall = calls.find((c) => c.name === 'purgeProjectedSessionOutbox');
+    expect(sessionCall).toBeDefined();
+    const sessionCutoff = (sessionCall!.args as { cutoff: Date }).cutoff;
+    expect(sessionCutoff.toISOString()).toBe('2026-04-10T21:00:00.000Z');
+
+    expect(infoCalls.at(-1)?.message).toContain('request archive retention complete');
+  });
+
+  it('respects REQUEST_ARCHIVE_RETENTION_DAYS and REQUEST_ARCHIVE_OUTBOX_RETENTION_DAYS env overrides', async () => {
+    const { repo, calls } = createRepoSpy({
+      deleteArchivesOlderThan: [0],
+      sweepOrphanedRawBlobs: [0],
+      sweepOrphanedMessageBlobs: [0],
+      purgeProjectedSessionOutbox: [0],
+      purgeProjectedAnalysisOutbox: [0]
+    });
+    const job = createRequestArchiveRetentionJob(repo);
+    const { logger } = createLoggerSpy();
+    const now = new Date('2026-04-17T00:00:00Z');
+
+    await withEnv(
+      {
+        REQUEST_ARCHIVE_RETENTION_DAYS: '3',
+        REQUEST_ARCHIVE_OUTBOX_RETENTION_DAYS: '1'
+      },
+      () => job.run({ now, logger })
+    );
+
+    const archiveCutoff = (calls.find((c) => c.name === 'deleteArchivesOlderThan')!.args as { cutoff: Date }).cutoff;
+    expect(archiveCutoff.toISOString()).toBe('2026-04-14T00:00:00.000Z');
+
+    const sessionCutoff = (calls.find((c) => c.name === 'purgeProjectedSessionOutbox')!.args as { cutoff: Date }).cutoff;
+    expect(sessionCutoff.toISOString()).toBe('2026-04-16T00:00:00.000Z');
+  });
+
+  it('keeps looping delete batches until a short batch is returned, capped at maxBatches', async () => {
+    const { repo, calls } = createRepoSpy({
+      // 3 full batches, then 2 less-than-full → loop exits on first short batch
+      deleteArchivesOlderThan: [5000, 5000, 5000, 37],
+      sweepOrphanedRawBlobs: [0],
+      sweepOrphanedMessageBlobs: [0],
+      purgeProjectedSessionOutbox: [0],
+      purgeProjectedAnalysisOutbox: [0]
+    });
+    const job = createRequestArchiveRetentionJob(repo, { batchSize: 5000, maxBatchesPerPhase: 50 });
+    const { logger, infoCalls } = createLoggerSpy();
+
+    await job.run({ now: new Date('2026-04-17T00:00:00Z'), logger });
+
+    const archiveCalls = calls.filter((c) => c.name === 'deleteArchivesOlderThan');
+    expect(archiveCalls).toHaveLength(4);
+
+    const summary = infoCalls.at(-1)?.fields as Record<string, number>;
+    expect(summary.deletedArchives).toBe(15037);
+  });
+
+  it('stops each phase at maxBatchesPerPhase even if rows remain', async () => {
+    const { repo, calls } = createRepoSpy({
+      deleteArchivesOlderThan: [5000, 5000, 5000, 5000, 5000],
+      sweepOrphanedRawBlobs: [0],
+      sweepOrphanedMessageBlobs: [0],
+      purgeProjectedSessionOutbox: [0],
+      purgeProjectedAnalysisOutbox: [0]
+    });
+    const job = createRequestArchiveRetentionJob(repo, { batchSize: 5000, maxBatchesPerPhase: 2 });
+    const { logger } = createLoggerSpy();
+
+    await job.run({ now: new Date('2026-04-17T00:00:00Z'), logger });
+
+    const archiveCalls = calls.filter((c) => c.name === 'deleteArchivesOlderThan');
+    expect(archiveCalls).toHaveLength(2);
+  });
+
+  it('runs archive deletes before orphan sweeps so dangling blobs are reachable', async () => {
+    const { repo, calls } = createRepoSpy({
+      deleteArchivesOlderThan: [1],
+      sweepOrphanedRawBlobs: [1],
+      sweepOrphanedMessageBlobs: [1],
+      purgeProjectedSessionOutbox: [1],
+      purgeProjectedAnalysisOutbox: [1]
+    });
+    const job = createRequestArchiveRetentionJob(repo);
+    const { logger } = createLoggerSpy();
+
+    await job.run({ now: new Date('2026-04-17T00:00:00Z'), logger });
+
+    const names = calls.map((c) => c.name);
+    expect(names.indexOf('deleteArchivesOlderThan')).toBeLessThan(names.indexOf('sweepOrphanedRawBlobs'));
+    expect(names.indexOf('deleteArchivesOlderThan')).toBeLessThan(names.indexOf('sweepOrphanedMessageBlobs'));
+  });
+});

--- a/api/tests/requestArchiveRetentionRepository.test.ts
+++ b/api/tests/requestArchiveRetentionRepository.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { RequestArchiveRetentionRepository } from '../src/repos/requestArchiveRetentionRepository.js';
+import { SequenceSqlClient } from './testHelpers.js';
+
+describe('RequestArchiveRetentionRepository', () => {
+  it('deletes archives older than the cutoff in bounded batches', async () => {
+    const db = new SequenceSqlClient([
+      { rows: [], rowCount: 5000 }
+    ]);
+    const repo = new RequestArchiveRetentionRepository(db);
+    const cutoff = new Date('2026-04-01T00:00:00Z');
+
+    const result = await repo.deleteArchivesOlderThan({ cutoff, batchSize: 5000 });
+
+    expect(result).toEqual({ deletedCount: 5000 });
+    expect(db.queries).toHaveLength(1);
+    expect(db.queries[0].sql).toContain('delete from in_request_attempt_archives');
+    expect(db.queries[0].sql).toContain('where id in (');
+    expect(db.queries[0].sql).toContain('select id');
+    expect(db.queries[0].sql).toContain('from in_request_attempt_archives');
+    expect(db.queries[0].sql).toContain('where created_at < $1');
+    expect(db.queries[0].sql).toContain('order by created_at asc');
+    expect(db.queries[0].sql).toContain('limit $2');
+    expect(db.queries[0].params).toEqual([cutoff, 5000]);
+  });
+
+  it('sweeps orphaned raw blobs with no attempt references', async () => {
+    const db = new SequenceSqlClient([
+      { rows: [], rowCount: 1234 }
+    ]);
+    const repo = new RequestArchiveRetentionRepository(db);
+
+    const result = await repo.sweepOrphanedRawBlobs({ batchSize: 5000 });
+
+    expect(result).toEqual({ deletedCount: 1234 });
+    expect(db.queries).toHaveLength(1);
+    expect(db.queries[0].sql).toContain('delete from in_raw_blobs');
+    expect(db.queries[0].sql).toContain('where id in (');
+    expect(db.queries[0].sql).toContain('not exists (');
+    expect(db.queries[0].sql).toContain('from in_request_attempt_raw_blobs');
+    expect(db.queries[0].sql).toContain('limit $1');
+    expect(db.queries[0].params).toEqual([5000]);
+  });
+
+  it('sweeps orphaned message blobs with no attempt references', async () => {
+    const db = new SequenceSqlClient([
+      { rows: [], rowCount: 7 }
+    ]);
+    const repo = new RequestArchiveRetentionRepository(db);
+
+    const result = await repo.sweepOrphanedMessageBlobs({ batchSize: 5000 });
+
+    expect(result).toEqual({ deletedCount: 7 });
+    expect(db.queries).toHaveLength(1);
+    expect(db.queries[0].sql).toContain('delete from in_message_blobs');
+    expect(db.queries[0].sql).toContain('not exists (');
+    expect(db.queries[0].sql).toContain('from in_request_attempt_messages');
+    expect(db.queries[0].sql).toContain('limit $1');
+    expect(db.queries[0].params).toEqual([5000]);
+  });
+
+  it('purges projected admin-session outbox rows older than the cutoff', async () => {
+    const db = new SequenceSqlClient([
+      { rows: [], rowCount: 42 }
+    ]);
+    const repo = new RequestArchiveRetentionRepository(db);
+    const cutoff = new Date('2026-04-11T00:00:00Z');
+
+    const result = await repo.purgeProjectedSessionOutbox({ cutoff, batchSize: 5000 });
+
+    expect(result).toEqual({ deletedCount: 42 });
+    expect(db.queries).toHaveLength(1);
+    expect(db.queries[0].sql).toContain('delete from in_admin_session_projection_outbox');
+    expect(db.queries[0].sql).toContain("projection_state = 'projected'");
+    expect(db.queries[0].sql).toContain('processed_at < $1');
+    expect(db.queries[0].params).toEqual([cutoff, 5000]);
+  });
+
+  it('purges projected admin-analysis outbox rows older than the cutoff', async () => {
+    const db = new SequenceSqlClient([
+      { rows: [], rowCount: 11 }
+    ]);
+    const repo = new RequestArchiveRetentionRepository(db);
+    const cutoff = new Date('2026-04-11T00:00:00Z');
+
+    const result = await repo.purgeProjectedAnalysisOutbox({ cutoff, batchSize: 5000 });
+
+    expect(result).toEqual({ deletedCount: 11 });
+    expect(db.queries).toHaveLength(1);
+    expect(db.queries[0].sql).toContain('delete from in_admin_analysis_request_projection_outbox');
+    expect(db.queries[0].sql).toContain("projection_state = 'projected'");
+    expect(db.queries[0].sql).toContain('processed_at < $1');
+    expect(db.queries[0].params).toEqual([cutoff, 5000]);
+  });
+
+  it('clamps batch size to a minimum of 1', async () => {
+    const db = new SequenceSqlClient([
+      { rows: [], rowCount: 0 }
+    ]);
+    const repo = new RequestArchiveRetentionRepository(db);
+
+    await repo.deleteArchivesOlderThan({
+      cutoff: new Date('2026-04-01T00:00:00Z'),
+      batchSize: -5
+    });
+
+    expect(db.queries[0].params?.[1]).toBe(1);
+  });
+});

--- a/api/tests/requestArchiveService.test.ts
+++ b/api/tests/requestArchiveService.test.ts
@@ -1073,53 +1073,96 @@ describe('RequestArchiveService', () => {
     ]);
   });
 
-  it('gzip-compresses raw request, response, and stream payloads and records exact blob metadata', async () => {
-    const { service, state } = createService();
-    const rawRequest = JSON.stringify({ kind: 'request', body: 'x'.repeat(512) });
-    const rawResponse = JSON.stringify({ kind: 'response', body: 'y'.repeat(512) });
-    const rawStream = [
-      'data: {"type":"response.output_text.delta","delta":"working"}',
-      '',
-      'data: [DONE]',
-      ''
-    ].join('\n');
+  it('skips raw_request archiving by default (opt-in via ARCHIVE_RAW_REQUEST_ENABLED)', async () => {
+    const prev = process.env.ARCHIVE_RAW_REQUEST_ENABLED;
+    delete process.env.ARCHIVE_RAW_REQUEST_ENABLED;
+    try {
+      const { service, state } = createService();
+      const rawRequest = JSON.stringify({ kind: 'request', body: 'x'.repeat(512) });
+      const rawResponse = JSON.stringify({ kind: 'response', body: 'y'.repeat(512) });
+      const rawStream = [
+        'data: {"type":"response.output_text.delta","delta":"working"}',
+        '',
+        'data: [DONE]',
+        ''
+      ].join('\n');
 
-    await service.archiveAttempt(baseAttempt({
-      rawRequest,
-      rawResponse,
-      rawStream
-    }));
+      await service.archiveAttempt(baseAttempt({ rawRequest, rawResponse, rawStream }));
 
-    expect(state.rawBlobs).toHaveLength(3);
-    expect(state.attemptRawBlobs).toEqual([
-      { requestAttemptArchiveId: 'archive_1', blobRole: 'request', rawBlobId: 'raw_1' },
-      { requestAttemptArchiveId: 'archive_1', blobRole: 'response', rawBlobId: 'raw_2' },
-      { requestAttemptArchiveId: 'archive_1', blobRole: 'stream', rawBlobId: 'raw_3' }
-    ]);
+      const kinds = state.rawBlobs.map((record) => record.blobKind).sort();
+      expect(kinds).toEqual(['raw_response', 'raw_stream']);
+      expect(state.attemptRawBlobs.map((record) => record.blobRole).sort()).toEqual(['response', 'stream']);
 
-    const byKind = Object.fromEntries(state.rawBlobs.map((record) => [record.blobKind, record]));
+      const byKind = Object.fromEntries(state.rawBlobs.map((record) => [record.blobKind, record]));
+      expect(byKind.raw_request).toBeUndefined();
+      expect(byKind.raw_response.encoding).toBe('gzip');
+      expect(byKind.raw_stream.encoding).toBe('gzip');
+    } finally {
+      if (prev === undefined) {
+        delete process.env.ARCHIVE_RAW_REQUEST_ENABLED;
+      } else {
+        process.env.ARCHIVE_RAW_REQUEST_ENABLED = prev;
+      }
+    }
+  });
 
-    expect(byKind.raw_request).toEqual(expect.objectContaining({
-      encoding: 'gzip',
-      bytesCompressed: byKind.raw_request.payload.length,
-      bytesUncompressed: Buffer.byteLength(rawRequest)
-    }));
-    expect(byKind.raw_response).toEqual(expect.objectContaining({
-      encoding: 'gzip',
-      bytesCompressed: byKind.raw_response.payload.length,
-      bytesUncompressed: Buffer.byteLength(rawResponse)
-    }));
-    expect(byKind.raw_stream).toEqual(expect.objectContaining({
-      encoding: 'gzip',
-      bytesCompressed: byKind.raw_stream.payload.length,
-      bytesUncompressed: Buffer.byteLength(rawStream)
-    }));
+  it('gzip-compresses raw request, response, and stream payloads when ARCHIVE_RAW_REQUEST_ENABLED=true', async () => {
+    const prev = process.env.ARCHIVE_RAW_REQUEST_ENABLED;
+    process.env.ARCHIVE_RAW_REQUEST_ENABLED = 'true';
+    try {
+      const { service, state } = createService();
+      const rawRequest = JSON.stringify({ kind: 'request', body: 'x'.repeat(512) });
+      const rawResponse = JSON.stringify({ kind: 'response', body: 'y'.repeat(512) });
+      const rawStream = [
+        'data: {"type":"response.output_text.delta","delta":"working"}',
+        '',
+        'data: [DONE]',
+        ''
+      ].join('\n');
 
-    expect(byKind.raw_request.bytesCompressed).toBeLessThan(byKind.raw_request.bytesUncompressed);
-    expect(byKind.raw_response.bytesCompressed).toBeLessThan(byKind.raw_response.bytesUncompressed);
-    expect(decodeBuffer(byKind.raw_request.payload)).toBe(rawRequest);
-    expect(decodeBuffer(byKind.raw_response.payload)).toBe(rawResponse);
-    expect(decodeBuffer(byKind.raw_stream.payload)).toBe(rawStream);
+      await service.archiveAttempt(baseAttempt({
+        rawRequest,
+        rawResponse,
+        rawStream
+      }));
+
+      expect(state.rawBlobs).toHaveLength(3);
+      expect(state.attemptRawBlobs).toEqual([
+        { requestAttemptArchiveId: 'archive_1', blobRole: 'request', rawBlobId: 'raw_1' },
+        { requestAttemptArchiveId: 'archive_1', blobRole: 'response', rawBlobId: 'raw_2' },
+        { requestAttemptArchiveId: 'archive_1', blobRole: 'stream', rawBlobId: 'raw_3' }
+      ]);
+
+      const byKind = Object.fromEntries(state.rawBlobs.map((record) => [record.blobKind, record]));
+
+      expect(byKind.raw_request).toEqual(expect.objectContaining({
+        encoding: 'gzip',
+        bytesCompressed: byKind.raw_request.payload.length,
+        bytesUncompressed: Buffer.byteLength(rawRequest)
+      }));
+      expect(byKind.raw_response).toEqual(expect.objectContaining({
+        encoding: 'gzip',
+        bytesCompressed: byKind.raw_response.payload.length,
+        bytesUncompressed: Buffer.byteLength(rawResponse)
+      }));
+      expect(byKind.raw_stream).toEqual(expect.objectContaining({
+        encoding: 'gzip',
+        bytesCompressed: byKind.raw_stream.payload.length,
+        bytesUncompressed: Buffer.byteLength(rawStream)
+      }));
+
+      expect(byKind.raw_request.bytesCompressed).toBeLessThan(byKind.raw_request.bytesUncompressed);
+      expect(byKind.raw_response.bytesCompressed).toBeLessThan(byKind.raw_response.bytesUncompressed);
+      expect(decodeBuffer(byKind.raw_request.payload)).toBe(rawRequest);
+      expect(decodeBuffer(byKind.raw_response.payload)).toBe(rawResponse);
+      expect(decodeBuffer(byKind.raw_stream.payload)).toBe(rawStream);
+    } finally {
+      if (prev === undefined) {
+        delete process.env.ARCHIVE_RAW_REQUEST_ENABLED;
+      } else {
+        process.env.ARCHIVE_RAW_REQUEST_ENABLED = prev;
+      }
+    }
   });
 
   it('rolls back the archive transaction without orphaned rows when a raw blob write fails', async () => {
@@ -1176,8 +1219,9 @@ describe('RequestArchiveService', () => {
     }));
 
     expect(state.attemptMessages.filter((record) => record.side === 'response')).toHaveLength(1);
-    expect(state.rawBlobs).toHaveLength(2);
-    expect(state.attemptRawBlobs.map((record) => record.blobRole).sort()).toEqual(['request', 'stream']);
+    // raw_request is opt-in (ARCHIVE_RAW_REQUEST_ENABLED); rawResponse is null here.
+    expect(state.rawBlobs).toHaveLength(1);
+    expect(state.attemptRawBlobs.map((record) => record.blobRole).sort()).toEqual(['stream']);
     expect(state.messageBlobs.find((record) => record.role === 'assistant')?.normalizedPayload).toEqual({
       role: 'assistant',
       content: [{ type: 'text', text: 'working' }]

--- a/docs/migrations/030_archive_retention.sql
+++ b/docs/migrations/030_archive_retention.sql
@@ -1,0 +1,26 @@
+BEGIN;
+
+-- Retention support for prompt-archive storage introduced in migration 024.
+-- Adds a pure-time index used by the archive retention job to purge rows
+-- older than REQUEST_ARCHIVE_RETENTION_DAYS efficiently. The existing
+-- (org_id, created_at desc) index is not used when scanning globally by
+-- time alone.
+CREATE INDEX IF NOT EXISTS idx_in_request_attempt_archives_created_at
+  ON in_request_attempt_archives (created_at);
+
+-- Projection outboxes accumulate rows with projection_state='projected'
+-- indefinitely. Add indexes on processed_at so the retention job can
+-- purge projected rows older than N days without sequential scans.
+CREATE INDEX IF NOT EXISTS idx_in_admin_session_projection_outbox_processed_at
+  ON in_admin_session_projection_outbox (processed_at)
+  WHERE projection_state = 'projected';
+
+CREATE INDEX IF NOT EXISTS idx_in_admin_analysis_request_projection_outbox_processed_at
+  ON in_admin_analysis_request_projection_outbox (processed_at)
+  WHERE projection_state = 'projected';
+
+-- No niyant grant changes: migration adds indexes on existing tables only;
+-- the underlying tables already have niyant grants from migrations 024, 026,
+-- and 027. Indexes inherit table permissions.
+
+COMMIT;

--- a/docs/migrations/030_archive_retention_no_extensions.sql
+++ b/docs/migrations/030_archive_retention_no_extensions.sql
@@ -1,0 +1,26 @@
+BEGIN;
+
+-- Retention support for prompt-archive storage introduced in migration 024.
+-- Adds a pure-time index used by the archive retention job to purge rows
+-- older than REQUEST_ARCHIVE_RETENTION_DAYS efficiently. The existing
+-- (org_id, created_at desc) index is not used when scanning globally by
+-- time alone.
+CREATE INDEX IF NOT EXISTS idx_in_request_attempt_archives_created_at
+  ON in_request_attempt_archives (created_at);
+
+-- Projection outboxes accumulate rows with projection_state='projected'
+-- indefinitely. Add indexes on processed_at so the retention job can
+-- purge projected rows older than N days without sequential scans.
+CREATE INDEX IF NOT EXISTS idx_in_admin_session_projection_outbox_processed_at
+  ON in_admin_session_projection_outbox (processed_at)
+  WHERE projection_state = 'projected';
+
+CREATE INDEX IF NOT EXISTS idx_in_admin_analysis_request_projection_outbox_processed_at
+  ON in_admin_analysis_request_projection_outbox (processed_at)
+  WHERE projection_state = 'projected';
+
+-- No niyant grant changes: migration adds indexes on existing tables only;
+-- the underlying tables already have niyant grants from migrations 024, 026,
+-- and 027. Indexes inherit table permissions.
+
+COMMIT;


### PR DESCRIPTION
## Summary

- **Gate `raw_request` archiving** behind `ARCHIVE_RAW_REQUEST_ENABLED` (default off). The per-message structured content is already captured in `in_message_blobs` with content-hash dedup; dropping the cumulative-conversation raw body removes the O(n²) write pattern that filled prod disk.
- **Add hourly retention job** (`request-archive-retention-hourly`). Batched-deletes `in_request_attempt_archives` older than `REQUEST_ARCHIVE_RETENTION_DAYS` (default 30), sweeps orphaned `in_raw_blobs` and `in_message_blobs` (RESTRICT joins), and purges projected outbox rows older than `REQUEST_ARCHIVE_OUTBOX_RETENTION_DAYS` (default 7).
- **Migration 030** adds a `created_at` index on `in_request_attempt_archives` and partial indexes on the projected outboxes so retention scans don't seq-scan.

## Why

Migration 024 (Mar 26) added prompt-archive storage with no retention. `raw_request` stores the full cumulative conversation every turn with no cross-turn dedup, so multi-turn agent traffic (claude code, codex) grew `in_raw_blobs` quadratically. This filled the sf-prod DB disk on Apr 17 and blocked all postgres logins (`server login has been failing, cached error: connect failed`), taking innies fully down.

## Test plan

- [x] `npm test -- --run tests/requestArchiveService.test.ts` — 16 pass (new split tests: `skips raw_request archiving by default` + `gzip-compresses all three when ARCHIVE_RAW_REQUEST_ENABLED=true`)
- [x] `npm test -- --run tests/requestArchiveRetentionRepository.test.ts` — 6 pass (SQL shape, batch bounds, outbox table names)
- [x] `npm test -- --run tests/requestArchiveRetentionJob.test.ts` — 6 pass (env defaults, env overrides, batch loop exit, maxBatchesPerPhase cap, ordering)
- [x] `npm test -- --run tests/jobs.test.ts` — 6 pass (registry includes `request-archive-retention-hourly`)
- [x] Full suite: 907 pass / 20 fail (20 failures are pre-existing `ECONNREFUSED 127.0.0.1:5432` integration tests, unchanged from `origin/main` baseline)
- [ ] On deploy, set `REQUEST_ARCHIVE_RETENTION_DAYS=30` and leave `ARCHIVE_RAW_REQUEST_ENABLED` unset
- [ ] First run may hit `maxBatchesPerPhase` cap on historical data; subsequent runs will drain within 1h windows

## Operational notes

- Migration 030 is additive (indexes only). Uses `CREATE INDEX IF NOT EXISTS` so idempotent.
- For the one-time backlog cleanup on existing prod, the job will chew through history at 50k rows/hr per phase; if faster cleanup is needed, run a manual `DELETE FROM in_request_attempt_archives WHERE created_at < now() - interval '30 days'` followed by `VACUUM` after disk is freed.
- `raw_response` and `raw_stream` continue to be archived (per-turn unique, debug-valuable, no amplification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)