### PR TITLE
feat: propagate CLI session id + realtime publication

### DIFF
--- a/cli/src/commands/claude.js
+++ b/cli/src/commands/claude.js
@@ -1,6 +1,6 @@
 import { spawn } from 'node:child_process';
 import { loadConfig, resolveProviderDefaultModel } from '../config.js';
-import { buildCorrelationId, fail } from '../utils.js';
+import { buildCorrelationId, buildSessionId, fail } from '../utils.js';
 import {
   classifyRuntimeFailure,
   printConnectionStatus,
@@ -81,10 +81,12 @@ export async function runClaude(args) {
   const model = resolveClaudeSessionModel(args, defaultModel);
   const proxyUrl = proxyBase(config.apiBaseUrl);
   const correlationId = buildCorrelationId();
+  const sessionId = buildSessionId();
   const claudeBridge = await startClaudeProxy({
     upstreamBaseUrl: config.apiBaseUrl,
     buyerToken: config.token,
     correlationId,
+    sessionId,
     sessionModel: model
   });
   const claudeBinary = resolveWrappedBinary({
@@ -110,6 +112,7 @@ export async function runClaude(args) {
     INNIES_MODEL: model,
     INNIES_ROUTE_MODE: 'token',
     INNIES_CORRELATION_ID: correlationId,
+    INNIES_SESSION_ID: sessionId,
     ANTHROPIC_API_KEY: config.token,
     ANTHROPIC_BASE_URL: claudeBridge.baseUrl,
     OPENAI_API_KEY: config.token,

--- a/cli/src/commands/claudeProxy.js
+++ b/cli/src/commands/claudeProxy.js
@@ -31,6 +31,11 @@ export function buildClaudeProxyHeaders(input) {
   headers['x-api-key'] = input.buyerToken;
   headers['x-request-id'] = input.requestId;
   headers['x-innies-provider-pin'] = 'true';
+  // Propagate the CLI-invocation session id so every turn of this
+  // `innies claude` run groups under one session on the API side.
+  if (typeof input.sessionId === 'string' && input.sessionId.length > 0) {
+    headers['x-openclaw-session-id'] = input.sessionId;
+  }
 
   return headers;
 }
@@ -105,7 +110,8 @@ export async function startClaudeProxy(input) {
         headers: buildClaudeProxyHeaders({
           headers: req.headers,
           buyerToken: input.buyerToken,
-          requestId
+          requestId,
+          sessionId: input.sessionId
         })
       };
 

--- a/cli/src/commands/codex.js
+++ b/cli/src/commands/codex.js
@@ -1,6 +1,6 @@
 import { spawn } from 'node:child_process';
 import { loadConfig, resolveProviderDefaultModel } from '../config.js';
-import { buildCorrelationId, fail } from '../utils.js';
+import { buildCorrelationId, buildSessionId, fail } from '../utils.js';
 import {
   classifyRuntimeFailure,
   printConnectionStatus,
@@ -38,7 +38,11 @@ export function buildCodexArgs(input) {
     '--config', `${providerPath}.supports_websockets=false`,
     '--config', 'responses_websockets_v2=false',
     '--config', `${providerPath}.env_http_headers."x-request-id"="INNIES_CORRELATION_ID"`,
-    '--config', `${providerPath}.env_http_headers."x-innies-provider-pin"="INNIES_PROVIDER_PIN"`
+    '--config', `${providerPath}.env_http_headers."x-innies-provider-pin"="INNIES_PROVIDER_PIN"`,
+    // Propagate the CLI-invocation session id so the Innies API can group
+    // every turn of this `innies codex` run under one session. Read by
+    // resolveOpenClawCorrelation in api/src/routes/proxy.ts.
+    '--config', `${providerPath}.env_http_headers."x-openclaw-session-id"="INNIES_SESSION_ID"`
   ];
 
   if (!hasExplicitModelArg(args)) {
@@ -75,6 +79,7 @@ export async function runCodex(args) {
   const model = resolveProviderDefaultModel(config, 'openai');
   const proxyUrl = proxyBase(config.apiBaseUrl);
   const correlationId = buildCorrelationId();
+  const sessionId = buildSessionId();
   const codexBinary = resolveWrappedBinary({
     binaryName: 'codex',
     displayName: 'Codex',
@@ -104,6 +109,7 @@ export async function runCodex(args) {
     INNIES_MODEL: model,
     INNIES_ROUTE_MODE: 'token',
     INNIES_CORRELATION_ID: correlationId,
+    INNIES_SESSION_ID: sessionId,
     INNIES_PROVIDER_PIN: 'true',
     OPENAI_API_KEY: config.token
   };

--- a/cli/src/utils.js
+++ b/cli/src/utils.js
@@ -57,6 +57,21 @@ export function buildCorrelationId() {
   return randomUUID();
 }
 
+/**
+ * Per-CLI-invocation session id.
+ *
+ * Propagated to upstream requests as the `x-openclaw-session-id` header so the
+ * Innies API can group every turn of a single `innies codex` / `innies claude`
+ * run under one session. Read by `resolveOpenClawCorrelation` in
+ * api/src/routes/proxy.ts.
+ *
+ * Must be stable for the lifetime of one CLI invocation and unique across
+ * invocations. UUID v4 meets both.
+ */
+export function buildSessionId() {
+  return randomUUID();
+}
+
 export async function fileExists(path) {
   try {
     await access(path, constants.F_OK);

--- a/cli/tests/claudeProxy.test.js
+++ b/cli/tests/claudeProxy.test.js
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { once } from 'node:events';
 import http from 'node:http';
 import test from 'node:test';
-import { startClaudeProxy } from '../src/commands/claudeProxy.js';
+import { buildClaudeProxyHeaders, startClaudeProxy } from '../src/commands/claudeProxy.js';
 
 function closeServer(server) {
   return new Promise((resolve, reject) => {
@@ -76,6 +76,50 @@ test('claude proxy injects buyer auth and strips claude oauth auth', async () =>
 
   await proxy.close();
   await closeServer(upstream);
+});
+
+test('claude proxy forwards x-openclaw-session-id when a sessionId is provided', async () => {
+  let capturedRequest = null;
+  const upstream = http.createServer((req, res) => {
+    capturedRequest = { headers: req.headers };
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ ok: true }));
+  });
+
+  upstream.listen(0, '127.0.0.1');
+  await once(upstream, 'listening');
+
+  const upstreamAddress = upstream.address();
+  const upstreamBaseUrl = `http://127.0.0.1:${upstreamAddress.port}`;
+  const proxy = await startClaudeProxy({
+    upstreamBaseUrl,
+    buyerToken: 'in_live_test',
+    correlationId: 'req_sid_xyz',
+    sessionId: 'sess_abc_uuid',
+    sessionModel: 'claude-opus-4-6'
+  });
+
+  const response = await fetch(`${proxy.baseUrl}/v1/messages`, {
+    method: 'GET',
+    headers: { 'content-type': 'application/json' }
+  });
+
+  assert.equal(response.status, 200);
+  assert.ok(capturedRequest);
+  assert.equal(capturedRequest.headers['x-openclaw-session-id'], 'sess_abc_uuid');
+
+  await proxy.close();
+  await closeServer(upstream);
+});
+
+test('buildClaudeProxyHeaders omits x-openclaw-session-id when no sessionId is provided', () => {
+  const headers = buildClaudeProxyHeaders({
+    headers: {},
+    buyerToken: 'in_live_test',
+    requestId: 'req_no_session'
+  });
+
+  assert.equal(Object.prototype.hasOwnProperty.call(headers, 'x-openclaw-session-id'), false);
 });
 
 test('claude proxy rewrites compat request model to the wrapped session model', async () => {

--- a/cli/tests/codexArgs.test.js
+++ b/cli/tests/codexArgs.test.js
@@ -30,3 +30,12 @@ test('injects a custom codex provider config that points at the innies proxy', (
   assert.ok(args.includes('model_providers.innies.supports_websockets=false'));
   assert.ok(args.includes('responses_websockets_v2=false'));
 });
+
+test('forwards INNIES_SESSION_ID into the codex env_http_headers config', () => {
+  const args = buildCodexArgs({ args: [], model: 'gpt-5.4', proxyUrl: 'https://api.innies.computer/v1/proxy/v1' });
+
+  assert.ok(
+    args.includes('model_providers.innies.env_http_headers."x-openclaw-session-id"="INNIES_SESSION_ID"'),
+    'expected codex config to inject x-openclaw-session-id from INNIES_SESSION_ID'
+  );
+});

--- a/cli/tests/utils.test.js
+++ b/cli/tests/utils.test.js
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { buildCorrelationId, buildSessionId } from '../src/utils.js';
+
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+test('buildCorrelationId returns a v4 UUID per call', () => {
+  const a = buildCorrelationId();
+  const b = buildCorrelationId();
+  assert.match(a, UUID_V4);
+  assert.match(b, UUID_V4);
+  assert.notEqual(a, b);
+});
+
+test('buildSessionId returns a v4 UUID per call', () => {
+  const a = buildSessionId();
+  const b = buildSessionId();
+  assert.match(a, UUID_V4);
+  assert.match(b, UUID_V4);
+  assert.notEqual(a, b);
+});
+
+test('buildSessionId and buildCorrelationId produce independent ids', () => {
+  const correlation = buildCorrelationId();
+  const session = buildSessionId();
+  assert.notEqual(correlation, session);
+});

--- a/docs/migrations/033_realtime_publication.sql
+++ b/docs/migrations/033_realtime_publication.sql
@@ -1,0 +1,47 @@
+BEGIN;
+
+-- Expose the live-session substrate to Supabase Realtime so UI clients can
+-- subscribe to new turns as they land. Hosted Supabase ships a publication
+-- named `supabase_realtime` that WAL-streams INSERT/UPDATE/DELETE events over
+-- websockets to subscribed clients.
+--
+-- Guarded so this migration is a no-op on any pg instance that does not have
+-- the `supabase_realtime` publication (plain pg, CI, sf-prod RDS legacy, etc).
+-- Adding a table that is already in the publication is idempotent on current
+-- pg versions via ALTER PUBLICATION ... ADD TABLE; we guard each ADD with a
+-- pg_publication_tables check so the migration stays re-runnable.
+
+DO $$
+DECLARE
+  target_tables text[] := ARRAY[
+    'in_request_attempt_archives',
+    'in_request_attempt_messages',
+    'in_message_blobs'
+  ];
+  tbl text;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_publication WHERE pubname = 'supabase_realtime'
+  ) THEN
+    RAISE NOTICE 'supabase_realtime publication not present; skipping (non-Supabase pg)';
+    RETURN;
+  END IF;
+
+  FOREACH tbl IN ARRAY target_tables LOOP
+    IF NOT EXISTS (
+      SELECT 1 FROM pg_publication_tables
+      WHERE pubname = 'supabase_realtime'
+        AND schemaname = 'public'
+        AND tablename = tbl
+    ) THEN
+      EXECUTE format('ALTER PUBLICATION supabase_realtime ADD TABLE public.%I', tbl);
+      RAISE NOTICE 'added %.% to supabase_realtime publication', 'public', tbl;
+    END IF;
+  END LOOP;
+END $$;
+
+-- No niyant grant changes: this migration only alters a Supabase-managed
+-- publication. The underlying tables already have niyant grants from
+-- migration 024. Publications do not have grantable surface of their own.
+
+COMMIT;

--- a/docs/migrations/033_realtime_publication_no_extensions.sql
+++ b/docs/migrations/033_realtime_publication_no_extensions.sql
@@ -1,0 +1,47 @@
+BEGIN;
+
+-- Expose the live-session substrate to Supabase Realtime so UI clients can
+-- subscribe to new turns as they land. Hosted Supabase ships a publication
+-- named `supabase_realtime` that WAL-streams INSERT/UPDATE/DELETE events over
+-- websockets to subscribed clients.
+--
+-- Guarded so this migration is a no-op on any pg instance that does not have
+-- the `supabase_realtime` publication (plain pg, CI, sf-prod RDS legacy, etc).
+-- Adding a table that is already in the publication is idempotent on current
+-- pg versions via ALTER PUBLICATION ... ADD TABLE; we guard each ADD with a
+-- pg_publication_tables check so the migration stays re-runnable.
+
+DO $$
+DECLARE
+  target_tables text[] := ARRAY[
+    'in_request_attempt_archives',
+    'in_request_attempt_messages',
+    'in_message_blobs'
+  ];
+  tbl text;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_publication WHERE pubname = 'supabase_realtime'
+  ) THEN
+    RAISE NOTICE 'supabase_realtime publication not present; skipping (non-Supabase pg)';
+    RETURN;
+  END IF;
+
+  FOREACH tbl IN ARRAY target_tables LOOP
+    IF NOT EXISTS (
+      SELECT 1 FROM pg_publication_tables
+      WHERE pubname = 'supabase_realtime'
+        AND schemaname = 'public'
+        AND tablename = tbl
+    ) THEN
+      EXECUTE format('ALTER PUBLICATION supabase_realtime ADD TABLE public.%I', tbl);
+      RAISE NOTICE 'added %.% to supabase_realtime publication', 'public', tbl;
+    END IF;
+  END LOOP;
+END $$;
+
+-- No niyant grant changes: this migration only alters a Supabase-managed
+-- publication. The underlying tables already have niyant grants from
+-- migration 024. Publications do not have grantable surface of their own.
+
+COMMIT;


### PR DESCRIPTION
## Summary

- **CLI session id injection** — `innies codex` and `innies claude` now generate a UUID per CLI invocation and send it upstream as `x-openclaw-session-id`. The API already reads this header (in `resolveOpenClawCorrelation`), so every turn of a single CLI run groups under one session automatically.
- **Supabase Realtime publication (migration 033)** — adds `in_request_attempt_archives`, `in_request_attempt_messages`, `in_message_blobs` to the `supabase_realtime` publication so UI clients can subscribe to new turns over websockets. Guarded so it's a no-op on non-Supabase pg.

## Why

Before this: 97% of codex turns and 100% of claude turns had `openclaw_session_id = NULL`. The server's session grouping ran on that column, so CLI turns could not be grouped back into conversations on the read side. The `publicLiveSessionsService` fallback that used a `prompt_cache_key` from `raw_request` stopped working after PR #190 gated raw_request archival off.

After this: every CLI turn carries a stable session id; the existing admin-session-projector + live-sessions feed groups them correctly; and UI clients can get push updates on new turns via Supabase Realtime instead of polling.

## Test plan

- [x] `cd cli && npm run test:unit` — **30/30 pass** (+6 new: buildSessionId helpers, codex config-arg assertion, claudeProxy header assertion)
- [x] `cd api && npm test -- --run` — **907 pass / 20 fail** (20 failures are pre-existing `ECONNREFUSED pg` integration tests, unchanged from baseline)
- [ ] Apply migration 033 to Supabase post-merge
- [ ] Deploy to exe.dev, verify `ssh innies-api.exe.xyz journalctl -u innies-api` is clean
- [ ] After CLI redeploy, run `innies codex` → check `in_request_attempt_archives.openclaw_session_id` is populated for the new rows

## Follow-ups

- Supabase Realtime publication adds do require `ALTER PUBLICATION` privilege; on Supabase hosted this works with the `postgres` role, but will fail gracefully (EXISTS check) on any pg without the publication.
- UI in innies-work can now use `supabase-js`'s `postgres_changes` channel filtered by `api_key_id=eq.<...>` to render live panels per session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)