### PR TITLE
chore(cli): bump to 0.1.10 for session id propagation release

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "innies",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "type": "module",
   "description": "CLI wrappers for routing Claude and Codex through the Innies proxy.",
   "repository": {


### PR DESCRIPTION
## Summary

- Bumps `cli/package.json` version 0.1.9 → 0.1.10 to release the `x-openclaw-session-id` header injection from PR #193 to npm users.

## Publish instructions

After merge, from a machine logged in to npm (`npm login` as `bicep_pump`):

```bash
cd cli
npm publish
```

Then users upgrade with:

```bash
npm install -g innies@latest
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)