### PR TITLE
feat(cli): add --version / -v flag + bump to 0.1.11

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "innies",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "type": "module",
   "description": "CLI wrappers for routing Claude and Codex through the Innies proxy.",
   "repository": {

--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -4,7 +4,7 @@ import { runDoctor } from './commands/doctor.js';
 import { runClaude } from './commands/claude.js';
 import { runCodex } from './commands/codex.js';
 import { runLinkClaude, runUnlinkClaude } from './commands/link.js';
-import { fail, printUsage } from './utils.js';
+import { fail, printUsage, readPackageVersion } from './utils.js';
 
 async function main() {
   const args = process.argv.slice(2);
@@ -12,6 +12,12 @@ async function main() {
 
   if (!command || command === '-h' || command === '--help') {
     printUsage();
+    return;
+  }
+
+  if (command === '-v' || command === '--version' || command === 'version') {
+    const version = await readPackageVersion();
+    console.log(version);
     return;
   }
 

--- a/cli/src/utils.js
+++ b/cli/src/utils.js
@@ -1,6 +1,8 @@
 import { randomUUID } from 'node:crypto';
-import { access } from 'node:fs/promises';
+import { access, readFile } from 'node:fs/promises';
 import { constants } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 export function printUsage() {
   console.log(
@@ -14,6 +16,7 @@ export function printUsage() {
       '  innies codex [-- <codex args...>]',
       '  innies link claude',
       '  innies unlink claude',
+      '  innies --version',
       ''
     ].join('\n')
   );
@@ -55,6 +58,27 @@ export function parseFlag(args, name) {
 
 export function buildCorrelationId() {
   return randomUUID();
+}
+
+/**
+ * Read the `version` field from the CLI package.json that ships alongside
+ * the installed module. Resolves relative to this source file so it works
+ * from both the source tree (ESM imports) and a globally-installed node
+ * package (symlinked bin → lib/node_modules/innies/bin).
+ */
+export async function readPackageVersion() {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const pkgPath = resolve(here, '..', 'package.json');
+  try {
+    const raw = await readFile(pkgPath, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (typeof parsed.version !== 'string' || parsed.version.length === 0) {
+      return 'unknown';
+    }
+    return parsed.version;
+  } catch {
+    return 'unknown';
+  }
 }
 
 /**

--- a/cli/tests/utils.test.js
+++ b/cli/tests/utils.test.js
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { buildCorrelationId, buildSessionId } from '../src/utils.js';
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { buildCorrelationId, buildSessionId, readPackageVersion } from '../src/utils.js';
 
 const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
@@ -24,4 +27,17 @@ test('buildSessionId and buildCorrelationId produce independent ids', () => {
   const correlation = buildCorrelationId();
   const session = buildSessionId();
   assert.notEqual(correlation, session);
+});
+
+test('readPackageVersion returns the version from the cli package.json', async () => {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const pkgPath = resolve(here, '..', 'package.json');
+  const pkg = JSON.parse(await readFile(pkgPath, 'utf8'));
+
+  const version = await readPackageVersion();
+
+  assert.equal(typeof version, 'string');
+  assert.notEqual(version, 'unknown');
+  assert.equal(version, pkg.version);
+  assert.match(version, /^\d+\.\d+\.\d+/);
 });


### PR DESCRIPTION
## Summary

- `innies --version`, `innies -v`, and `innies version` now print the installed version
- `innies --help` lists the new flag
- Bumps `cli/package.json` 0.1.10 → 0.1.11
- Tests: 31/31 pass (+1 new for `readPackageVersion`)

## Why

Surprisingly, the CLI had no way to report its own version. When debugging an `npm install -g` cache snafu on 0.1.10 I had to run `npm ls -g innies` to check — that's exactly the UX fingerprint a `--version` flag fixes.

## Publish

After merge, same as the last publish:

```bash
cd cli && npm publish
npm install -g innies@latest
innies --version   # should print 0.1.11
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)