### PR TITLE
feat(cli): local HTTP bridge for codex + bump 0.1.12

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "innies",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "type": "module",
   "description": "CLI wrappers for routing Claude and Codex through the Innies proxy.",
   "repository": {

--- a/cli/src/commands/codex.js
+++ b/cli/src/commands/codex.js
@@ -9,6 +9,7 @@ import {
   shouldCaptureCommandOutput
 } from './wrapperRuntime.js';
 import { prepareCodexAuthOverlay } from './codexAuthOverlay.js';
+import { startCodexProxy } from './codexProxy.js';
 
 const CODEX_PROXY_PROVIDER = 'innies';
 
@@ -28,6 +29,11 @@ export function hasExplicitModelArg(args) {
 export function buildCodexArgs(input) {
   const { args, model, proxyUrl } = input;
   const providerPath = `model_providers.${CODEX_PROXY_PROVIDER}`;
+  // Headers (x-request-id, x-innies-provider-pin, x-openclaw-session-id)
+  // are stamped by the local HTTP bridge (codexProxy.js) on every forwarded
+  // request — this guarantees injection regardless of whether the codex
+  // binary honors env_http_headers for our header names. Keep the codex
+  // config minimal.
   const forcedArgs = [
     '--config', `model_provider="${CODEX_PROXY_PROVIDER}"`,
     '--config', `${providerPath}.name="${CODEX_PROXY_PROVIDER}"`,
@@ -36,13 +42,7 @@ export function buildCodexArgs(input) {
     '--config', `${providerPath}.wire_api="responses"`,
     '--config', `${providerPath}.requires_openai_auth=false`,
     '--config', `${providerPath}.supports_websockets=false`,
-    '--config', 'responses_websockets_v2=false',
-    '--config', `${providerPath}.env_http_headers."x-request-id"="INNIES_CORRELATION_ID"`,
-    '--config', `${providerPath}.env_http_headers."x-innies-provider-pin"="INNIES_PROVIDER_PIN"`,
-    // Propagate the CLI-invocation session id so the Innies API can group
-    // every turn of this `innies codex` run under one session. Read by
-    // resolveOpenClawCorrelation in api/src/routes/proxy.ts.
-    '--config', `${providerPath}.env_http_headers."x-openclaw-session-id"="INNIES_SESSION_ID"`
+    '--config', 'responses_websockets_v2=false'
   ];
 
   if (!hasExplicitModelArg(args)) {
@@ -77,9 +77,17 @@ export async function runCodex(args) {
   }
 
   const model = resolveProviderDefaultModel(config, 'openai');
-  const proxyUrl = proxyBase(config.apiBaseUrl);
+  const upstreamProxyUrl = proxyBase(config.apiBaseUrl);
   const correlationId = buildCorrelationId();
   const sessionId = buildSessionId();
+  // Start a local HTTP bridge that stamps x-openclaw-session-id on every
+  // request before forwarding to Innies. Point codex at the bridge URL.
+  const codexBridge = await startCodexProxy({
+    upstreamBaseUrl: config.apiBaseUrl,
+    correlationId,
+    sessionId
+  });
+  const bridgeProxyUrl = `${codexBridge.baseUrl}/v1/proxy/v1`;
   const codexBinary = resolveWrappedBinary({
     binaryName: 'codex',
     displayName: 'Codex',
@@ -90,7 +98,9 @@ export async function runCodex(args) {
     sourceCodexHome: process.env.CODEX_HOME
   });
 
-  printConnectionStatus({ model, proxyUrl, correlationId });
+  // Display the user-visible upstream URL in the banner, not the local bridge
+  // port (which changes per invocation and is an implementation detail).
+  printConnectionStatus({ model, proxyUrl: upstreamProxyUrl, correlationId });
 
   const {
     OPENAI_BASE_URL: _deprecatedOpenAiBaseUrl,
@@ -105,7 +115,7 @@ export async function runCodex(args) {
     INNIES_CODEX_WRAPPED: '1',
     INNIES_TOKEN: config.token,
     INNIES_API_BASE_URL: config.apiBaseUrl,
-    INNIES_PROXY_URL: proxyUrl,
+    INNIES_PROXY_URL: upstreamProxyUrl,
     INNIES_MODEL: model,
     INNIES_ROUTE_MODE: 'token',
     INNIES_CORRELATION_ID: correlationId,
@@ -117,7 +127,7 @@ export async function runCodex(args) {
   const captureOutput = shouldCaptureCommandOutput('INNIES_CAPTURE_CODEX_OUTPUT');
   let combinedOutput = '';
   const stdio = captureOutput ? ['inherit', 'pipe', 'pipe'] : 'inherit';
-  const child = spawn(codexBinary, buildCodexArgs({ args, model, proxyUrl }), {
+  const child = spawn(codexBinary, buildCodexArgs({ args, model, proxyUrl: bridgeProxyUrl }), {
     stdio,
     env
   });
@@ -143,13 +153,21 @@ export async function runCodex(args) {
     authOverlay.cleanup();
   }
 
-  child.on('error', (error) => {
+  async function closeBridge() {
+    try {
+      await codexBridge.close();
+    } catch {}
+  }
+
+  child.on('error', async (error) => {
     cleanupOverlay();
+    await closeBridge();
     fail(`Failed to run codex: ${error.message}`);
   });
 
-  child.on('close', (code, signal) => {
+  child.on('close', async (code, signal) => {
     cleanupOverlay();
+    await closeBridge();
     if (signal) {
       process.kill(process.pid, signal);
       return;
@@ -162,4 +180,7 @@ export async function runCodex(args) {
 
     process.exit(code ?? 0);
   });
+
+  process.on('SIGINT', () => { void closeBridge(); process.exit(130); });
+  process.on('SIGTERM', () => { void closeBridge(); process.exit(143); });
 }

--- a/cli/src/commands/codexProxy.js
+++ b/cli/src/commands/codexProxy.js
@@ -1,0 +1,131 @@
+import { randomUUID } from 'node:crypto';
+import http from 'node:http';
+import { once } from 'node:events';
+import { Readable } from 'node:stream';
+
+function hasRequestBody(method) {
+  const normalized = (method ?? 'GET').toUpperCase();
+  return normalized !== 'GET' && normalized !== 'HEAD';
+}
+
+/**
+ * Build outgoing headers from an incoming codex request.
+ *
+ * Copies everything codex sent, then stamps in the CLI-invocation
+ * correlation id and session id so every turn of a single `innies codex`
+ * run groups under one session on the Innies side. Strips `host` and
+ * `content-length` (they are managed by the fetch layer on forward).
+ */
+export function buildCodexProxyHeaders(input) {
+  const headers = {};
+
+  for (const [name, value] of Object.entries(input.headers ?? {})) {
+    if (value == null) {
+      continue;
+    }
+
+    const lowerName = name.toLowerCase();
+    if (lowerName === 'host' || lowerName === 'content-length') {
+      continue;
+    }
+
+    headers[name] = Array.isArray(value) ? value.join(', ') : value;
+  }
+
+  headers['x-request-id'] = input.requestId;
+  headers['x-innies-provider-pin'] = 'true';
+
+  if (typeof input.sessionId === 'string' && input.sessionId.length > 0) {
+    headers['x-openclaw-session-id'] = input.sessionId;
+  }
+
+  return headers;
+}
+
+function forwardedRequestId(headers, correlationId) {
+  const raw = headers?.['x-request-id'];
+  if (Array.isArray(raw)) {
+    const value = raw.find((entry) => typeof entry === 'string' && entry.trim().length > 0);
+    if (value) return value.trim();
+  }
+  if (typeof raw === 'string' && raw.trim().length > 0) {
+    return raw.trim();
+  }
+  return `${correlationId}:${randomUUID()}`;
+}
+
+/**
+ * Start a local HTTP bridge that codex talks to. Every request codex
+ * issues is proxied to `input.upstreamBaseUrl` (the real Innies API) with
+ * `x-openclaw-session-id` stamped in, regardless of whether codex honors
+ * its own `env_http_headers` config. This matches the approach used by
+ * `startClaudeProxy` for the anthropic lane.
+ */
+export async function startCodexProxy(input) {
+  const server = http.createServer(async (req, res) => {
+    try {
+      const targetUrl = new URL(req.url || '/', input.upstreamBaseUrl);
+      const requestId = forwardedRequestId(req.headers, input.correlationId);
+      const init = {
+        method: req.method,
+        headers: buildCodexProxyHeaders({
+          headers: req.headers,
+          requestId,
+          sessionId: input.sessionId
+        })
+      };
+
+      if (hasRequestBody(req.method)) {
+        init.body = Readable.toWeb(req);
+        init.duplex = 'half';
+      }
+
+      const upstreamResponse = await fetch(targetUrl, init);
+      const responseHeaders = {};
+      upstreamResponse.headers.forEach((value, name) => {
+        responseHeaders[name] = value;
+      });
+
+      res.writeHead(upstreamResponse.status, responseHeaders);
+
+      if (!upstreamResponse.body) {
+        res.end();
+        return;
+      }
+
+      Readable.fromWeb(upstreamResponse.body).pipe(res);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      res.writeHead(502, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({
+        code: 'codex_proxy_error',
+        message: `Innies Codex bridge failed: ${message}`
+      }));
+    }
+  });
+
+  server.on('clientError', (_error, socket) => {
+    socket.end('HTTP/1.1 400 Bad Request\r\n\r\n');
+  });
+
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Innies Codex bridge failed to bind a local port.');
+  }
+
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    close: () => new Promise((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    })
+  };
+}

--- a/cli/tests/codexArgs.test.js
+++ b/cli/tests/codexArgs.test.js
@@ -31,11 +31,15 @@ test('injects a custom codex provider config that points at the innies proxy', (
   assert.ok(args.includes('responses_websockets_v2=false'));
 });
 
-test('forwards INNIES_SESSION_ID into the codex env_http_headers config', () => {
-  const args = buildCodexArgs({ args: [], model: 'gpt-5.4', proxyUrl: 'https://api.innies.computer/v1/proxy/v1' });
+test('does not inject env_http_headers — headers are stamped by the local bridge', () => {
+  const args = buildCodexArgs({ args: [], model: 'gpt-5.4', proxyUrl: 'https://bridge.local/v1/proxy/v1' });
 
-  assert.ok(
-    args.includes('model_providers.innies.env_http_headers."x-openclaw-session-id"="INNIES_SESSION_ID"'),
-    'expected codex config to inject x-openclaw-session-id from INNIES_SESSION_ID'
+  // Header injection now happens in codexProxy.js on every forwarded request.
+  // Emitting env_http_headers here was redundant and unreliable (codex does
+  // not propagate them for our header names), so buildCodexArgs no longer
+  // emits any env_http_headers entries.
+  assert.equal(
+    args.some((entry) => typeof entry === 'string' && entry.includes('env_http_headers')),
+    false
   );
 });

--- a/cli/tests/codexProxy.test.js
+++ b/cli/tests/codexProxy.test.js
@@ -1,0 +1,154 @@
+import assert from 'node:assert/strict';
+import { once } from 'node:events';
+import http from 'node:http';
+import test from 'node:test';
+import { buildCodexProxyHeaders, startCodexProxy } from '../src/commands/codexProxy.js';
+
+function closeServer(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+test('codex proxy forwards x-openclaw-session-id on every request', async () => {
+  const captured = [];
+  const upstream = http.createServer((req, res) => {
+    captured.push({ url: req.url, headers: req.headers });
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ ok: true }));
+  });
+  upstream.listen(0, '127.0.0.1');
+  await once(upstream, 'listening');
+
+  const { port } = upstream.address();
+  const upstreamBaseUrl = `http://127.0.0.1:${port}`;
+  const bridge = await startCodexProxy({
+    upstreamBaseUrl,
+    correlationId: 'corr_abc',
+    sessionId: 'sess_codex_xyz'
+  });
+
+  // Two turns through the bridge — both should carry the same session id
+  await fetch(`${bridge.baseUrl}/v1/proxy/v1/responses`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ turn: 1 })
+  });
+  await fetch(`${bridge.baseUrl}/v1/proxy/v1/responses`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ turn: 2 })
+  });
+
+  assert.equal(captured.length, 2);
+  for (const row of captured) {
+    assert.equal(row.url, '/v1/proxy/v1/responses');
+    assert.equal(row.headers['x-openclaw-session-id'], 'sess_codex_xyz');
+    assert.equal(row.headers['x-innies-provider-pin'], 'true');
+    assert.match(String(row.headers['x-request-id']), /^corr_abc:/);
+  }
+
+  await bridge.close();
+  await closeServer(upstream);
+});
+
+test('codex proxy preserves client-supplied x-request-id when present', async () => {
+  let captured = null;
+  const upstream = http.createServer((req, res) => {
+    captured = { headers: req.headers };
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ ok: true }));
+  });
+  upstream.listen(0, '127.0.0.1');
+  await once(upstream, 'listening');
+
+  const { port } = upstream.address();
+  const bridge = await startCodexProxy({
+    upstreamBaseUrl: `http://127.0.0.1:${port}`,
+    correlationId: 'corr_test',
+    sessionId: 'sess_test'
+  });
+
+  await fetch(`${bridge.baseUrl}/v1/proxy/v1/responses`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-request-id': 'client-preferred-id'
+    },
+    body: '{}'
+  });
+
+  assert.equal(captured.headers['x-request-id'], 'client-preferred-id');
+
+  await bridge.close();
+  await closeServer(upstream);
+});
+
+test('buildCodexProxyHeaders omits x-openclaw-session-id when no sessionId is provided', () => {
+  const headers = buildCodexProxyHeaders({
+    headers: {},
+    requestId: 'req_none'
+  });
+
+  assert.equal(Object.prototype.hasOwnProperty.call(headers, 'x-openclaw-session-id'), false);
+  assert.equal(headers['x-request-id'], 'req_none');
+  assert.equal(headers['x-innies-provider-pin'], 'true');
+});
+
+test('buildCodexProxyHeaders strips host and content-length headers', () => {
+  const headers = buildCodexProxyHeaders({
+    headers: {
+      host: 'irrelevant.example',
+      'content-length': '1234',
+      'user-agent': 'codex/0.121.0'
+    },
+    requestId: 'req_strip',
+    sessionId: 'sess_strip'
+  });
+
+  assert.equal(Object.prototype.hasOwnProperty.call(headers, 'host'), false);
+  assert.equal(Object.prototype.hasOwnProperty.call(headers, 'content-length'), false);
+  assert.equal(headers['user-agent'], 'codex/0.121.0');
+});
+
+test('codex proxy forwards request body and streams response', async () => {
+  const upstream = http.createServer((req, res) => {
+    let body = '';
+    req.setEncoding('utf8');
+    req.on('data', (chunk) => {
+      body += chunk;
+    });
+    req.on('end', () => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ echoed: JSON.parse(body) }));
+    });
+  });
+  upstream.listen(0, '127.0.0.1');
+  await once(upstream, 'listening');
+
+  const { port } = upstream.address();
+  const bridge = await startCodexProxy({
+    upstreamBaseUrl: `http://127.0.0.1:${port}`,
+    correlationId: 'corr_echo',
+    sessionId: 'sess_echo'
+  });
+
+  const res = await fetch(`${bridge.baseUrl}/v1/proxy/v1/responses`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ hello: 'bridge' })
+  });
+
+  assert.equal(res.status, 200);
+  const parsed = await res.json();
+  assert.deepEqual(parsed, { echoed: { hello: 'bridge' } });
+
+  await bridge.close();
+  await closeServer(upstream);
+});


### PR DESCRIPTION
## Summary

- **Robust session-id injection for `innies codex`** — new local HTTP bridge (`cli/src/commands/codexProxy.js`) that codex talks to, which stamps `x-openclaw-session-id` on every forwarded request. Mirrors the anthropic-lane bridge that was already in place (`claudeProxy.js`).
- **Removes the unreliable `env_http_headers` config** — empirically, codex v0.121.0 does not propagate our header names via that config. Switching to the bridge eliminates the dependency.
- **Bumps cli/package.json to 0.1.12**.

## Why this architecture

Before: `innies codex` set `env_http_headers."x-openclaw-session-id"="INNIES_SESSION_ID"` in codex's TOML config. After shipping 0.1.10 and running real traffic, every archive row still had `openclaw_session_id = null`. The assumption that codex honors env_http_headers for arbitrary header names was wrong in practice.

After: codex's `base_url` now points at a local `127.0.0.1:<random>` HTTP server. Every request codex makes goes through our code, which stamps the session id before forwarding. Guaranteed correct regardless of codex version or config quirks.

Critically — **this fixes the "parallel codex windows merge into one panel" problem** flagged in review. Each CLI invocation generates a distinct `buildSessionId()`, so concurrent `innies codex` processes get independent sessions.

## Test plan

- [x] `cd cli && npm run test:unit` — **36/36 pass** (+5 new: session-id stamping across multiple turns, request-id preservation, host/content-length stripping, body echoing, absence of env_http_headers in buildCodexArgs output)
- [ ] Publish 0.1.12 to npm, `npm install -g innies@latest`
- [ ] Run 2 `innies codex` instances in parallel, verify they land 2 distinct `openclaw_session_id` values in supabase (query in the PR description of #193)

## Follow-ups

- The claude lane was already shipped with this pattern in PR #193; with 0.1.12 both lanes finally propagate session ids reliably.
- Once deployed, `innies-work` UI can safely use the supabase realtime subscription on `in_request_attempt_archives` filtered by `api_key_id`, grouping panels purely by `openclaw_session_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)