### PR TITLE
feat(api): GET /v1/admin/me/live-sessions authenticated endpoint

### DIFF
--- a/api/src/routes/adminMeLiveSessions.ts
+++ b/api/src/routes/adminMeLiveSessions.ts
@@ -1,0 +1,90 @@
+/// <reference path="../types/express.d.ts" />
+
+import { Router } from 'express';
+import { z } from 'zod';
+import { requireApiKey } from '../middleware/auth.js';
+import { runtime } from '../services/runtime.js';
+import { MyLiveSessionsService } from '../services/adminLive/myLiveSessionsService.js';
+import type { MyLiveSessionsFeed } from '../services/adminLive/myLiveSessionsTypes.js';
+
+export const ADMIN_ME_LIVE_SESSIONS_PATH = '/v1/admin/me/live-sessions';
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const querySchema = z.object({
+  api_key_ids: z
+    .string()
+    .trim()
+    .min(1, 'api_key_ids must contain at least one UUID'),
+  window_hours: z
+    .string()
+    .trim()
+    .regex(/^\d+(?:\.\d+)?$/, 'window_hours must be a positive number')
+    .optional()
+});
+
+function parseApiKeyIds(raw: string): string[] {
+  const ids = raw
+    .split(',')
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+
+  const invalid = ids.find((id) => !UUID_REGEX.test(id));
+  if (invalid) {
+    throw new InvalidQueryError(`api_key_ids contains invalid uuid: ${invalid}`);
+  }
+
+  return Array.from(new Set(ids));
+}
+
+class InvalidQueryError extends Error {}
+
+type RouterDeps = {
+  liveSessions?: Pick<MyLiveSessionsService, 'listFeed'>;
+};
+
+export function buildAdminMeLiveSessionsRouter(deps: RouterDeps = {}): Router {
+  const router = Router();
+  const liveSessions: Pick<MyLiveSessionsService, 'listFeed'> =
+    deps.liveSessions ?? new MyLiveSessionsService({ sql: runtime.sql });
+
+  router.get(
+    ADMIN_ME_LIVE_SESSIONS_PATH,
+    requireApiKey(runtime.repos.apiKeys, ['admin']),
+    async (req, res, next) => {
+      try {
+        const parseResult = querySchema.safeParse(req.query);
+        if (!parseResult.success) {
+          res.status(400).json({
+            code: 'invalid_query',
+            message: parseResult.error.issues[0]?.message ?? 'invalid query'
+          });
+          return;
+        }
+
+        const apiKeyIds = parseApiKeyIds(parseResult.data.api_key_ids);
+        const windowHours = parseResult.data.window_hours
+          ? Number(parseResult.data.window_hours)
+          : undefined;
+
+        const feed: MyLiveSessionsFeed = await liveSessions.listFeed({
+          apiKeyIds,
+          windowHours
+        });
+
+        res.setHeader('Cache-Control', 'no-store');
+        res.json(feed);
+      } catch (error) {
+        if (error instanceof InvalidQueryError) {
+          res.status(400).json({ code: 'invalid_query', message: error.message });
+          return;
+        }
+        next(error);
+      }
+    }
+  );
+
+  return router;
+}
+
+export default buildAdminMeLiveSessionsRouter();

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import adminRoutes from './routes/admin.js';
 import adminAnalysisRoutes from './routes/adminAnalysis.js';
 import adminArchiveRoutes from './routes/adminArchive.js';
+import adminMeLiveSessionsRoutes from './routes/adminMeLiveSessions.js';
 import adminMonitorRoutes from './routes/adminMonitor.js';
 import adminOrgsRouter from './routes/adminOrgs.js';
 import analyticsRoutes from './routes/analytics.js';
@@ -149,6 +150,7 @@ export function createApp(): express.Express {
 
   app.use(publicInniesRoutes);
   app.use(adminMonitorRoutes);
+  app.use(adminMeLiveSessionsRoutes);
   app.use(adminRoutes);
   app.use(adminAnalysisRoutes);
   app.use(adminArchiveRoutes);

--- a/api/src/services/adminLive/myLiveSessionsService.ts
+++ b/api/src/services/adminLive/myLiveSessionsService.ts
@@ -1,0 +1,228 @@
+import { TABLES } from '../../repos/tableNames.js';
+import type { SqlValue } from '../../repos/sqlClient.js';
+import {
+  MY_LIVE_SESSIONS_DEFAULT_WINDOW_HOURS,
+  MY_LIVE_SESSIONS_MAX_SESSIONS,
+  MY_LIVE_SESSIONS_MAX_TURNS_PER_SESSION,
+  MY_LIVE_SESSIONS_MAX_WINDOW_HOURS,
+  MY_LIVE_SESSIONS_POLL_INTERVAL_SECONDS,
+  type MyLiveSession,
+  type MyLiveSessionTurn,
+  type MyLiveSessionTurnMessage,
+  type MyLiveSessionsFeed,
+  type MyLiveSessionsListInput,
+  type MyLiveSessionsServiceDeps
+} from './myLiveSessionsTypes.js';
+
+type ArchiveRow = {
+  id: string;
+  request_id: string;
+  attempt_no: number;
+  api_key_id: string;
+  openclaw_session_id: string | null;
+  provider: string;
+  model: string;
+  streaming: boolean;
+  status: 'success' | 'failed' | 'partial';
+  upstream_status: number | null;
+  started_at: string | Date;
+  completed_at: string | Date | null;
+};
+
+type MessageRow = {
+  request_attempt_archive_id: string;
+  side: 'request' | 'response';
+  ordinal: number;
+  role: string | null;
+  content_type: string;
+  normalized_payload: Record<string, unknown>;
+};
+
+function clampWindowHours(requested: number | undefined): number {
+  if (requested == null || !Number.isFinite(requested) || requested <= 0) {
+    return MY_LIVE_SESSIONS_DEFAULT_WINDOW_HOURS;
+  }
+  return Math.min(Math.max(1, Math.floor(requested)), MY_LIVE_SESSIONS_MAX_WINDOW_HOURS);
+}
+
+function toIso(value: string | Date): string {
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+function toIsoNullable(value: string | Date | null): string | null {
+  return value == null ? null : toIso(value);
+}
+
+function sessionKeyForArchive(row: ArchiveRow): string {
+  return row.openclaw_session_id ? row.openclaw_session_id : `archive:${row.id}`;
+}
+
+export class MyLiveSessionsService {
+  constructor(private readonly deps: MyLiveSessionsServiceDeps) {}
+
+  async listFeed(input: MyLiveSessionsListInput): Promise<MyLiveSessionsFeed> {
+    const now = input.now ?? new Date();
+    const windowHours = clampWindowHours(input.windowHours);
+    const generatedAt = now.toISOString();
+    const apiKeyIds = Array.from(new Set(input.apiKeyIds.filter((id) => typeof id === 'string' && id.length > 0)));
+
+    const emptyFeed: MyLiveSessionsFeed = {
+      generatedAt,
+      windowHours,
+      pollIntervalSeconds: MY_LIVE_SESSIONS_POLL_INTERVAL_SECONDS,
+      apiKeyIds,
+      sessions: []
+    };
+
+    if (apiKeyIds.length === 0) {
+      return emptyFeed;
+    }
+
+    const archives = await this.loadArchives(apiKeyIds, now, windowHours);
+    if (archives.length === 0) {
+      return emptyFeed;
+    }
+
+    const archiveIds = archives.map((row) => row.id);
+    const messageRows = await this.loadMessages(archiveIds);
+    const messagesByArchiveId = new Map<string, MessageRow[]>();
+    for (const row of messageRows) {
+      const existing = messagesByArchiveId.get(row.request_attempt_archive_id) ?? [];
+      existing.push(row);
+      messagesByArchiveId.set(row.request_attempt_archive_id, existing);
+    }
+
+    const sessionsByKey = new Map<string, MyLiveSession>();
+    for (const row of archives) {
+      const sessionKey = sessionKeyForArchive(row);
+      const existing = sessionsByKey.get(sessionKey);
+      const turn = this.buildTurn(row, messagesByArchiveId.get(row.id) ?? []);
+
+      if (!existing) {
+        sessionsByKey.set(sessionKey, {
+          sessionKey,
+          apiKeyId: row.api_key_id,
+          startedAt: toIso(row.started_at),
+          lastActivityAt: toIso(row.completed_at ?? row.started_at),
+          turnCount: 1,
+          providerSet: [row.provider],
+          modelSet: [row.model],
+          turns: [turn]
+        });
+        continue;
+      }
+
+      existing.turns.push(turn);
+      existing.turnCount = existing.turns.length;
+      existing.startedAt = earlier(existing.startedAt, toIso(row.started_at));
+      existing.lastActivityAt = later(existing.lastActivityAt, toIso(row.completed_at ?? row.started_at));
+      if (!existing.providerSet.includes(row.provider)) existing.providerSet.push(row.provider);
+      if (!existing.modelSet.includes(row.model)) existing.modelSet.push(row.model);
+    }
+
+    // Sort turns within each session by startedAt ascending, then trim to cap.
+    for (const session of sessionsByKey.values()) {
+      session.turns.sort((left, right) => Date.parse(left.startedAt) - Date.parse(right.startedAt));
+      if (session.turns.length > MY_LIVE_SESSIONS_MAX_TURNS_PER_SESSION) {
+        session.turns = session.turns.slice(-MY_LIVE_SESSIONS_MAX_TURNS_PER_SESSION);
+        session.turnCount = session.turns.length;
+      }
+    }
+
+    const sessions = Array.from(sessionsByKey.values())
+      .sort((left, right) => Date.parse(right.lastActivityAt) - Date.parse(left.lastActivityAt))
+      .slice(0, MY_LIVE_SESSIONS_MAX_SESSIONS);
+
+    return {
+      ...emptyFeed,
+      sessions
+    };
+  }
+
+  private async loadArchives(apiKeyIds: string[], now: Date, windowHours: number): Promise<ArchiveRow[]> {
+    const cutoff = new Date(now.getTime() - windowHours * 60 * 60 * 1000);
+    const sql = `
+      select
+        id,
+        request_id,
+        attempt_no,
+        api_key_id,
+        openclaw_session_id,
+        provider,
+        model,
+        streaming,
+        status,
+        upstream_status,
+        started_at,
+        completed_at
+      from ${TABLES.requestAttemptArchives}
+      where api_key_id = any($1::uuid[])
+        and started_at >= $2::timestamptz
+      order by started_at asc
+    `;
+    const params: SqlValue[] = [apiKeyIds, cutoff];
+    const result = await this.deps.sql.query<ArchiveRow>(sql, params);
+    return result.rows;
+  }
+
+  private async loadMessages(archiveIds: string[]): Promise<MessageRow[]> {
+    if (archiveIds.length === 0) return [];
+    const sql = `
+      select
+        rm.request_attempt_archive_id,
+        rm.side,
+        rm.ordinal,
+        rm.role,
+        rm.content_type,
+        mb.normalized_payload
+      from ${TABLES.requestAttemptMessages} rm
+      inner join ${TABLES.messageBlobs} mb
+        on mb.id = rm.message_blob_id
+      where rm.request_attempt_archive_id = any($1::uuid[])
+      order by rm.request_attempt_archive_id asc,
+               rm.side desc,
+               rm.ordinal asc
+    `;
+    const params: SqlValue[] = [archiveIds];
+    const result = await this.deps.sql.query<MessageRow>(sql, params);
+    return result.rows;
+  }
+
+  private buildTurn(archive: ArchiveRow, messageRows: MessageRow[]): MyLiveSessionTurn {
+    const messages: MyLiveSessionTurnMessage[] = messageRows
+      .slice()
+      .sort((left, right) => {
+        if (left.side !== right.side) return left.side === 'request' ? -1 : 1;
+        return left.ordinal - right.ordinal;
+      })
+      .map((row) => ({
+        side: row.side,
+        ordinal: row.ordinal,
+        role: row.role,
+        contentType: row.content_type,
+        normalizedPayload: row.normalized_payload ?? {}
+      }));
+
+    return {
+      archiveId: archive.id,
+      requestId: archive.request_id,
+      attemptNo: archive.attempt_no,
+      provider: archive.provider,
+      model: archive.model,
+      streaming: archive.streaming,
+      status: archive.status,
+      upstreamStatus: archive.upstream_status ?? null,
+      startedAt: toIso(archive.started_at),
+      completedAt: toIsoNullable(archive.completed_at),
+      messages
+    };
+  }
+}
+
+function earlier(a: string, b: string): string {
+  return Date.parse(a) <= Date.parse(b) ? a : b;
+}
+
+function later(a: string, b: string): string {
+  return Date.parse(a) >= Date.parse(b) ? a : b;
+}

--- a/api/src/services/adminLive/myLiveSessionsTypes.ts
+++ b/api/src/services/adminLive/myLiveSessionsTypes.ts
@@ -1,0 +1,58 @@
+import type { SqlClient } from '../../repos/sqlClient.js';
+
+export const MY_LIVE_SESSIONS_DEFAULT_WINDOW_HOURS = 24;
+export const MY_LIVE_SESSIONS_MAX_WINDOW_HOURS = 7 * 24; // hard cap one week
+export const MY_LIVE_SESSIONS_POLL_INTERVAL_SECONDS = 5;
+export const MY_LIVE_SESSIONS_MAX_SESSIONS = 60;
+export const MY_LIVE_SESSIONS_MAX_TURNS_PER_SESSION = 200;
+
+export type MyLiveSessionTurnMessage = {
+  side: 'request' | 'response';
+  ordinal: number;
+  role: string | null;
+  contentType: string;
+  normalizedPayload: Record<string, unknown>;
+};
+
+export type MyLiveSessionTurn = {
+  archiveId: string;
+  requestId: string;
+  attemptNo: number;
+  provider: string;
+  model: string;
+  streaming: boolean;
+  status: 'success' | 'failed' | 'partial';
+  upstreamStatus: number | null;
+  startedAt: string;
+  completedAt: string | null;
+  messages: MyLiveSessionTurnMessage[];
+};
+
+export type MyLiveSession = {
+  sessionKey: string;
+  apiKeyId: string;
+  startedAt: string;
+  lastActivityAt: string;
+  turnCount: number;
+  providerSet: string[];
+  modelSet: string[];
+  turns: MyLiveSessionTurn[];
+};
+
+export type MyLiveSessionsFeed = {
+  generatedAt: string;
+  windowHours: number;
+  pollIntervalSeconds: number;
+  apiKeyIds: string[];
+  sessions: MyLiveSession[];
+};
+
+export type MyLiveSessionsListInput = {
+  apiKeyIds: string[];
+  now?: Date;
+  windowHours?: number;
+};
+
+export type MyLiveSessionsServiceDeps = {
+  sql: SqlClient;
+};

--- a/api/tests/adminMeLiveSessions.route.test.ts
+++ b/api/tests/adminMeLiveSessions.route.test.ts
@@ -1,0 +1,165 @@
+process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgres://postgres:postgres@127.0.0.1:5432/innies_test';
+process.env.SELLER_SECRET_ENC_KEY_B64 = process.env.SELLER_SECRET_ENC_KEY_B64 || Buffer.alloc(32, 7).toString('base64');
+
+import { beforeAll, describe, expect, it } from 'vitest';
+
+type RouteModule = typeof import('../src/routes/adminMeLiveSessions.js');
+type TypesModule = typeof import('../src/services/adminLive/myLiveSessionsTypes.js');
+type MyLiveSessionsFeed = TypesModule extends { MyLiveSessionsFeed: infer T } ? T : any;
+
+type ListFeedFn = (input: { apiKeyIds: string[]; windowHours?: number }) => any | Promise<any>;
+type AnyHandler = (req: any, res: any, next: (error?: unknown) => void) => unknown;
+
+let ADMIN_ME_LIVE_SESSIONS_PATH: string;
+let buildAdminMeLiveSessionsRouter: RouteModule['buildAdminMeLiveSessionsRouter'];
+
+beforeAll(async () => {
+  const mod = await import('../src/routes/adminMeLiveSessions.js');
+  ADMIN_ME_LIVE_SESSIONS_PATH = mod.ADMIN_ME_LIVE_SESSIONS_PATH;
+  buildAdminMeLiveSessionsRouter = mod.buildAdminMeLiveSessionsRouter;
+});
+
+function extractGetHandlers(router: any, path: string): AnyHandler[] {
+  const layer = router.stack.find((entry: any) => entry.route?.path === path);
+  if (!layer) throw new Error(`route not found: ${path}`);
+  return layer.route.stack.map((s: any) => s.handle);
+}
+
+function createMockRes() {
+  const headers: Record<string, string> = {};
+  const state: { statusCode: number; body: unknown } = { statusCode: 200, body: undefined };
+  const res: any = {
+    get statusCode() { return state.statusCode; },
+    get body() { return state.body; },
+    get headers() { return headers; },
+    setHeader(name: string, value: string) { headers[name] = value; },
+    status(code: number) { state.statusCode = code; return res; },
+    json(payload: unknown) { state.body = payload; }
+  };
+  return res;
+}
+
+function createLiveSessionsFake(handler: ListFeedFn) {
+  const calls: Array<{ apiKeyIds: string[]; windowHours?: number }> = [];
+  const service = {
+    async listFeed(input: { apiKeyIds: string[]; windowHours?: number }) {
+      calls.push({ apiKeyIds: input.apiKeyIds, windowHours: input.windowHours });
+      return handler(input);
+    }
+  };
+  return { service, calls };
+}
+
+function emptyFeed(overrides: Partial<any> = {}): any {
+  return {
+    generatedAt: '2026-04-19T00:00:00.000Z',
+    windowHours: 24,
+    pollIntervalSeconds: 5,
+    apiKeyIds: [],
+    sessions: [],
+    ...overrides
+  };
+}
+
+function getHandler(service: { listFeed: ListFeedFn }): AnyHandler {
+  const router = buildAdminMeLiveSessionsRouter({ liveSessions: service as any });
+  const handlers = extractGetHandlers(router, ADMIN_ME_LIVE_SESSIONS_PATH);
+  return handlers[handlers.length - 1];
+}
+
+describe('GET /v1/admin/me/live-sessions', () => {
+  const validUuid1 = 'f3f97490-540f-4d13-ba1b-2ad1adff1ff1';
+  const validUuid2 = '9f700001-1111-4111-8111-111111111111';
+
+  it('returns the feed from the service on happy path', async () => {
+    const feed = emptyFeed({
+      apiKeyIds: [validUuid1],
+      sessions: [
+        {
+          sessionKey: 'sess_hello',
+          apiKeyId: validUuid1,
+          startedAt: '2026-04-19T00:00:00.000Z',
+          lastActivityAt: '2026-04-19T00:05:00.000Z',
+          turnCount: 1,
+          providerSet: ['openai'],
+          modelSet: ['gpt-5.4'],
+          turns: []
+        }
+      ]
+    });
+    const { service, calls } = createLiveSessionsFake(() => feed);
+    const handler = getHandler(service);
+
+    const req = { query: { api_key_ids: validUuid1 } };
+    const res = createMockRes();
+    await handler(req, res, (err) => { if (err) throw err; });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(feed);
+    expect(res.headers['Cache-Control']).toBe('no-store');
+    expect(calls).toEqual([{ apiKeyIds: [validUuid1], windowHours: undefined }]);
+  });
+
+  it('parses comma-separated api_key_ids and deduplicates', async () => {
+    const { service, calls } = createLiveSessionsFake(() => emptyFeed());
+    const handler = getHandler(service);
+
+    const req = { query: { api_key_ids: `${validUuid1}, ${validUuid2}, ${validUuid1}` } };
+    const res = createMockRes();
+    await handler(req, res, () => {});
+
+    expect(calls[0].apiKeyIds).toEqual([validUuid1, validUuid2]);
+  });
+
+  it('forwards window_hours to the service as a number', async () => {
+    const { service, calls } = createLiveSessionsFake(() => emptyFeed());
+    const handler = getHandler(service);
+
+    const req = { query: { api_key_ids: validUuid1, window_hours: '6' } };
+    const res = createMockRes();
+    await handler(req, res, () => {});
+
+    expect(calls[0].windowHours).toBe(6);
+  });
+
+  it('returns 400 when api_key_ids is missing', async () => {
+    const { service } = createLiveSessionsFake(() => emptyFeed());
+    const handler = getHandler(service);
+
+    const req = { query: {} };
+    const res = createMockRes();
+    await handler(req, res, () => {});
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual(expect.objectContaining({ code: 'invalid_query' }));
+  });
+
+  it('returns 400 when api_key_ids contains a non-uuid entry', async () => {
+    const { service } = createLiveSessionsFake(() => emptyFeed());
+    const handler = getHandler(service);
+
+    const req = { query: { api_key_ids: `${validUuid1},not-a-uuid` } };
+    const res = createMockRes();
+    await handler(req, res, () => {});
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        code: 'invalid_query',
+        message: expect.stringContaining('not-a-uuid')
+      })
+    );
+  });
+
+  it('returns 400 when window_hours is not a number', async () => {
+    const { service } = createLiveSessionsFake(() => emptyFeed());
+    const handler = getHandler(service);
+
+    const req = { query: { api_key_ids: validUuid1, window_hours: 'abc' } };
+    const res = createMockRes();
+    await handler(req, res, () => {});
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual(expect.objectContaining({ code: 'invalid_query' }));
+  });
+});

--- a/api/tests/myLiveSessionsService.test.ts
+++ b/api/tests/myLiveSessionsService.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, it } from 'vitest';
+import { MyLiveSessionsService } from '../src/services/adminLive/myLiveSessionsService.js';
+import type { SqlClient, SqlQueryResult, SqlValue, TransactionContext } from '../src/repos/sqlClient.js';
+
+type QueryHandler = (sql: string, params: SqlValue[]) => SqlQueryResult;
+
+class MultiQueryClient implements SqlClient {
+  readonly queries: Array<{ sql: string; params: SqlValue[] }> = [];
+
+  constructor(private readonly handler: QueryHandler) {}
+
+  async query<T = Record<string, unknown>>(sql: string, params: SqlValue[] = []): Promise<SqlQueryResult<T>> {
+    this.queries.push({ sql, params });
+    return this.handler(sql, params) as SqlQueryResult<T>;
+  }
+
+  async transaction<T>(run: (tx: TransactionContext) => Promise<T>): Promise<T> {
+    return run(this);
+  }
+}
+
+function makeArchiveRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const base = {
+    id: 'archive_base',
+    request_id: 'req_base',
+    attempt_no: 1,
+    api_key_id: 'key_mine',
+    openclaw_session_id: 'sess_one',
+    provider: 'openai',
+    model: 'gpt-5.4',
+    streaming: true,
+    status: 'success',
+    upstream_status: 200,
+    started_at: new Date('2026-04-19T00:00:00Z'),
+    completed_at: new Date('2026-04-19T00:00:05Z')
+  };
+  return { ...base, ...overrides };
+}
+
+function makeMessageRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const base = {
+    request_attempt_archive_id: 'archive_base',
+    side: 'request',
+    ordinal: 0,
+    role: 'user',
+    content_type: 'text',
+    normalized_payload: { role: 'user', content: [{ type: 'text', text: 'hello' }] }
+  };
+  return { ...base, ...overrides };
+}
+
+describe('MyLiveSessionsService.listFeed', () => {
+  it('returns empty feed when apiKeyIds is empty', async () => {
+    const db = new MultiQueryClient(() => ({ rows: [], rowCount: 0 }));
+    const svc = new MyLiveSessionsService({ sql: db });
+
+    const feed = await svc.listFeed({
+      apiKeyIds: [],
+      now: new Date('2026-04-19T01:00:00Z')
+    });
+
+    expect(feed.sessions).toEqual([]);
+    expect(feed.apiKeyIds).toEqual([]);
+    expect(feed.windowHours).toBe(24);
+    expect(db.queries).toHaveLength(0);
+  });
+
+  it('filters archives by api_key_ids and window', async () => {
+    const db = new MultiQueryClient((sql) => {
+      if (sql.includes('from in_request_attempt_archives')) {
+        return { rows: [], rowCount: 0 };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+    const svc = new MyLiveSessionsService({ sql: db });
+
+    await svc.listFeed({
+      apiKeyIds: ['key-uuid-1', 'key-uuid-2'],
+      now: new Date('2026-04-19T01:00:00Z'),
+      windowHours: 6
+    });
+
+    expect(db.queries[0].sql).toContain('from in_request_attempt_archives');
+    expect(db.queries[0].sql).toContain('api_key_id = any($1::uuid[])');
+    expect(db.queries[0].sql).toContain('started_at >= $2::timestamptz');
+    const cutoff = db.queries[0].params[1] as Date;
+    expect(cutoff.toISOString()).toBe('2026-04-18T19:00:00.000Z');
+    expect(db.queries[0].params[0]).toEqual(['key-uuid-1', 'key-uuid-2']);
+  });
+
+  it('clamps windowHours to 7 days max', async () => {
+    const db = new MultiQueryClient(() => ({ rows: [], rowCount: 0 }));
+    const svc = new MyLiveSessionsService({ sql: db });
+
+    const feed = await svc.listFeed({
+      apiKeyIds: ['key'],
+      now: new Date('2026-04-19T00:00:00Z'),
+      windowHours: 999
+    });
+
+    expect(feed.windowHours).toBe(168);
+  });
+
+  it('clamps negative / zero windowHours to default', async () => {
+    const db = new MultiQueryClient(() => ({ rows: [], rowCount: 0 }));
+    const svc = new MyLiveSessionsService({ sql: db });
+
+    const feed = await svc.listFeed({
+      apiKeyIds: ['key'],
+      now: new Date('2026-04-19T00:00:00Z'),
+      windowHours: -5
+    });
+
+    expect(feed.windowHours).toBe(24);
+  });
+
+  it('groups archives by openclaw_session_id and orders turns by started_at', async () => {
+    const archives = [
+      makeArchiveRow({
+        id: 'archive_a1',
+        request_id: 'req_a1',
+        attempt_no: 1,
+        openclaw_session_id: 'sess_A',
+        started_at: new Date('2026-04-19T00:00:10Z'),
+        completed_at: new Date('2026-04-19T00:00:11Z')
+      }),
+      makeArchiveRow({
+        id: 'archive_a2',
+        request_id: 'req_a2',
+        attempt_no: 1,
+        openclaw_session_id: 'sess_A',
+        started_at: new Date('2026-04-19T00:00:20Z'),
+        completed_at: new Date('2026-04-19T00:00:21Z')
+      }),
+      makeArchiveRow({
+        id: 'archive_b1',
+        request_id: 'req_b1',
+        attempt_no: 1,
+        openclaw_session_id: 'sess_B',
+        started_at: new Date('2026-04-19T00:00:30Z'),
+        completed_at: new Date('2026-04-19T00:00:31Z')
+      })
+    ];
+    const messages = [
+      makeMessageRow({
+        request_attempt_archive_id: 'archive_a1',
+        side: 'request',
+        ordinal: 0,
+        normalized_payload: { role: 'user', content: [{ type: 'text', text: 'turn1 req' }] }
+      }),
+      makeMessageRow({
+        request_attempt_archive_id: 'archive_a1',
+        side: 'response',
+        ordinal: 0,
+        role: 'assistant',
+        normalized_payload: { role: 'assistant', content: [{ type: 'text', text: 'turn1 resp' }] }
+      }),
+      makeMessageRow({
+        request_attempt_archive_id: 'archive_a2',
+        side: 'request',
+        ordinal: 0,
+        normalized_payload: { role: 'user', content: [{ type: 'text', text: 'turn2 req' }] }
+      }),
+      makeMessageRow({
+        request_attempt_archive_id: 'archive_b1',
+        side: 'request',
+        ordinal: 0,
+        normalized_payload: { role: 'user', content: [{ type: 'text', text: 'solo req' }] }
+      })
+    ];
+
+    const db = new MultiQueryClient((sql) => {
+      if (sql.includes('from in_request_attempt_archives')) {
+        return { rows: archives, rowCount: archives.length };
+      }
+      if (sql.includes('from in_request_attempt_messages')) {
+        return { rows: messages, rowCount: messages.length };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+    const svc = new MyLiveSessionsService({ sql: db });
+
+    const feed = await svc.listFeed({
+      apiKeyIds: ['key_mine'],
+      now: new Date('2026-04-19T01:00:00Z')
+    });
+
+    expect(feed.sessions).toHaveLength(2);
+
+    const sessionB = feed.sessions[0]; // sorted by lastActivityAt desc
+    expect(sessionB.sessionKey).toBe('sess_B');
+    expect(sessionB.turnCount).toBe(1);
+    expect(sessionB.turns[0].archiveId).toBe('archive_b1');
+
+    const sessionA = feed.sessions[1];
+    expect(sessionA.sessionKey).toBe('sess_A');
+    expect(sessionA.turnCount).toBe(2);
+    // turns ordered by startedAt ascending within a session
+    expect(sessionA.turns[0].archiveId).toBe('archive_a1');
+    expect(sessionA.turns[1].archiveId).toBe('archive_a2');
+    expect(sessionA.turns[0].messages).toHaveLength(2);
+    expect(sessionA.turns[0].messages[0].side).toBe('request');
+    expect(sessionA.turns[0].messages[1].side).toBe('response');
+  });
+
+  it('synthesizes a per-archive fallback session when openclaw_session_id is null', async () => {
+    const archives = [
+      makeArchiveRow({
+        id: 'archive_null1',
+        openclaw_session_id: null,
+        started_at: new Date('2026-04-19T00:10:00Z'),
+        completed_at: new Date('2026-04-19T00:10:05Z')
+      }),
+      makeArchiveRow({
+        id: 'archive_null2',
+        openclaw_session_id: null,
+        started_at: new Date('2026-04-19T00:11:00Z'),
+        completed_at: new Date('2026-04-19T00:11:05Z')
+      })
+    ];
+    const db = new MultiQueryClient((sql) => {
+      if (sql.includes('from in_request_attempt_archives')) {
+        return { rows: archives, rowCount: archives.length };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+    const svc = new MyLiveSessionsService({ sql: db });
+
+    const feed = await svc.listFeed({
+      apiKeyIds: ['key_mine'],
+      now: new Date('2026-04-19T01:00:00Z')
+    });
+
+    expect(feed.sessions).toHaveLength(2);
+    expect(feed.sessions[0].sessionKey).toBe('archive:archive_null2');
+    expect(feed.sessions[1].sessionKey).toBe('archive:archive_null1');
+  });
+
+  it('computes provider/model sets per session', async () => {
+    const archives = [
+      makeArchiveRow({ id: 'a1', openclaw_session_id: 'sess_mix', provider: 'openai', model: 'gpt-5.4' }),
+      makeArchiveRow({ id: 'a2', openclaw_session_id: 'sess_mix', provider: 'anthropic', model: 'claude-opus-4-6' }),
+      makeArchiveRow({ id: 'a3', openclaw_session_id: 'sess_mix', provider: 'openai', model: 'gpt-5.4-mini' })
+    ];
+    const db = new MultiQueryClient((sql) => {
+      if (sql.includes('from in_request_attempt_archives')) {
+        return { rows: archives, rowCount: archives.length };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+    const svc = new MyLiveSessionsService({ sql: db });
+
+    const feed = await svc.listFeed({ apiKeyIds: ['key_mine'] });
+
+    expect(feed.sessions[0].providerSet.sort()).toEqual(['anthropic', 'openai']);
+    expect(feed.sessions[0].modelSet.sort()).toEqual(['claude-opus-4-6', 'gpt-5.4', 'gpt-5.4-mini']);
+  });
+
+  it('does not load messages when no archives match', async () => {
+    const db = new MultiQueryClient(() => ({ rows: [], rowCount: 0 }));
+    const svc = new MyLiveSessionsService({ sql: db });
+
+    await svc.listFeed({ apiKeyIds: ['key_none'] });
+
+    // only the archive query should have run; messages query skipped
+    expect(db.queries).toHaveLength(1);
+    expect(db.queries[0].sql).toContain('from in_request_attempt_archives');
+  });
+});


### PR DESCRIPTION
## Summary

- New endpoint `GET /v1/admin/me/live-sessions` returning live-session feed for specific api_key_ids over a configurable window.
- Admin-api-key auth via standard `requireApiKey(['admin'])`.
- Supabase DB is NOT exposed to the browser. UI talks to innies, innies talks to DB — auth + filtering enforced server-side.
- 14 new tests (8 service + 6 route).

## Contract

```
GET /v1/admin/me/live-sessions
  headers: x-api-key: <admin-scope>
  query:
    api_key_ids: csv of UUIDs (required, at least one)
    window_hours: positive integer, default 24, max 168
  response 200:
    {
      generatedAt, windowHours, pollIntervalSeconds: 5, apiKeyIds,
      sessions: [
        {
          sessionKey, apiKeyId, startedAt, lastActivityAt,
          turnCount, providerSet, modelSet,
          turns: [
            { archiveId, requestId, attemptNo, provider, model,
              streaming, status, upstreamStatus, startedAt, completedAt,
              messages: [ { side, ordinal, role, contentType, normalizedPayload } ] }
          ]
        }
      ]
    }
```

Sessions are grouped by `openclaw_session_id`; rows where that column is null fall back to `sessionKey = "archive:<archive_id>"` so legacy pre-CLI-bridge traffic still renders sanely (one panel per orphaned turn).

## Why server-side

We previously enabled Supabase Realtime publication (PR #193, migration 033) so browsers could subscribe directly. That works but exposes DB schema to the browser and requires trusting the `api_key_id=eq.<...>` filter on the client. Routing through innies fixes both.

Realtime publication stays in place — it's additive and could still be useful for internal tools. UI will polling `/v1/admin/me/live-sessions` every ~5s initially; SSE upgrade is a follow-up if latency becomes a concern.

## Test plan

- [x] `cd api && npm test -- --run tests/myLiveSessionsService.test.ts` — 8/8 pass
- [x] `cd api && npm test -- --run tests/adminMeLiveSessions.route.test.ts` — 6/6 pass
- [x] Full suite: 921/941 pass; 20 failures are pre-existing ECONNREFUSED integration tests
- [ ] After merge: deploy to exe.dev, smoke test with `curl -H "x-api-key: <admin>" https://innies-api.exe.xyz/v1/admin/me/live-sessions?api_key_ids=<buyer-uuid>`
- [ ] Rebuild innies-work UI against the new endpoint (follow-up branch/PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)