### PR TITLE
feat(api): host shared-notes backend on innies-api for SSE + cross-tab sync

### DIFF
--- a/api/src/routes/v2Notes.ts
+++ b/api/src/routes/v2Notes.ts
@@ -1,0 +1,162 @@
+import { Router } from 'express';
+import type express from 'express';
+import { getSharedNotesRepository } from '../services/v2Notes/sharedNotesRuntime.js';
+import type { SharedNotesRepository } from '../services/v2Notes/sharedNotesRepository.js';
+
+const MAX_NOTES_LENGTH = 50_000;
+const HEARTBEAT_INTERVAL_MS = 15_000;
+const FALLBACK_ORIGINS = [
+  'https://innies.work',
+  'https://www.innies.work',
+  'http://localhost:3000'
+];
+
+type V2NotesRouterDeps = {
+  repository?: Pick<SharedNotesRepository, 'getDocument' | 'saveDocument' | 'listen'>;
+  env?: NodeJS.ProcessEnv;
+};
+
+function readAllowedOrigins(env: NodeJS.ProcessEnv | undefined): Set<string> {
+  const configured = (env?.V2_NOTES_ALLOWED_ORIGINS ?? '')
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+  return new Set(configured.length > 0 ? configured : FALLBACK_ORIGINS);
+}
+
+function appendVary(res: express.Response, value: string): void {
+  const existing = String(res.getHeader('Vary') ?? '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  if (!existing.includes(value)) existing.push(value);
+  res.setHeader('Vary', existing.join(', '));
+}
+
+function applyCors(req: express.Request, res: express.Response, env: NodeJS.ProcessEnv | undefined, methods: string): void {
+  const origin = req.header('origin');
+  const allowed = readAllowedOrigins(env);
+  if (origin && allowed.has(origin)) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+  }
+  res.setHeader('Access-Control-Allow-Methods', methods);
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  appendVary(res, 'Origin');
+}
+
+export function buildV2NotesRouter(deps: V2NotesRouterDeps = {}): Router {
+  const router = Router();
+  const env = deps.env ?? process.env;
+  const getRepo = (): Pick<SharedNotesRepository, 'getDocument' | 'saveDocument' | 'listen'> =>
+    deps.repository ?? getSharedNotesRepository();
+
+  router.options('/v2/notes', (req, res) => {
+    applyCors(req, res, env, 'GET, PUT, OPTIONS');
+    res.status(204).end();
+  });
+
+  router.options('/v2/notes/stream', (req, res) => {
+    applyCors(req, res, env, 'GET, OPTIONS');
+    res.status(204).end();
+  });
+
+  router.get('/v2/notes', async (req, res, next) => {
+    applyCors(req, res, env, 'GET, PUT, OPTIONS');
+    try {
+      const document = await getRepo().getDocument();
+      res.setHeader('Cache-Control', 'no-store');
+      res.json(document);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.put('/v2/notes', async (req, res, next) => {
+    applyCors(req, res, env, 'GET, PUT, OPTIONS');
+    try {
+      const payload = req.body as { content?: unknown; baseRevision?: unknown } | undefined;
+      const content = payload?.content;
+      const baseRevisionRaw = payload?.baseRevision;
+
+      if (typeof content !== 'string') {
+        res.status(400).json({ error: '`content` must be a string' });
+        return;
+      }
+
+      if (content.length > MAX_NOTES_LENGTH) {
+        res.status(400).json({ error: 'Shared notes content is too large' });
+        return;
+      }
+
+      let baseRevision: number | null = null;
+      if (baseRevisionRaw !== undefined && baseRevisionRaw !== null) {
+        if (typeof baseRevisionRaw !== 'number' || Number.isNaN(baseRevisionRaw)) {
+          res.status(400).json({ error: '`baseRevision` must be a number when provided' });
+          return;
+        }
+        baseRevision = baseRevisionRaw;
+      }
+
+      const document = await getRepo().saveDocument(content, baseRevision);
+      res.setHeader('Cache-Control', 'no-store');
+      res.json(document);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get('/v2/notes/stream', async (req, res, next) => {
+    applyCors(req, res, env, 'GET, OPTIONS');
+    try {
+      res.setHeader('Content-Type', 'text/event-stream; charset=utf-8');
+      res.setHeader('Cache-Control', 'no-cache, no-transform');
+      res.setHeader('Connection', 'keep-alive');
+      res.flushHeaders?.();
+
+      const repo = getRepo();
+      let closed = false;
+
+      const push = (event: string, payload: unknown) => {
+        if (closed || res.writableEnded) return;
+        res.write(`event: ${event}\ndata: ${JSON.stringify(payload)}\n\n`);
+      };
+
+      const initial = await repo.getDocument();
+      push('notes', initial);
+
+      const heartbeat = setInterval(() => {
+        if (closed || res.writableEnded) return;
+        res.write(': keepalive\n\n');
+      }, HEARTBEAT_INTERVAL_MS);
+
+      const disposeListener = await repo.listen(async (document) => {
+        push('notes', document);
+      });
+
+      const shutdown = async () => {
+        if (closed) return;
+        closed = true;
+        clearInterval(heartbeat);
+        try {
+          await disposeListener();
+        } catch {}
+        try {
+          res.end();
+        } catch {}
+      };
+
+      req.on('close', () => {
+        void shutdown();
+      });
+      req.on('aborted', () => {
+        void shutdown();
+      });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  return router;
+}
+
+export default buildV2NotesRouter();

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -17,6 +17,7 @@ import pilotRoutes from './routes/pilot.js';
 import proxyRoutes from './routes/proxy.js';
 import sellerKeysRoutes from './routes/sellerKeys.js';
 import usageRoutes from './routes/usage.js';
+import v2NotesRoutes from './routes/v2Notes.js';
 import { startBackgroundJobs } from './services/runtime.js';
 import {
   captureCompatRawBody,
@@ -162,6 +163,7 @@ export function createApp(): express.Express {
   app.use(pilotRoutes);
   app.use(sellerKeysRoutes);
   app.use(usageRoutes);
+  app.use(v2NotesRoutes);
   app.use(proxyRoutes);
 
   app.use((err: unknown, _req: express.Request, res: express.Response, _next: express.NextFunction) => {

--- a/api/src/services/v2Notes/sharedNotesRepository.ts
+++ b/api/src/services/v2Notes/sharedNotesRepository.ts
@@ -1,0 +1,143 @@
+import type { Notification, Pool, Client } from 'pg';
+
+const SHARED_NOTES_DOCUMENT_ID = 'v2:notes.md';
+const SHARED_NOTES_CHANNEL = 'v2_shared_notes_updates';
+
+type SharedNotesRow = {
+  id: string;
+  content: string;
+  revision: number | string;
+  updatedAt: string | Date;
+};
+
+export type SharedNotesDocument = {
+  id: string;
+  content: string;
+  revision: number;
+  updatedAt: string;
+};
+
+export type SharedNotesRepositoryDeps = {
+  /** Pool used for read/write queries. Can be transaction-pooled. */
+  pool: Pool;
+  /** Factory for a dedicated session-mode client used for LISTEN. Must support LISTEN. */
+  createListenerClient: () => Promise<Client>;
+};
+
+function mapSharedNotesRow(row: SharedNotesRow): SharedNotesDocument {
+  return {
+    id: row.id,
+    content: row.content,
+    revision: Number(row.revision),
+    updatedAt: new Date(row.updatedAt).toISOString()
+  };
+}
+
+export class SharedNotesRepository {
+  constructor(private readonly deps: SharedNotesRepositoryDeps) {}
+
+  async getDocument(): Promise<SharedNotesDocument> {
+    await this.ensureDocument();
+
+    const result = await this.deps.pool.query<SharedNotesRow>(
+      `select
+          id,
+          content,
+          revision,
+          updated_at as "updatedAt"
+        from shared_documents
+        where id = $1
+        limit 1`,
+      [SHARED_NOTES_DOCUMENT_ID]
+    );
+
+    if (result.rowCount !== 1) {
+      throw new Error('Shared notes document not found');
+    }
+
+    return mapSharedNotesRow(result.rows[0]);
+  }
+
+  async saveDocument(content: string, baseRevision: number | null): Promise<SharedNotesDocument> {
+    const client = await this.deps.pool.connect();
+    try {
+      await client.query('begin');
+
+      const result = await client.query<SharedNotesRow>(
+        `insert into shared_documents (id, content, revision)
+         values ($1, $2, 1)
+         on conflict (id) do update
+           set content = excluded.content,
+               revision = shared_documents.revision + 1,
+               updated_at = now()
+         returning
+           id,
+           content,
+           revision,
+           updated_at as "updatedAt"`,
+        [SHARED_NOTES_DOCUMENT_ID, content]
+      );
+
+      const document = mapSharedNotesRow(result.rows[0]);
+
+      await client.query('select pg_notify($1, $2)', [
+        SHARED_NOTES_CHANNEL,
+        JSON.stringify({
+          id: SHARED_NOTES_DOCUMENT_ID,
+          revision: document.revision,
+          baseRevision
+        })
+      ]);
+
+      await client.query('commit');
+      return document;
+    } catch (error) {
+      await client.query('rollback');
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Opens a dedicated session-mode pg client and subscribes to
+   * `v2_shared_notes_updates`. Each notification triggers a fresh doc read,
+   * which is then pushed to the caller. Returns a disposer.
+   */
+  async listen(onUpdate: (document: SharedNotesDocument) => Promise<void> | void): Promise<() => Promise<void>> {
+    const client = await this.deps.createListenerClient();
+
+    const handleNotification = async (notification: Notification) => {
+      if (notification.channel !== SHARED_NOTES_CHANNEL) {
+        return;
+      }
+      const document = await this.getDocument();
+      await onUpdate(document);
+    };
+
+    client.on('notification', handleNotification);
+    await client.query(`LISTEN ${SHARED_NOTES_CHANNEL}`);
+
+    let disposed = false;
+    return async () => {
+      if (disposed) return;
+      disposed = true;
+      client.off('notification', handleNotification);
+      try {
+        await client.query(`UNLISTEN ${SHARED_NOTES_CHANNEL}`);
+      } catch {}
+      try {
+        await client.end();
+      } catch {}
+    };
+  }
+
+  private async ensureDocument(): Promise<void> {
+    await this.deps.pool.query(
+      `insert into shared_documents (id, content, revision)
+        values ($1, '', 0)
+        on conflict (id) do nothing`,
+      [SHARED_NOTES_DOCUMENT_ID]
+    );
+  }
+}

--- a/api/src/services/v2Notes/sharedNotesRuntime.ts
+++ b/api/src/services/v2Notes/sharedNotesRuntime.ts
@@ -1,0 +1,54 @@
+import { Client, Pool } from 'pg';
+import { SharedNotesRepository } from './sharedNotesRepository.js';
+
+let cachedRepo: SharedNotesRepository | null = null;
+
+function readDatabaseUrl(): string {
+  const value = process.env.DATABASE_URL;
+  if (!value || value.trim().length === 0) {
+    throw new Error('DATABASE_URL is required for shared notes');
+  }
+  return value;
+}
+
+function readListenerDatabaseUrl(): string {
+  // LISTEN requires a session-mode pg connection; Supabase's transaction
+  // pooler (:6543) re-allocates sessions per statement and does not keep
+  // LISTEN subscriptions alive. Use the session pooler (:5432) via a
+  // dedicated env var so the runtime DATABASE_URL can stay on the
+  // transaction pooler for regular writes.
+  const value = process.env.NOTES_LISTEN_DATABASE_URL?.trim();
+  if (value && value.length > 0) {
+    return value;
+  }
+
+  // Fallback: if only DATABASE_URL is provided AND it points at a Supabase
+  // supavisor host, swap :6543 → :5432 to reach the session pooler. This
+  // is a convenience for single-URL deployments; prefer explicit
+  // NOTES_LISTEN_DATABASE_URL in prod.
+  const fallback = readDatabaseUrl();
+  if (fallback.includes(':6543/')) {
+    return fallback.replace(':6543/', ':5432/');
+  }
+  return fallback;
+}
+
+export function getSharedNotesRepository(): SharedNotesRepository {
+  if (cachedRepo) return cachedRepo;
+
+  const pool = new Pool({
+    connectionString: readDatabaseUrl(),
+    max: 5
+  });
+
+  const createListenerClient = async (): Promise<Client> => {
+    const client = new Client({
+      connectionString: readListenerDatabaseUrl()
+    });
+    await client.connect();
+    return client;
+  };
+
+  cachedRepo = new SharedNotesRepository({ pool, createListenerClient });
+  return cachedRepo;
+}

--- a/api/tests/sharedNotesRepository.test.ts
+++ b/api/tests/sharedNotesRepository.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from 'vitest';
+import { SharedNotesRepository } from '../src/services/v2Notes/sharedNotesRepository.js';
+
+type PoolStub = {
+  query: ReturnType<typeof vi.fn>;
+  connect: ReturnType<typeof vi.fn>;
+};
+
+type ClientStub = {
+  query: ReturnType<typeof vi.fn>;
+  release: ReturnType<typeof vi.fn>;
+};
+
+function makePool(responses: Array<{ rows: unknown[]; rowCount?: number }>): { pool: PoolStub; client: ClientStub } {
+  let responseIdx = 0;
+  const clientQuery = vi.fn(async () => {
+    const next = responses[responseIdx++] ?? { rows: [], rowCount: 0 };
+    return next;
+  });
+  const client: ClientStub = {
+    query: clientQuery,
+    release: vi.fn()
+  };
+  const pool: PoolStub = {
+    query: vi.fn(async () => {
+      const next = responses[responseIdx++] ?? { rows: [], rowCount: 0 };
+      return next;
+    }),
+    connect: vi.fn(async () => client)
+  };
+  return { pool, client };
+}
+
+describe('SharedNotesRepository', () => {
+  it('getDocument upserts an empty document and selects it back', async () => {
+    const { pool } = makePool([
+      // ensureDocument insert
+      { rows: [], rowCount: 0 },
+      // select
+      {
+        rows: [{ id: 'v2:notes.md', content: 'hello', revision: 3, updatedAt: '2026-04-19T00:00:00Z' }],
+        rowCount: 1
+      }
+    ]);
+    const repo = new SharedNotesRepository({
+      pool: pool as any,
+      createListenerClient: async () => ({} as any)
+    });
+
+    const doc = await repo.getDocument();
+
+    expect(doc).toEqual({
+      id: 'v2:notes.md',
+      content: 'hello',
+      revision: 3,
+      updatedAt: '2026-04-19T00:00:00.000Z'
+    });
+    expect(pool.query).toHaveBeenCalledTimes(2);
+    expect((pool.query as any).mock.calls[0][0]).toContain('insert into shared_documents');
+    expect((pool.query as any).mock.calls[1][0]).toContain('select');
+  });
+
+  it('saveDocument inserts/updates and fires pg_notify inside a tx', async () => {
+    const { pool, client } = makePool([]);
+    // Set up specific responses on the connected client (pool.connect → client)
+    const responses = [
+      { rows: [] }, // begin
+      {
+        rows: [{ id: 'v2:notes.md', content: 'new', revision: 4, updatedAt: '2026-04-19T00:00:00Z' }],
+        rowCount: 1
+      },
+      { rows: [] }, // pg_notify
+      { rows: [] } // commit
+    ];
+    let idx = 0;
+    client.query.mockImplementation(async () => responses[idx++] ?? { rows: [] });
+
+    const repo = new SharedNotesRepository({
+      pool: pool as any,
+      createListenerClient: async () => ({} as any)
+    });
+    const doc = await repo.saveDocument('new', 3);
+
+    expect(doc.content).toBe('new');
+    expect(doc.revision).toBe(4);
+    const sqls = client.query.mock.calls.map((args: any[]) => String(args[0]));
+    expect(sqls[0]).toBe('begin');
+    expect(sqls[1]).toContain('insert into shared_documents');
+    expect(sqls[2]).toContain('pg_notify');
+    expect(sqls[3]).toBe('commit');
+    expect(client.release).toHaveBeenCalledOnce();
+  });
+
+  it('saveDocument rolls back on pg error', async () => {
+    const { pool, client } = makePool([]);
+    const responses: Array<{ rows: unknown[] } | Error> = [
+      { rows: [] }, // begin
+      new Error('boom'), // insert fails
+      { rows: [] } // rollback
+    ];
+    let idx = 0;
+    client.query.mockImplementation(async () => {
+      const next = responses[idx++];
+      if (next instanceof Error) throw next;
+      return next ?? { rows: [] };
+    });
+
+    const repo = new SharedNotesRepository({
+      pool: pool as any,
+      createListenerClient: async () => ({} as any)
+    });
+
+    await expect(repo.saveDocument('x', null)).rejects.toThrow('boom');
+    const sqls = client.query.mock.calls.map((args: any[]) => String(args[0]));
+    expect(sqls[0]).toBe('begin');
+    expect(sqls[sqls.length - 1]).toBe('rollback');
+    expect(client.release).toHaveBeenCalledOnce();
+  });
+
+  it('listen subscribes to the v2_shared_notes_updates channel and returns a disposer', async () => {
+    const { pool } = makePool([]);
+    const listenerQuery = vi.fn(async () => ({ rows: [] }));
+    const listenerOn = vi.fn();
+    const listenerOff = vi.fn();
+    const listenerEnd = vi.fn(async () => {});
+    const listenerClient = {
+      query: listenerQuery,
+      on: listenerOn,
+      off: listenerOff,
+      end: listenerEnd
+    };
+
+    const repo = new SharedNotesRepository({
+      pool: pool as any,
+      createListenerClient: async () => listenerClient as any
+    });
+
+    const updates: any[] = [];
+    const dispose = await repo.listen((doc) => updates.push(doc));
+
+    expect(listenerOn).toHaveBeenCalledWith('notification', expect.any(Function));
+    expect(listenerQuery).toHaveBeenCalledWith('LISTEN v2_shared_notes_updates');
+
+    await dispose();
+
+    expect(listenerOff).toHaveBeenCalled();
+    expect(listenerQuery).toHaveBeenCalledWith('UNLISTEN v2_shared_notes_updates');
+    expect(listenerEnd).toHaveBeenCalledOnce();
+
+    // second dispose is a no-op
+    await dispose();
+    expect(listenerEnd).toHaveBeenCalledOnce();
+  });
+});

--- a/api/tests/v2Notes.route.test.ts
+++ b/api/tests/v2Notes.route.test.ts
@@ -1,0 +1,142 @@
+process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgres://postgres:postgres@127.0.0.1:5432/innies_test';
+process.env.SELLER_SECRET_ENC_KEY_B64 = process.env.SELLER_SECRET_ENC_KEY_B64 || Buffer.alloc(32, 7).toString('base64');
+
+import { beforeAll, describe, expect, it } from 'vitest';
+
+type RouteModule = typeof import('../src/routes/v2Notes.js');
+let buildV2NotesRouter: RouteModule['buildV2NotesRouter'];
+
+beforeAll(async () => {
+  const mod = await import('../src/routes/v2Notes.js');
+  buildV2NotesRouter = mod.buildV2NotesRouter;
+});
+
+type AnyHandler = (req: any, res: any, next: (error?: unknown) => void) => unknown;
+
+function extractHandlers(router: any, path: string, method: 'get' | 'put' | 'options'): AnyHandler[] {
+  const layer = router.stack.find((entry: any) => entry.route?.path === path && entry.route?.methods?.[method]);
+  if (!layer) throw new Error(`route not found: ${method.toUpperCase()} ${path}`);
+  return layer.route.stack.map((s: any) => s.handle);
+}
+
+function createMockRes() {
+  const headers: Record<string, string> = {};
+  const state: { statusCode: number; body: unknown; ended: boolean } = {
+    statusCode: 200,
+    body: undefined,
+    ended: false
+  };
+  const res: any = {
+    get statusCode() { return state.statusCode; },
+    get body() { return state.body; },
+    get headers() { return headers; },
+    get writableEnded() { return state.ended; },
+    setHeader(name: string, value: string) { headers[name] = value; },
+    getHeader(name: string) { return headers[name]; },
+    status(code: number) { state.statusCode = code; return res; },
+    json(payload: unknown) { state.body = payload; state.ended = true; },
+    end() { state.ended = true; },
+    flushHeaders() {}
+  };
+  return res;
+}
+
+function fakeRepo(overrides: { document?: any; save?: any } = {}) {
+  const calls: Array<{ method: string; args: any[] }> = [];
+  return {
+    calls,
+    async getDocument() {
+      calls.push({ method: 'getDocument', args: [] });
+      return overrides.document ?? { id: 'v2:notes.md', content: '', revision: 0, updatedAt: '2026-04-19T00:00:00Z' };
+    },
+    async saveDocument(content: string, baseRevision: number | null) {
+      calls.push({ method: 'saveDocument', args: [content, baseRevision] });
+      return overrides.save ?? { id: 'v2:notes.md', content, revision: (baseRevision ?? 0) + 1, updatedAt: '2026-04-19T00:00:01Z' };
+    },
+    async listen() {
+      return async () => {};
+    }
+  };
+}
+
+describe('v2Notes router', () => {
+  it('GET /v2/notes returns the current document with no-store cache', async () => {
+    const repo = fakeRepo();
+    const router = buildV2NotesRouter({ repository: repo as any });
+    const [handler] = extractHandlers(router, '/v2/notes', 'get');
+
+    const req: any = { header: () => undefined, body: undefined };
+    const res = createMockRes();
+    await handler(req, res, () => {});
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(expect.objectContaining({ id: 'v2:notes.md' }));
+    expect(res.headers['Cache-Control']).toBe('no-store');
+    expect(repo.calls).toEqual([{ method: 'getDocument', args: [] }]);
+  });
+
+  it('PUT /v2/notes rejects non-string content with 400', async () => {
+    const repo = fakeRepo();
+    const router = buildV2NotesRouter({ repository: repo as any });
+    const [handler] = extractHandlers(router, '/v2/notes', 'put');
+
+    const req: any = { header: () => undefined, body: { content: 123 } };
+    const res = createMockRes();
+    await handler(req, res, () => {});
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: '`content` must be a string' });
+  });
+
+  it('PUT /v2/notes rejects oversize content with 400', async () => {
+    const repo = fakeRepo();
+    const router = buildV2NotesRouter({ repository: repo as any });
+    const [handler] = extractHandlers(router, '/v2/notes', 'put');
+
+    const req: any = { header: () => undefined, body: { content: 'x'.repeat(50_001) } };
+    const res = createMockRes();
+    await handler(req, res, () => {});
+
+    expect(res.statusCode).toBe(400);
+    expect(String((res.body as any).error)).toContain('too large');
+  });
+
+  it('PUT /v2/notes saves and returns the new revision', async () => {
+    const repo = fakeRepo();
+    const router = buildV2NotesRouter({ repository: repo as any });
+    const [handler] = extractHandlers(router, '/v2/notes', 'put');
+
+    const req: any = { header: () => undefined, body: { content: 'hello', baseRevision: 3 } };
+    const res = createMockRes();
+    await handler(req, res, () => {});
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(expect.objectContaining({ content: 'hello', revision: 4 }));
+    expect(repo.calls).toEqual([{ method: 'saveDocument', args: ['hello', 3] }]);
+  });
+
+  it('OPTIONS preflight echoes allowed origin + methods', async () => {
+    const router = buildV2NotesRouter({ env: { V2_NOTES_ALLOWED_ORIGINS: 'https://innies.work,https://www.innies.work' } as any });
+    const [handler] = extractHandlers(router, '/v2/notes', 'options');
+
+    const req: any = { header: (name: string) => (name.toLowerCase() === 'origin' ? 'https://innies.work' : undefined) };
+    const res = createMockRes();
+    await handler(req, res, () => {});
+
+    expect(res.statusCode).toBe(204);
+    expect(res.headers['Access-Control-Allow-Origin']).toBe('https://innies.work');
+    expect(res.headers['Access-Control-Allow-Methods']).toContain('PUT');
+  });
+
+  it('OPTIONS preflight does not set Allow-Origin for untrusted origin', async () => {
+    const router = buildV2NotesRouter({ env: { V2_NOTES_ALLOWED_ORIGINS: 'https://innies.work' } as any });
+    const [handler] = extractHandlers(router, '/v2/notes', 'options');
+
+    const req: any = { header: (name: string) => (name.toLowerCase() === 'origin' ? 'https://evil.example' : undefined) };
+    const res = createMockRes();
+    await handler(req, res, () => {});
+
+    expect(res.statusCode).toBe(204);
+    expect(res.headers['Access-Control-Allow-Origin']).toBeUndefined();
+  });
+});

--- a/docs/migrations/034_shared_documents.sql
+++ b/docs/migrations/034_shared_documents.sql
@@ -1,0 +1,29 @@
+BEGIN;
+
+-- Shared notes substrate for the innies-work /v2 leave-a-note.md tab.
+-- Backed by a single row per document id (MVP: one `v2:notes.md` document).
+-- The app issues pg_notify on `v2_shared_notes_updates` after each save, and
+-- SSE clients LISTEN on that channel to push live updates across open tabs.
+
+CREATE TABLE IF NOT EXISTS shared_documents (
+  id          text PRIMARY KEY,
+  content     text NOT NULL DEFAULT '',
+  revision    bigint NOT NULL DEFAULT 0,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  updated_at  timestamptz NOT NULL DEFAULT now()
+);
+
+-- Seed the primary v2 notes document so the first GET request succeeds
+-- without forcing a write-first bootstrap.
+INSERT INTO shared_documents (id, content, revision)
+VALUES ('v2:notes.md', '', 0)
+ON CONFLICT (id) DO NOTHING;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'niyant') THEN
+    GRANT ALL PRIVILEGES ON TABLE shared_documents TO niyant;
+  END IF;
+END $$;
+
+COMMIT;

--- a/docs/migrations/034_shared_documents_no_extensions.sql
+++ b/docs/migrations/034_shared_documents_no_extensions.sql
@@ -1,0 +1,29 @@
+BEGIN;
+
+-- Shared notes substrate for the innies-work /v2 leave-a-note.md tab.
+-- Backed by a single row per document id (MVP: one `v2:notes.md` document).
+-- The app issues pg_notify on `v2_shared_notes_updates` after each save, and
+-- SSE clients LISTEN on that channel to push live updates across open tabs.
+
+CREATE TABLE IF NOT EXISTS shared_documents (
+  id          text PRIMARY KEY,
+  content     text NOT NULL DEFAULT '',
+  revision    bigint NOT NULL DEFAULT 0,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  updated_at  timestamptz NOT NULL DEFAULT now()
+);
+
+-- Seed the primary v2 notes document so the first GET request succeeds
+-- without forcing a write-first bootstrap.
+INSERT INTO shared_documents (id, content, revision)
+VALUES ('v2:notes.md', '', 0)
+ON CONFLICT (id) DO NOTHING;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'niyant') THEN
+    GRANT ALL PRIVILEGES ON TABLE shared_documents TO niyant;
+  END IF;
+END $$;
+
+COMMIT;


### PR DESCRIPTION
Moves the /v2/notes + /v2/notes/stream endpoints off Vercel onto innies-api. Vercel serverless kills SSE connections; the long-running node on exe.dev keeps them open. Follow-up PR on innies-work will remove its Next.js /api/v2/notes routes and repoint the UI at `https://innies-api.exe.xyz/v2/notes`.