### PR TITLE
Enable Claude Opus 4.7

### DIFF
--- a/docs/migrations/035_anthropic_model_claude_opus_4_7.sql
+++ b/docs/migrations/035_anthropic_model_claude_opus_4_7.sql
@@ -1,0 +1,40 @@
+-- Enable Anthropic Claude Opus 4.7 (model id `claude-opus-4-7`, GA 2026-04-16).
+-- Follows the same shape as 029_openai_model_gpt_5_4_mini.sql — guarded INSERT
+-- that no-ops if an active rule for this (provider, model) already exists.
+-- Streaming + tools: same as opus 4.6.
+-- max_input_tokens / max_output_tokens: left null, matching the rest of the
+-- anthropic + openai rows (the model's own 1M context / 128k output caps are
+-- enforced upstream; nothing in this table gates them).
+
+insert into in_model_compatibility_rules (
+  id,
+  provider,
+  model,
+  supports_streaming,
+  supports_tools,
+  max_input_tokens,
+  max_output_tokens,
+  is_enabled,
+  effective_from
+)
+select
+  '10570001-0000-4000-8000-000000000000'::uuid,
+  'anthropic',
+  'claude-opus-4-7',
+  true,
+  true,
+  null,
+  null,
+  true,
+  now()
+where not exists (
+  select 1
+  from in_model_compatibility_rules
+  where provider = 'anthropic'
+    and model = 'claude-opus-4-7'
+    and is_enabled = true
+    and effective_from <= now()
+    and (effective_to is null or effective_to > now())
+);
+
+-- No niyant grant changes: seeds compatibility data only.

--- a/docs/migrations/035_anthropic_model_claude_opus_4_7_no_extensions.sql
+++ b/docs/migrations/035_anthropic_model_claude_opus_4_7_no_extensions.sql
@@ -1,0 +1,40 @@
+-- Enable Anthropic Claude Opus 4.7 (model id `claude-opus-4-7`, GA 2026-04-16).
+-- Follows the same shape as 029_openai_model_gpt_5_4_mini.sql — guarded INSERT
+-- that no-ops if an active rule for this (provider, model) already exists.
+-- Streaming + tools: same as opus 4.6.
+-- max_input_tokens / max_output_tokens: left null, matching the rest of the
+-- anthropic + openai rows (the model's own 1M context / 128k output caps are
+-- enforced upstream; nothing in this table gates them).
+
+insert into in_model_compatibility_rules (
+  id,
+  provider,
+  model,
+  supports_streaming,
+  supports_tools,
+  max_input_tokens,
+  max_output_tokens,
+  is_enabled,
+  effective_from
+)
+select
+  '10570001-0000-4000-8000-000000000000'::uuid,
+  'anthropic',
+  'claude-opus-4-7',
+  true,
+  true,
+  null,
+  null,
+  true,
+  now()
+where not exists (
+  select 1
+  from in_model_compatibility_rules
+  where provider = 'anthropic'
+    and model = 'claude-opus-4-7'
+    and is_enabled = true
+    and effective_from <= now()
+    and (effective_to is null or effective_to > now())
+);
+
+-- No niyant grant changes: seeds compatibility data only.


### PR DESCRIPTION
## Summary
- Adds `claude-opus-4-7` (Anthropic's flagship model, GA 2026-04-16) to `in_model_compatibility_rules`
- Streaming + tools enabled; `max_input_tokens`/`max_output_tokens` left null (matches the existing anthropic + openai rows — the model's own 1M context / 128k output caps are enforced upstream)
- Migration follows `029_openai_model_gpt_5_4_mini.sql` — a guarded INSERT that no-ops if an active rule already exists

Already applied directly to prod supabase. This commit just persists the migration alongside the rest of the model enablement history.

## Test plan
- [x] Migration syntactically valid (copied from existing 029 pattern)
- [x] Applied to prod supabase (`select ... where model = 'claude-opus-4-7'` returns 1 enabled row)
- [ ] Fire a `claude-opus-4-7` request through the proxy and confirm it routes instead of rejecting

## Sources for model identifier
- [Introducing Claude Opus 4.7 — Anthropic](https://www.anthropic.com/news/claude-opus-4-7)
- [What's new in Claude Opus 4.7 — Claude API Docs](https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7)