### PR TITLE
CLI: default anthropic model to claude-opus-4-7 + bump 0.1.13

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "innies",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "type": "module",
   "description": "CLI wrappers for routing Claude and Codex through the Innies proxy.",
   "repository": {

--- a/cli/src/modelSelection.js
+++ b/cli/src/modelSelection.js
@@ -1,5 +1,5 @@
 const DEFAULT_MODELS = Object.freeze({
-  anthropic: 'claude-opus-4-6',
+  anthropic: 'claude-opus-4-7',
   openai: 'gpt-5.4'
 });
 

--- a/cli/tests/config.test.js
+++ b/cli/tests/config.test.js
@@ -29,12 +29,12 @@ test('sentinel config falls back to provider defaults for both lanes', async () 
   const configModule = await importConfigModuleForHome(home);
   const config = await configModule.loadConfig(true);
 
-  assert.equal(config.defaultModel, 'claude-opus-4-6');
+  assert.equal(config.defaultModel, 'claude-opus-4-7');
   assert.deepEqual(config.providerDefaults, {
-    anthropic: 'claude-opus-4-6',
+    anthropic: 'claude-opus-4-7',
     openai: 'gpt-5.4'
   });
-  assert.equal(configModule.resolveProviderDefaultModel(config, 'anthropic'), 'claude-opus-4-6');
+  assert.equal(configModule.resolveProviderDefaultModel(config, 'anthropic'), 'claude-opus-4-7');
   assert.equal(configModule.resolveProviderDefaultModel(config, 'openai'), 'gpt-5.4');
 });
 
@@ -59,9 +59,9 @@ test('saveConfig with unknown model preserves fallback but leaves provider defau
 
   assert.equal(saved.defaultModel, 'future-model-x');
   assert.deepEqual(saved.providerDefaults, {
-    anthropic: 'claude-opus-4-6',
+    anthropic: 'claude-opus-4-7',
     openai: 'gpt-5.4'
   });
-  assert.equal(configModule.resolveProviderDefaultModel(saved, 'anthropic'), 'claude-opus-4-6');
+  assert.equal(configModule.resolveProviderDefaultModel(saved, 'anthropic'), 'claude-opus-4-7');
   assert.equal(configModule.resolveProviderDefaultModel(saved, 'openai'), 'gpt-5.4');
 });

--- a/cli/tests/modelSelection.test.js
+++ b/cli/tests/modelSelection.test.js
@@ -27,7 +27,7 @@ test('applies anthropic model hints without rewriting openai defaults', () => {
 
 test('applies openai model hints without rewriting anthropic defaults', () => {
   assert.deepEqual(providerDefaultsFromModelHint('gpt-5.5'), {
-    anthropic: 'claude-opus-4-6',
+    anthropic: 'claude-opus-4-7',
     openai: 'gpt-5.5'
   });
 });


### PR DESCRIPTION
## Summary
- Bumps the CLI's hardcoded anthropic default from `claude-opus-4-6` → `claude-opus-4-7`
- `innies claude` (no `--model` flag, no local override) now routes to 4.7 out of the box
- `gpt-5.4` openai default unchanged
- CLI version 0.1.12 → 0.1.13 so `npm install -g innies@latest` picks it up

Pairs with #199 which added `claude-opus-4-7` to the proxy's `in_model_compatibility_rules`.

## Test plan
- [x] `node --test tests/*.test.js` → 36/36 pass
- [ ] `npm publish` + `innies claude` resolves to `claude-opus-4-7` by default