### PR TITLE
CLI: auto-migrate stale provider defaults on load + bump 0.1.14

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "innies",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "type": "module",
   "description": "CLI wrappers for routing Claude and Codex through the Innies proxy.",
   "repository": {

--- a/cli/src/config.js
+++ b/cli/src/config.js
@@ -7,6 +7,8 @@ import {
   defaultOpenAiModel,
   defaultProviderModels as defaultProviderModelsBase,
   inferModelProvider,
+  isStaleProviderDefault,
+  migrateStaleProviderDefaults,
   normalizeLegacyFallbackModel,
   normalizeModel,
   normalizeProviderDefaults,
@@ -55,7 +57,11 @@ export async function loadConfig(required = true) {
       fail(`Invalid config at ${PRIMARY_CONFIG_PATH}. Run: innies login --token <in_token>`);
     }
 
-    return config;
+    // Auto-upgrade provider defaults that were previously hardcoded in an
+    // older CLI version (e.g. `claude-opus-4-6` → `claude-opus-4-7`).
+    // Rewrites the config to disk so the migration only happens once.
+    const migrated = await migrateConfigIfStale(config);
+    return migrated;
   } catch (error) {
     if (!required) {
       return null;
@@ -64,6 +70,45 @@ export async function loadConfig(required = true) {
     const message = error instanceof Error ? error.message : String(error);
     fail(`Missing or unreadable config (${PRIMARY_CONFIG_PATH}): ${message}`);
   }
+}
+
+/**
+ * Walk a loaded config, upgrade any provider defaults that match a known
+ * previously-hardcoded value to the current default, and persist the
+ * result. `defaultModel` is upgraded in lock-step with `providerDefaults.anthropic`
+ * so the two stay coherent. Returns the (possibly-migrated) config.
+ */
+async function migrateConfigIfStale(config) {
+  const { providerDefaults: nextProviderDefaults, migrated: providerMigrated } =
+    migrateStaleProviderDefaults(config.providerDefaults);
+
+  const defaultModelIsStale = isStaleProviderDefault('anthropic', config.defaultModel);
+  const nextDefaultModel = defaultModelIsStale
+    ? nextProviderDefaults.anthropic
+    : config.defaultModel;
+
+  if (!providerMigrated && !defaultModelIsStale) {
+    return config;
+  }
+
+  const nextConfig = {
+    ...config,
+    defaultModel: nextDefaultModel,
+    providerDefaults: nextProviderDefaults,
+    updatedAt: new Date().toISOString()
+  };
+
+  try {
+    const file = configPath();
+    await mkdir(dirname(file), { recursive: true });
+    await writeFile(file, `${JSON.stringify(nextConfig, null, 2)}\n`, { mode: 0o600 });
+  } catch {
+    // Non-fatal: even if we couldn't persist the migration, returning the
+    // upgraded config lets this session use the new defaults. Next load
+    // will retry the rewrite.
+  }
+
+  return nextConfig;
 }
 
 export async function saveConfig(token, apiBaseUrl, defaultModel) {

--- a/cli/src/modelSelection.js
+++ b/cli/src/modelSelection.js
@@ -6,6 +6,19 @@ const DEFAULT_MODELS = Object.freeze({
 const LEGACY_DEFAULT_MODEL = DEFAULT_MODELS.anthropic;
 const LEGACY_DEFAULT_MODEL_SENTINELS = new Set(['innies/default']);
 
+// Provider-default values that were previously hardcoded in older CLI
+// versions. When `loadConfig` encounters one of these, it's assumed to
+// have been auto-saved by `innies login` against an older release rather
+// than an explicit user pick — so we transparently upgrade it to the
+// current default (DEFAULT_MODELS[provider]). This lets `npm install -g
+// innies@latest` actually surface new defaults to existing users.
+const STALE_PROVIDER_DEFAULTS = Object.freeze({
+  anthropic: new Set([
+    'claude-opus-4-6'
+  ]),
+  openai: new Set([])
+});
+
 export function defaultProviderModels() {
   return { ...DEFAULT_MODELS };
 }
@@ -83,4 +96,36 @@ export function normalizeProviderDefaults(raw, fallbackModel) {
     anthropic: normalizeLegacyFallbackModel(providerDefaults.anthropic) ?? defaults.anthropic,
     openai: normalizeLegacyFallbackModel(providerDefaults.openai) ?? defaults.openai
   };
+}
+
+/**
+ * Return true when `value` matches a previously-hardcoded provider
+ * default that older CLI versions auto-saved into the config. Used by
+ * loadConfig to distinguish "was auto-saved by older CLI" from "user
+ * explicitly picked this model".
+ */
+export function isStaleProviderDefault(provider, value) {
+  const normalized = normalizeModel(value);
+  if (!normalized) return false;
+  const staleSet = STALE_PROVIDER_DEFAULTS[provider];
+  return staleSet ? staleSet.has(normalized) : false;
+}
+
+/**
+ * Upgrade a providerDefaults map by replacing stale entries with the
+ * current hardcoded defaults. Returns `{ providerDefaults, migrated }`
+ * where `migrated` is true if anything changed.
+ */
+export function migrateStaleProviderDefaults(providerDefaults) {
+  const next = { ...providerDefaults };
+  let migrated = false;
+
+  for (const provider of Object.keys(DEFAULT_MODELS)) {
+    if (isStaleProviderDefault(provider, next[provider])) {
+      next[provider] = DEFAULT_MODELS[provider];
+      migrated = true;
+    }
+  }
+
+  return { providerDefaults: next, migrated };
 }

--- a/cli/tests/config.test.js
+++ b/cli/tests/config.test.js
@@ -65,3 +65,67 @@ test('saveConfig with unknown model preserves fallback but leaves provider defau
   assert.equal(configModule.resolveProviderDefaultModel(saved, 'anthropic'), 'claude-opus-4-7');
   assert.equal(configModule.resolveProviderDefaultModel(saved, 'openai'), 'gpt-5.4');
 });
+
+test('loadConfig auto-upgrades stale anthropic default from a previous CLI version', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'innies-cli-config-'));
+  await mkdir(join(home, '.innies'), { recursive: true });
+  const configFile = join(home, '.innies', 'config.json');
+
+  // Simulate a config saved by 0.1.12 (when claude-opus-4-6 was the
+  // hardcoded anthropic default).
+  await writeFile(configFile, JSON.stringify({
+    version: 1,
+    token: 'in_live_migrated',
+    apiBaseUrl: 'https://innies-api.exe.xyz',
+    defaultModel: 'claude-opus-4-6',
+    providerDefaults: {
+      anthropic: 'claude-opus-4-6',
+      openai: 'gpt-5.4'
+    },
+    updatedAt: '2026-04-18T00:00:00.000Z'
+  }));
+
+  const configModule = await importConfigModuleForHome(home);
+  const config = await configModule.loadConfig(true);
+
+  // In-memory config reflects the new default immediately.
+  assert.equal(config.defaultModel, 'claude-opus-4-7');
+  assert.deepEqual(config.providerDefaults, {
+    anthropic: 'claude-opus-4-7',
+    openai: 'gpt-5.4'
+  });
+
+  // Config file on disk is rewritten so subsequent loads don't need
+  // to re-run the migration.
+  const { readFile } = await import('node:fs/promises');
+  const persisted = JSON.parse(await readFile(configFile, 'utf8'));
+  assert.equal(persisted.defaultModel, 'claude-opus-4-7');
+  assert.equal(persisted.providerDefaults.anthropic, 'claude-opus-4-7');
+  assert.notEqual(persisted.updatedAt, '2026-04-18T00:00:00.000Z');
+});
+
+test('loadConfig leaves an explicit non-stale anthropic default alone', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'innies-cli-config-'));
+  await mkdir(join(home, '.innies'), { recursive: true });
+
+  // User explicitly chose sonnet (not in the stale set) — we must not
+  // silently rewrite this to opus.
+  await writeFile(join(home, '.innies', 'config.json'), JSON.stringify({
+    version: 1,
+    token: 'in_live_explicit',
+    apiBaseUrl: 'https://innies-api.exe.xyz',
+    defaultModel: 'claude-sonnet-4-6',
+    providerDefaults: {
+      anthropic: 'claude-sonnet-4-6',
+      openai: 'gpt-5.4'
+    },
+    updatedAt: '2026-04-18T00:00:00.000Z'
+  }));
+
+  const configModule = await importConfigModuleForHome(home);
+  const config = await configModule.loadConfig(true);
+
+  assert.equal(config.defaultModel, 'claude-sonnet-4-6');
+  assert.equal(config.providerDefaults.anthropic, 'claude-sonnet-4-6');
+  assert.equal(config.updatedAt, '2026-04-18T00:00:00.000Z');
+});


### PR DESCRIPTION
## Summary
- Fixes the issue where users who ran `innies login` on an older CLI stay pinned to the old default model (e.g. `claude-opus-4-6`) even after `npm install -g innies@latest`, because `~/.innies/config.json` still has the old value in `providerDefaults.anthropic`
- Introduces a `STALE_PROVIDER_DEFAULTS` set in `modelSelection.js` listing previously-hardcoded defaults
- On `loadConfig`, any saved value matching an entry in that set is silently upgraded to the current `DEFAULT_MODELS[provider]` and the config file is rewritten so the migration runs once per user
- User-explicit picks (models not in the stale set) are preserved untouched

## Test plan
- [x] `node --test tests/*.test.js` → 38/38 pass (2 new migration tests)
  - stale `claude-opus-4-6` → `claude-opus-4-7` upgrade + file rewrite
  - explicit `claude-sonnet-4-6` left alone
- [ ] `npm publish` + existing users running `innies claude` resolve to 4.7 without manually editing the config