### PR TITLE
Sanitize secrets from /v1/admin/me/live-sessions

### DIFF
--- a/api/src/services/adminLive/myLiveSessionsService.ts
+++ b/api/src/services/adminLive/myLiveSessionsService.ts
@@ -1,5 +1,6 @@
 import { TABLES } from '../../repos/tableNames.js';
 import type { SqlValue } from '../../repos/sqlClient.js';
+import { sanitizePublicDeep } from '../publicInnies/publicTextSanitizer.js';
 import {
   MY_LIVE_SESSIONS_DEFAULT_WINDOW_HOURS,
   MY_LIVE_SESSIONS_MAX_SESSIONS,
@@ -200,7 +201,14 @@ export class MyLiveSessionsService {
         ordinal: row.ordinal,
         role: row.role,
         contentType: row.content_type,
-        normalizedPayload: row.normalized_payload ?? {}
+        // The /v1/admin/me/live-sessions response is relayed to the
+        // innies.work `watch-me-work.md` tab via a server-side proxy
+        // route (`INNIES_ADMIN_API_KEY` is injected on the Next.js
+        // side, so the browser-facing endpoint needs no auth). That
+        // makes this payload publicly readable for anyone who hits
+        // innies.work — so we scrub the same secret/credential/PII
+        // patterns as the public landing feed before returning.
+        normalizedPayload: sanitizePublicDeep(row.normalized_payload ?? {})
       }));
 
     return {

--- a/api/src/services/publicInnies/publicTextSanitizer.ts
+++ b/api/src/services/publicInnies/publicTextSanitizer.ts
@@ -120,3 +120,39 @@ export function stringifyPublicToolPayload(input: unknown): string {
 
   return capText(sanitizePublicText(stringified));
 }
+
+/**
+ * Walk an arbitrary JSON-shaped value and return a deep copy where every
+ * string has been passed through `sanitizePublicText`. Arrays and plain
+ * objects are reconstructed; non-string scalars pass through unchanged.
+ *
+ * Use this when you need to scrub a normalized payload (e.g. the admin
+ * `/v1/admin/me/live-sessions` endpoint) that contains user/assistant
+ * content before handing it to a client that might leak to the public
+ * internet (e.g. innies.work rendering via a server-side proxy route).
+ */
+export function sanitizePublicDeep<T>(value: T, seen: WeakSet<object> = new WeakSet()): T {
+  if (typeof value === 'string') {
+    return sanitizePublicText(value) as unknown as T;
+  }
+
+  if (value == null || typeof value !== 'object') {
+    return value;
+  }
+
+  if (seen.has(value as object)) {
+    return value;
+  }
+  seen.add(value as object);
+
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizePublicDeep(item, seen)) as unknown as T;
+  }
+
+  const source = value as Record<string, unknown>;
+  const next: Record<string, unknown> = {};
+  for (const key of Object.keys(source)) {
+    next[key] = sanitizePublicDeep(source[key], seen);
+  }
+  return next as unknown as T;
+}

--- a/api/tests/myLiveSessionsService.test.ts
+++ b/api/tests/myLiveSessionsService.test.ts
@@ -256,6 +256,59 @@ describe('MyLiveSessionsService.listFeed', () => {
     expect(feed.sessions[0].modelSet.sort()).toEqual(['claude-opus-4-6', 'gpt-5.4', 'gpt-5.4-mini']);
   });
 
+  it('sanitizes secrets/paths/emails from normalizedPayload before returning', async () => {
+    const archives = [
+      makeArchiveRow({
+        id: 'archive_secretful',
+        openclaw_session_id: 'sess_scrub'
+      })
+    ];
+    const messages = [
+      makeMessageRow({
+        request_attempt_archive_id: 'archive_secretful',
+        side: 'request',
+        ordinal: 0,
+        normalized_payload: {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: [
+                'my key is sk-proj-abc123XYZ_tokenhere',
+                'also bearer eyJhbGciOiJIUzI1NiJ.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U',
+                'file at /Users/dylan/.ssh/id_ed25519',
+                'email me at dylan@innies.work'
+              ].join('\n')
+            }
+          ]
+        }
+      })
+    ];
+    const db = new MultiQueryClient((sql) => {
+      if (sql.includes('from in_request_attempt_archives')) {
+        return { rows: archives, rowCount: archives.length };
+      }
+      if (sql.includes('from in_request_attempt_messages')) {
+        return { rows: messages, rowCount: messages.length };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+    const svc = new MyLiveSessionsService({ sql: db });
+
+    const feed = await svc.listFeed({ apiKeyIds: ['key_mine'] });
+
+    const text = (feed.sessions[0].turns[0].messages[0].normalizedPayload.content as Array<Record<string, unknown>>)[0]
+      .text as string;
+    // Anything the public sanitizer redacts must also be scrubbed here.
+    expect(text).not.toContain('sk-proj-abc123XYZ_tokenhere');
+    expect(text).not.toContain('eyJhbGciOiJIUzI1NiJ');
+    expect(text).not.toContain('/Users/dylan/.ssh/id_ed25519');
+    expect(text).not.toContain('dylan@innies.work');
+    expect(text).toContain('[REDACTED_TOKEN]');
+    expect(text).toContain('[REDACTED_PATH]');
+    expect(text).toContain('[REDACTED_EMAIL]');
+  });
+
   it('does not load messages when no archives match', async () => {
     const db = new MultiQueryClient(() => ({ rows: [], rowCount: 0 }));
     const svc = new MyLiveSessionsService({ sql: db });


### PR DESCRIPTION
## Summary
- The /v1/admin/me/live-sessions endpoint (which feeds innies.work's watch-me-work.md tab) was returning raw \`normalized_payload\` content. Since the Vercel proxy route injects \`INNIES_ADMIN_API_KEY\` server-side, \`https://innies.work/api/innies/live-sessions\` serves this data to any anonymous visitor.
- Every secret, token, file path, or email I've pasted into an \`innies claude\` / \`innies codex\` prompt has been leaking publicly.

## Fix
- Add \`sanitizePublicDeep()\` to \`publicTextSanitizer.ts\` — walks any JSON-shaped value and applies \`sanitizePublicText\` to every string.
- Apply it to \`normalizedPayload\` in \`MyLiveSessionsService.buildTurn\`. Same redaction ruleset the public landing feed already uses:
  - auth headers (\`authorization\`, \`x-api-key\`, \`bearer ...\`)
  - prefixed tokens (\`sk-\`, \`ghp_\`, \`xoxb-\`, \`pat_\`, \`tok_\`, etc.)
  - JWTs
  - emails
  - unix + windows file paths

## Test plan
- [x] 9/9 tests pass in \`tests/myLiveSessionsService.test.ts\` including a new assertion that secrets/paths/emails in \`normalized_payload.content[].text\` come back as \`[REDACTED_*]\`
- [ ] Deploy to exe.dev, \`curl https://innies.work/api/innies/live-sessions\` and confirm redactions