### PR TITLE
feat(api): strip anthropic thinking blocks from live sessions feed

### DIFF
--- a/api/src/services/adminLive/myLiveSessionsService.ts
+++ b/api/src/services/adminLive/myLiveSessionsService.ts
@@ -58,6 +58,29 @@ function sessionKeyForArchive(row: ArchiveRow): string {
   return row.openclaw_session_id ? row.openclaw_session_id : `archive:${row.id}`;
 }
 
+// Anthropic responses include `{type: "thinking"|"redacted_thinking", ...}`
+// blocks that the archive normalizer preserves as `{type: "json", value: <block>}`.
+// They carry opaque encrypted signatures meant for provider round-tripping, are
+// huge on the wire, and render as noisy JSON blobs in the public watch-me-work
+// tab. Strip them from the content array before serializing.
+function stripThinkingParts(payload: Record<string, unknown>): Record<string, unknown> {
+  const content = payload.content;
+  if (!Array.isArray(content)) return payload;
+
+  const filtered = content.filter((part) => {
+    if (!part || typeof part !== 'object') return true;
+    const record = part as Record<string, unknown>;
+    if (record.type !== 'json') return true;
+    const inner = record.value;
+    if (!inner || typeof inner !== 'object') return true;
+    const innerRecord = inner as Record<string, unknown>;
+    return innerRecord.type !== 'thinking' && innerRecord.type !== 'redacted_thinking';
+  });
+
+  if (filtered.length === content.length) return payload;
+  return { ...payload, content: filtered };
+}
+
 export class MyLiveSessionsService {
   constructor(private readonly deps: MyLiveSessionsServiceDeps) {}
 
@@ -208,7 +231,7 @@ export class MyLiveSessionsService {
         // makes this payload publicly readable for anyone who hits
         // innies.work — so we scrub the same secret/credential/PII
         // patterns as the public landing feed before returning.
-        normalizedPayload: sanitizePublicDeep(row.normalized_payload ?? {})
+        normalizedPayload: stripThinkingParts(sanitizePublicDeep(row.normalized_payload ?? {}))
       }));
 
     return {

--- a/api/tests/myLiveSessionsService.test.ts
+++ b/api/tests/myLiveSessionsService.test.ts
@@ -309,6 +309,38 @@ describe('MyLiveSessionsService.listFeed', () => {
     expect(text).toContain('[REDACTED_EMAIL]');
   });
 
+  it('strips anthropic thinking blocks from normalizedPayload content', async () => {
+    const archives = [makeArchiveRow({ id: 'archive_thinky', openclaw_session_id: 'sess_thinky' })];
+    const messages = [
+      makeMessageRow({
+        request_attempt_archive_id: 'archive_thinky',
+        side: 'response',
+        ordinal: 0,
+        role: 'assistant',
+        normalized_payload: {
+          role: 'assistant',
+          content: [
+            { type: 'json', value: { type: 'thinking', thinking: '', signature: 'ErQEClk...' } },
+            { type: 'json', value: { type: 'redacted_thinking', data: 'opaque' } },
+            { type: 'text', text: 'hello world' }
+          ]
+        }
+      })
+    ];
+    const db = new MultiQueryClient((sql) => {
+      if (sql.includes('from in_request_attempt_archives')) return { rows: archives, rowCount: archives.length };
+      if (sql.includes('from in_request_attempt_messages')) return { rows: messages, rowCount: messages.length };
+      return { rows: [], rowCount: 0 };
+    });
+    const svc = new MyLiveSessionsService({ sql: db });
+
+    const feed = await svc.listFeed({ apiKeyIds: ['key_mine'] });
+
+    const parts = feed.sessions[0].turns[0].messages[0].normalizedPayload.content as Array<Record<string, unknown>>;
+    expect(parts).toHaveLength(1);
+    expect(parts[0]).toEqual({ type: 'text', text: 'hello world' });
+  });
+
   it('does not load messages when no archives match', async () => {
     const db = new MultiQueryClient(() => ({ rows: [], rowCount: 0 }));
     const svc = new MyLiveSessionsService({ sql: db });


### PR DESCRIPTION
## Summary
- Filter `{type: 'thinking'}` and `{type: 'redacted_thinking'}` blocks out of `normalizedPayload.content` in the admin `/v1/admin/me/live-sessions` response.
- These reasoning blocks were rendering as raw JSON blobs in the shirtless.life "watch-me-work" panel: `{"type":"thinking","thinking":"","signature":"ErQE..."}`.

## Why
The watch-me-work panel surfaces session turns verbatim to the user; thinking blocks are noise (and can be large). Strip them server-side so every client gets the cleaned feed, with a belt+suspenders client-side filter in innies-work as a fallback.

## Test plan
- [x] `pnpm test -- myLiveSessionsService` — 10/10 pass, including new "strips anthropic thinking blocks from normalizedPayload content" test
- [ ] After merge + deploy, watch-me-work panel on shirtless.life/v2 shows no thinking JSON blobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)