### PR TITLE
fix(api): aggressively cap live-sessions payload size

### DIFF
--- a/api/src/services/adminLive/myLiveSessionsTypes.ts
+++ b/api/src/services/adminLive/myLiveSessionsTypes.ts
@@ -3,8 +3,12 @@ import type { SqlClient } from '../../repos/sqlClient.js';
 export const MY_LIVE_SESSIONS_DEFAULT_WINDOW_HOURS = 24;
 export const MY_LIVE_SESSIONS_MAX_WINDOW_HOURS = 7 * 24; // hard cap one week
 export const MY_LIVE_SESSIONS_POLL_INTERVAL_SECONDS = 5;
-export const MY_LIVE_SESSIONS_MAX_SESSIONS = 60;
-export const MY_LIVE_SESSIONS_MAX_TURNS_PER_SESSION = 200;
+// Tight caps so the response stays well under Vercel's ~40s function timeout.
+// With Claude coding sessions a single turn's normalizedPayload can run 100KB-1MB
+// (tool_use results, file contents, etc.), and the shirtless.life watch-me-work
+// panel only needs recent context per session — not the full history.
+export const MY_LIVE_SESSIONS_MAX_SESSIONS = 20;
+export const MY_LIVE_SESSIONS_MAX_TURNS_PER_SESSION = 20;
 
 export type MyLiveSessionTurnMessage = {
   side: 'request' | 'response';


### PR DESCRIPTION
## Summary
- Drop `MY_LIVE_SESSIONS_MAX_SESSIONS` 60 → 20
- Drop `MY_LIVE_SESSIONS_MAX_TURNS_PER_SESSION` 200 → 20

## Why
Verified the admin live-sessions endpoint was returning **319 MB** for the shirtless api key on a 12h window — Claude coding turns carry 100KB–1MB of tool_use/tool_result content each. 60×200 = 12,000 turn slots was absurdly generous for a "watch-me-work" timeline. Vercel's function timeout (~40s) couldn't stream that through, so the shirtless.life proxy route was 500ing.

20×20 = 400 turn slots puts us comfortably under 25MB, well within Vercel's budget.

## Test plan
- [x] `pnpm test -- myLiveSessionsService` 10/10 pass
- [ ] After deploy, `curl https://shirtless.life/api/innies/live-sessions` returns 200 in <2s
- [ ] /v2 watch-me-work panel paints populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)