### PR TITLE
fix(api): drop tool_use/tool_result from live-sessions payload

### DIFF
--- a/api/src/services/adminLive/myLiveSessionsService.ts
+++ b/api/src/services/adminLive/myLiveSessionsService.ts
@@ -58,23 +58,38 @@ function sessionKeyForArchive(row: ArchiveRow): string {
   return row.openclaw_session_id ? row.openclaw_session_id : `archive:${row.id}`;
 }
 
-// Anthropic responses include `{type: "thinking"|"redacted_thinking", ...}`
-// blocks that the archive normalizer preserves as `{type: "json", value: <block>}`.
-// They carry opaque encrypted signatures meant for provider round-tripping, are
-// huge on the wire, and render as noisy JSON blobs in the public watch-me-work
-// tab. Strip them from the content array before serializing.
-function stripThinkingParts(payload: Record<string, unknown>): Record<string, unknown> {
+// Strip content blocks the watch-me-work panel never renders:
+//   - anthropic thinking / redacted_thinking (opaque, often huge)
+//   - tool_use / tool_result (panel hides tool activity — SessionPanel.tsx)
+// The archive normalizer either emits these at top level (`{type: "thinking"}`)
+// or wraps them (`{type: "json", value: {type: "thinking"}}`), so handle both.
+// Tool-use/result blocks are the dominant size driver — a single file-read
+// tool_result can be hundreds of KB, and we were shipping thousands of them
+// per session just for the browser to drop them on the floor.
+const HIDDEN_PART_TYPES = new Set([
+  'thinking',
+  'redacted_thinking',
+  'tool_use',
+  'tool_result'
+]);
+
+function stripHiddenParts(payload: Record<string, unknown>): Record<string, unknown> {
   const content = payload.content;
   if (!Array.isArray(content)) return payload;
 
   const filtered = content.filter((part) => {
     if (!part || typeof part !== 'object') return true;
     const record = part as Record<string, unknown>;
-    if (record.type !== 'json') return true;
-    const inner = record.value;
-    if (!inner || typeof inner !== 'object') return true;
-    const innerRecord = inner as Record<string, unknown>;
-    return innerRecord.type !== 'thinking' && innerRecord.type !== 'redacted_thinking';
+    const type = record.type;
+    if (typeof type === 'string' && HIDDEN_PART_TYPES.has(type)) return false;
+    if (type === 'json') {
+      const inner = record.value;
+      if (inner && typeof inner === 'object') {
+        const innerType = (inner as Record<string, unknown>).type;
+        if (typeof innerType === 'string' && HIDDEN_PART_TYPES.has(innerType)) return false;
+      }
+    }
+    return true;
   });
 
   if (filtered.length === content.length) return payload;
@@ -231,7 +246,7 @@ export class MyLiveSessionsService {
         // makes this payload publicly readable for anyone who hits
         // innies.work — so we scrub the same secret/credential/PII
         // patterns as the public landing feed before returning.
-        normalizedPayload: stripThinkingParts(sanitizePublicDeep(row.normalized_payload ?? {}))
+        normalizedPayload: stripHiddenParts(sanitizePublicDeep(row.normalized_payload ?? {}))
       }));
 
     return {

--- a/api/tests/myLiveSessionsService.test.ts
+++ b/api/tests/myLiveSessionsService.test.ts
@@ -309,7 +309,7 @@ describe('MyLiveSessionsService.listFeed', () => {
     expect(text).toContain('[REDACTED_EMAIL]');
   });
 
-  it('strips anthropic thinking blocks from normalizedPayload content', async () => {
+  it('strips hidden parts (thinking, tool_use, tool_result) from normalizedPayload content', async () => {
     const archives = [makeArchiveRow({ id: 'archive_thinky', openclaw_session_id: 'sess_thinky' })];
     const messages = [
       makeMessageRow({
@@ -320,8 +320,17 @@ describe('MyLiveSessionsService.listFeed', () => {
         normalized_payload: {
           role: 'assistant',
           content: [
+            // wrapped-json thinking (anthropic via normalizer)
             { type: 'json', value: { type: 'thinking', thinking: '', signature: 'ErQEClk...' } },
             { type: 'json', value: { type: 'redacted_thinking', data: 'opaque' } },
+            // top-level thinking (should also be dropped)
+            { type: 'thinking', thinking: 'reasoning', signature: 'sig' },
+            // tool activity — dominant size driver, UI hides it
+            { type: 'tool_use', id: 'call_1', name: 'read_file', input: { path: '/huge/file' } },
+            { type: 'tool_result', tool_use_id: 'call_1', content: 'x'.repeat(50000) },
+            { type: 'json', value: { type: 'tool_use', id: 'call_2', name: 'grep' } },
+            { type: 'json', value: { type: 'tool_result', content: 'y'.repeat(50000) } },
+            // kept
             { type: 'text', text: 'hello world' }
           ]
         }


### PR DESCRIPTION
## Summary
Strip `tool_use` / `tool_result` content blocks from the admin `/v1/admin/me/live-sessions` response, alongside the existing `thinking` / `redacted_thinking` filter.

## Why
The shirtless.life watch-me-work panel (`SessionPanel.tsx:102-105`) explicitly filters tool activity before render — only `text` and non-reasoning `json` parts are displayed. Yet the admin endpoint was shipping every `tool_result` blob (file reads, grep dumps, full codebase listings) across the network for the browser to throw away. On the `shirtless` api key, a 12h window shipped **26MB** post-thinking-filter — tool blobs were the dominant remaining driver.

Expected: ~3-5MB payload, ~2-3s fetch vs 13s currently.

## Test plan
- [x] `pnpm test -- myLiveSessionsService` 10/10 pass (existing test extended to cover tool_use/tool_result in both top-level and `{type: "json", value: ...}` shapes)
- [ ] After deploy, curl payload size drops from ~26MB → single-digit MB
- [ ] /v2 watch-me-work transcript rows visually unchanged (UI wasn't rendering these anyway)

🤖 Generated with [Claude Code](https://claude.com/claude-code)