### PR TITLE
fix(api): dedup cumulative messages across live-session turns

### DIFF
--- a/api/src/services/adminLive/myLiveSessionsService.ts
+++ b/api/src/services/adminLive/myLiveSessionsService.ts
@@ -166,6 +166,13 @@ export class MyLiveSessionsService {
         session.turns = session.turns.slice(-MY_LIVE_SESSIONS_MAX_TURNS_PER_SESSION);
         session.turnCount = session.turns.length;
       }
+      // Claude/Codex archive turns are cumulative: turn N's messages include
+      // every prior turn's messages re-sent as context. Shipping that verbatim
+      // is a quadratic blow-up (we measured 20 turns × ~220 messages × ~230KB
+      // ≈ 23MB per session). SessionPanel.tsx's flattenSession already strips
+      // these client-side by tracking max (side, ordinal) — mirror that here
+      // so the wire payload matches what the UI actually renders.
+      dedupCumulativeMessages(session.turns);
     }
 
     const sessions = Array.from(sessionsByKey.values())
@@ -271,4 +278,25 @@ function earlier(a: string, b: string): string {
 
 function later(a: string, b: string): string {
   return Date.parse(a) >= Date.parse(b) ? a : b;
+}
+
+function dedupCumulativeMessages(turns: MyLiveSessionTurn[]): void {
+  let priorMaxRequest = -1;
+  let priorMaxResponse = -1;
+  for (let i = 0; i < turns.length; i++) {
+    const turn = turns[i];
+    if (i > 0) {
+      turn.messages = turn.messages.filter((m) => {
+        const priorMax = m.side === 'request' ? priorMaxRequest : priorMaxResponse;
+        return m.ordinal > priorMax;
+      });
+    }
+    for (const m of turn.messages) {
+      if (m.side === 'request') {
+        if (m.ordinal > priorMaxRequest) priorMaxRequest = m.ordinal;
+      } else if (m.ordinal > priorMaxResponse) {
+        priorMaxResponse = m.ordinal;
+      }
+    }
+  }
 }

--- a/api/tests/myLiveSessionsService.test.ts
+++ b/api/tests/myLiveSessionsService.test.ts
@@ -350,6 +350,105 @@ describe('MyLiveSessionsService.listFeed', () => {
     expect(parts[0]).toEqual({ type: 'text', text: 'hello world' });
   });
 
+  it('dedupes cumulative messages across turns by (side, ordinal)', async () => {
+    // Claude/Codex sessions re-send the full history each turn. The panel
+    // only renders newly-appended (side, ordinal) pairs, so the server
+    // should drop the duplicates before shipping them.
+    const archives = [
+      makeArchiveRow({
+        id: 'archive_t1',
+        openclaw_session_id: 'sess_dedup',
+        started_at: new Date('2026-04-19T00:00:10Z'),
+        completed_at: new Date('2026-04-19T00:00:11Z')
+      }),
+      makeArchiveRow({
+        id: 'archive_t2',
+        openclaw_session_id: 'sess_dedup',
+        started_at: new Date('2026-04-19T00:00:20Z'),
+        completed_at: new Date('2026-04-19T00:00:21Z')
+      }),
+      makeArchiveRow({
+        id: 'archive_t3',
+        openclaw_session_id: 'sess_dedup',
+        started_at: new Date('2026-04-19T00:00:30Z'),
+        completed_at: new Date('2026-04-19T00:00:31Z')
+      })
+    ];
+    const messages = [
+      // turn 1: user q1, assistant a1
+      makeMessageRow({ request_attempt_archive_id: 'archive_t1', side: 'request', ordinal: 0 }),
+      makeMessageRow({
+        request_attempt_archive_id: 'archive_t1',
+        side: 'response',
+        ordinal: 0,
+        role: 'assistant'
+      }),
+      // turn 2: re-sends turn 1 history + new user q2, new assistant a2
+      makeMessageRow({ request_attempt_archive_id: 'archive_t2', side: 'request', ordinal: 0 }),
+      makeMessageRow({ request_attempt_archive_id: 'archive_t2', side: 'request', ordinal: 1 }),
+      makeMessageRow({
+        request_attempt_archive_id: 'archive_t2',
+        side: 'response',
+        ordinal: 0,
+        role: 'assistant'
+      }),
+      makeMessageRow({
+        request_attempt_archive_id: 'archive_t2',
+        side: 'response',
+        ordinal: 1,
+        role: 'assistant'
+      }),
+      // turn 3: re-sends turns 1+2 history + new user q3
+      makeMessageRow({ request_attempt_archive_id: 'archive_t3', side: 'request', ordinal: 0 }),
+      makeMessageRow({ request_attempt_archive_id: 'archive_t3', side: 'request', ordinal: 1 }),
+      makeMessageRow({ request_attempt_archive_id: 'archive_t3', side: 'request', ordinal: 2 }),
+      makeMessageRow({
+        request_attempt_archive_id: 'archive_t3',
+        side: 'response',
+        ordinal: 0,
+        role: 'assistant'
+      }),
+      makeMessageRow({
+        request_attempt_archive_id: 'archive_t3',
+        side: 'response',
+        ordinal: 1,
+        role: 'assistant'
+      })
+    ];
+    const db = new MultiQueryClient((sql) => {
+      if (sql.includes('from in_request_attempt_archives')) {
+        return { rows: archives, rowCount: archives.length };
+      }
+      if (sql.includes('from in_request_attempt_messages')) {
+        return { rows: messages, rowCount: messages.length };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+    const svc = new MyLiveSessionsService({ sql: db });
+
+    const feed = await svc.listFeed({
+      apiKeyIds: ['key_mine'],
+      now: new Date('2026-04-19T01:00:00Z')
+    });
+
+    const session = feed.sessions[0];
+    expect(session.sessionKey).toBe('sess_dedup');
+    // turn 1 keeps everything (it's the first in the slice).
+    expect(session.turns[0].messages.map((m) => [m.side, m.ordinal])).toEqual([
+      ['request', 0],
+      ['response', 0]
+    ]);
+    // turn 2 drops the duplicates (request/response ordinal 0) and keeps only the new ones.
+    expect(session.turns[1].messages.map((m) => [m.side, m.ordinal])).toEqual([
+      ['request', 1],
+      ['response', 1]
+    ]);
+    // turn 3 drops everything <= max seen so far; only request ordinal 2 is new.
+    expect(session.turns[2].messages.map((m) => [m.side, m.ordinal])).toEqual([
+      ['request', 2]
+    ]);
+  });
+
   it('does not load messages when no archives match', async () => {
     const db = new MultiQueryClient(() => ({ rows: [], rowCount: 0 }));
     const svc = new MyLiveSessionsService({ sql: db });


### PR DESCRIPTION
## Summary
- Claude/Codex archive turns are cumulative — turn N re-sends every prior turn's messages as context. Shipping that verbatim was quadratic: 20 turns × ~220 msgs × ~230KB ≈ 23MB per active session, which is why /v1/admin/me/live-sessions was still 13s+ even after the tool_use/tool_result strip in #205.
- SessionPanel.tsx's \`flattenSession\` already dedupes these client-side by tracking max (side, ordinal) per turn — this PR mirrors that on the server so the wire payload matches what the UI actually renders.
- Expected reduction from ~23MB → a few MB for heavy Claude sessions.

## Test plan
- [x] New unit test covering 3-turn cumulative dedup by (side, ordinal)
- [x] All 11 existing tests in myLiveSessionsService.test.ts still pass
- [ ] Verify shirtless.life watch-me-work panel still renders correctly (UI dedup is a no-op on already-deduped data)
- [ ] Confirm /v1/admin/me/live-sessions response size drops from 23MB to a few MB post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)