### PR TITLE
fix(api): strip Claude Code scaffold tags from watch-me-work feed

### DIFF
--- a/api/src/services/publicInnies/publicTextSanitizer.ts
+++ b/api/src/services/publicInnies/publicTextSanitizer.ts
@@ -23,6 +23,14 @@ const UNIX_PATH_PATTERN = /(^|[\s("'=])(~\/[^\s"'`,;)\]}]+|\/(?:Users|home|tmp|p
 const WINDOWS_PATH_PATTERN = /(^|[\s("'=])([A-Za-z]:\\(?:Users|Documents and Settings|Temp|Windows|Program Files(?: \(x86\))?)[^ \t\r\n"'`,;)\]}]*)/g;
 const JWT_TOKEN_PATTERN = /\beyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9._-]{10,}\.[A-Za-z0-9._-]{10,}\b/g;
 const PREFIXED_TOKEN_PATTERN = /\b(?:sk(?:-proj)?|rk|pk|pat|tok|ghp|gho|ghu|ghs|ghr|xox[baprs])[-_][A-Za-z0-9_-]{8,}\b/gi;
+// Claude Code injects <system-reminder> blocks into user turns ("The task tools
+// haven't been used recently...", "You have a persistent memory system at..."
+// etc). They're CLI-side scaffolding, not part of the human conversation —
+// strip them before rendering on the public watch-me-work panel. Also handles
+// the rarer <command-name>/<command-message>/<command-args> trio that surfaces
+// when a user runs a slash command.
+const SYSTEM_REMINDER_PATTERN = /<system-reminder>[\s\S]*?<\/system-reminder>\s*/gi;
+const COMMAND_TAG_PATTERN = /<(command-name|command-message|command-args|local-command-stdout|user-prompt-submit-hook)>[\s\S]*?<\/\1>\s*/gi;
 
 function capText(value: string, maxChars = TOOL_PAYLOAD_MAX_CHARS): string {
   const safeMaxChars = Number.isFinite(maxChars) ? Math.max(1, Math.floor(maxChars)) : TOOL_PAYLOAD_MAX_CHARS;
@@ -97,6 +105,12 @@ export function sanitizePublicText(input: string): string {
   }
 
   let text = input;
+
+  // Strip the CLI-injected tag blocks first so their internal auth headers,
+  // paths, etc. don't get redacted-into-place (which would leave orphan
+  // "[REDACTED_TOKEN]" lines with no surrounding context).
+  text = text.replace(SYSTEM_REMINDER_PATTERN, '');
+  text = text.replace(COMMAND_TAG_PATTERN, '');
 
   text = text.replace(AUTH_HEADER_QUOTED_PATTERN, (_match, prefix: string, _value: string, suffix: string) =>
     `${prefix}${REDACTED_CREDENTIAL}${suffix}`

--- a/api/tests/publicTextSanitizer.test.ts
+++ b/api/tests/publicTextSanitizer.test.ts
@@ -51,6 +51,40 @@ describe('publicTextSanitizer', () => {
     expect(result.length).toBeLessThanOrEqual(4_000);
   });
 
+  it('strips <system-reminder> blocks injected by the Claude Code CLI', () => {
+    const input = [
+      'help me refactor this',
+      '<system-reminder>',
+      'The task tools haven\'t been used recently. You have a persistent memory at /Users/dylan/.claude/memory',
+      '</system-reminder>',
+      'here is the code'
+    ].join('\n');
+
+    const result = sanitizePublicText(input);
+    expect(result).not.toContain('<system-reminder>');
+    expect(result).not.toContain('persistent memory');
+    expect(result).toContain('help me refactor this');
+    expect(result).toContain('here is the code');
+  });
+
+  it('strips slash-command scaffolding tags', () => {
+    const input = [
+      '<command-name>/memorize</command-name>',
+      '<command-args>use twitter api</command-args>',
+      'actual message'
+    ].join('\n');
+
+    const result = sanitizePublicText(input);
+    expect(result).not.toContain('<command-name>');
+    expect(result).not.toContain('<command-args>');
+    expect(result).toContain('actual message');
+  });
+
+  it('handles multiple reminder blocks in a single text', () => {
+    const input = '<system-reminder>one</system-reminder>between<system-reminder>two</system-reminder>end';
+    expect(sanitizePublicText(input)).toBe('betweenend');
+  });
+
   it('handles circular tool payloads without throwing', () => {
     const payload: Record<string, unknown> = {
       name: 'tool'


### PR DESCRIPTION
## Summary
- Claude Code injects \`<system-reminder>\` blocks into user turns (task-tools nudges, memory-system docs, etc). They're CLI-side scaffolding, not part of the human conversation, but they were leaking onto shirtless.life as walls of boilerplate.
- Drop them (and the \`<command-name>\`/\`<command-args>\`/\`<local-command-stdout>\`/\`<user-prompt-submit-hook>\` slash-command scaffold) up front in \`sanitizePublicText\`, before the credential/path regexes run.

## Why before redaction
If we redacted first, auth headers inside a reminder block would become orphan \`[REDACTED_TOKEN]\` lines with no surrounding context. Stripping the wrapper first lets the regexes work on the actual human content.

## Test plan
- [x] 3 new tests: system-reminder strip, command-tag strip, multiple reminders in a single text
- [x] 20/20 existing sanitizer + myLiveSessions tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)