### PR TITLE
fix(api): slice live-sessions archives to last N before loading messages

### DIFF
--- a/api/src/services/adminLive/myLiveSessionsService.ts
+++ b/api/src/services/adminLive/myLiveSessionsService.ts
@@ -122,8 +122,42 @@ export class MyLiveSessionsService {
       return emptyFeed;
     }
 
-    const archiveIds = archives.map((row) => row.id);
-    const messageRows = await this.loadMessages(archiveIds);
+    // Group archives by session and sort each bucket by started_at asc up
+    // front. Session-level metadata (startedAt, lastActivityAt, providerSet,
+    // modelSet) is computed from the full bucket so long-running sessions
+    // still show their true start time and full provider/model footprint.
+    const archivesBySessionKey = new Map<string, ArchiveRow[]>();
+    for (const row of archives) {
+      const key = sessionKeyForArchive(row);
+      const bucket = archivesBySessionKey.get(key) ?? [];
+      bucket.push(row);
+      archivesBySessionKey.set(key, bucket);
+    }
+    for (const bucket of archivesBySessionKey.values()) {
+      bucket.sort((a, b) => new Date(a.started_at).getTime() - new Date(b.started_at).getTime());
+    }
+
+    // Slice each bucket to the last N archives BEFORE calling loadMessages.
+    // The SQL dedup in loadMessages attributes each logical (side, ordinal)
+    // pair to the earliest archive that carried it. For long-running sessions
+    // where the first 100+ archives already cover every ordinal, slicing to
+    // the last 20 turns after-the-fact leaves the visible archives owning
+    // nothing — the UI renders "no transcript rows yet" even though the
+    // session is actively producing messages. Slicing first guarantees dedup
+    // happens within the displayed window, and shrinks the message query to
+    // boot.
+    const visibleArchiveIds: string[] = [];
+    const visibleBySessionKey = new Map<string, ArchiveRow[]>();
+    for (const [key, bucket] of archivesBySessionKey) {
+      const visible =
+        bucket.length > MY_LIVE_SESSIONS_MAX_TURNS_PER_SESSION
+          ? bucket.slice(-MY_LIVE_SESSIONS_MAX_TURNS_PER_SESSION)
+          : bucket;
+      visibleBySessionKey.set(key, visible);
+      for (const row of visible) visibleArchiveIds.push(row.id);
+    }
+
+    const messageRows = await this.loadMessages(visibleArchiveIds);
     const messagesByArchiveId = new Map<string, MessageRow[]>();
     for (const row of messageRows) {
       const existing = messagesByArchiveId.get(row.request_attempt_archive_id) ?? [];
@@ -132,47 +166,44 @@ export class MyLiveSessionsService {
     }
 
     const sessionsByKey = new Map<string, MyLiveSession>();
-    for (const row of archives) {
-      const sessionKey = sessionKeyForArchive(row);
-      const existing = sessionsByKey.get(sessionKey);
-      const turn = this.buildTurn(row, messagesByArchiveId.get(row.id) ?? []);
-
-      if (!existing) {
-        sessionsByKey.set(sessionKey, {
-          sessionKey,
-          apiKeyId: row.api_key_id,
-          startedAt: toIso(row.started_at),
-          lastActivityAt: toIso(row.completed_at ?? row.started_at),
-          turnCount: 1,
-          providerSet: [row.provider],
-          modelSet: [row.model],
-          turns: [turn]
-        });
-        continue;
+    for (const [sessionKey, fullBucket] of archivesBySessionKey) {
+      const visibleBucket = visibleBySessionKey.get(sessionKey) ?? fullBucket;
+      const first = fullBucket[0];
+      let startedAtMs = Infinity;
+      let lastActivityMs = -Infinity;
+      const providerSet: string[] = [];
+      const modelSet: string[] = [];
+      for (const row of fullBucket) {
+        const startMs = new Date(row.started_at).getTime();
+        const endMs = new Date(row.completed_at ?? row.started_at).getTime();
+        if (startMs < startedAtMs) startedAtMs = startMs;
+        if (endMs > lastActivityMs) lastActivityMs = endMs;
+        if (!providerSet.includes(row.provider)) providerSet.push(row.provider);
+        if (!modelSet.includes(row.model)) modelSet.push(row.model);
       }
 
-      existing.turns.push(turn);
-      existing.turnCount = existing.turns.length;
-      existing.startedAt = earlier(existing.startedAt, toIso(row.started_at));
-      existing.lastActivityAt = later(existing.lastActivityAt, toIso(row.completed_at ?? row.started_at));
-      if (!existing.providerSet.includes(row.provider)) existing.providerSet.push(row.provider);
-      if (!existing.modelSet.includes(row.model)) existing.modelSet.push(row.model);
-    }
+      const turns = visibleBucket.map((row) =>
+        this.buildTurn(row, messagesByArchiveId.get(row.id) ?? [])
+      );
 
-    // Sort turns within each session by startedAt ascending, then trim to cap.
-    for (const session of sessionsByKey.values()) {
-      session.turns.sort((left, right) => Date.parse(left.startedAt) - Date.parse(right.startedAt));
-      if (session.turns.length > MY_LIVE_SESSIONS_MAX_TURNS_PER_SESSION) {
-        session.turns = session.turns.slice(-MY_LIVE_SESSIONS_MAX_TURNS_PER_SESSION);
-        session.turnCount = session.turns.length;
-      }
       // Claude/Codex archive turns are cumulative: turn N's messages include
-      // every prior turn's messages re-sent as context. Shipping that verbatim
-      // is a quadratic blow-up (we measured 20 turns × ~220 messages × ~230KB
-      // ≈ 23MB per session). SessionPanel.tsx's flattenSession already strips
-      // these client-side by tracking max (side, ordinal) — mirror that here
-      // so the wire payload matches what the UI actually renders.
-      dedupCumulativeMessages(session.turns);
+      // every prior turn's messages re-sent as context. SessionPanel.tsx's
+      // flattenSession already strips these client-side by tracking max
+      // (side, ordinal) — mirror that here so the wire payload matches what
+      // the UI actually renders. Belt-and-suspenders for rows that slip past
+      // the SQL-side DISTINCT ON.
+      dedupCumulativeMessages(turns);
+
+      sessionsByKey.set(sessionKey, {
+        sessionKey,
+        apiKeyId: first.api_key_id,
+        startedAt: new Date(startedAtMs).toISOString(),
+        lastActivityAt: new Date(lastActivityMs).toISOString(),
+        turnCount: turns.length,
+        providerSet,
+        modelSet,
+        turns
+      });
     }
 
     const sessions = Array.from(sessionsByKey.values())
@@ -336,14 +367,6 @@ export class MyLiveSessionsService {
       messages
     };
   }
-}
-
-function earlier(a: string, b: string): string {
-  return Date.parse(a) <= Date.parse(b) ? a : b;
-}
-
-function later(a: string, b: string): string {
-  return Date.parse(a) >= Date.parse(b) ? a : b;
 }
 
 function dedupCumulativeMessages(turns: MyLiveSessionTurn[]): void {

--- a/api/tests/myLiveSessionsService.test.ts
+++ b/api/tests/myLiveSessionsService.test.ts
@@ -449,6 +449,69 @@ describe('MyLiveSessionsService.listFeed', () => {
     ]);
   });
 
+  it('slices archives to last N per session BEFORE loading messages, so ownership lands in the visible window', async () => {
+    // A long-running session with 25 archives — only the last 20 should reach
+    // loadMessages, and the session metadata should still reflect the full
+    // window (earliest start, latest completion).
+    const archives: Record<string, unknown>[] = [];
+    for (let i = 0; i < 25; i++) {
+      archives.push(
+        makeArchiveRow({
+          id: `archive_long_${i}`,
+          request_id: `req_long_${i}`,
+          openclaw_session_id: 'sess_long',
+          started_at: new Date(Date.parse('2026-04-19T00:00:00Z') + i * 60_000),
+          completed_at: new Date(Date.parse('2026-04-19T00:00:00Z') + i * 60_000 + 5_000)
+        })
+      );
+    }
+    // Each archive owns one message when loadMessages is called for it.
+    const db = new MultiQueryClient((sql, params) => {
+      if (sql.includes('from in_request_attempt_archives')) {
+        return { rows: archives, rowCount: archives.length };
+      }
+      if (sql.includes('from in_request_attempt_messages')) {
+        const ids = params[0] as string[];
+        const rows = ids.map((id) =>
+          makeMessageRow({
+            request_attempt_archive_id: id,
+            side: 'request',
+            ordinal: 0,
+            normalized_payload: { role: 'user', content: [{ type: 'text', text: id }] }
+          })
+        );
+        return { rows, rowCount: rows.length };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+    const svc = new MyLiveSessionsService({ sql: db });
+
+    const feed = await svc.listFeed({
+      apiKeyIds: ['key_mine'],
+      now: new Date('2026-04-19T02:00:00Z')
+    });
+
+    const messagesQuery = db.queries.find((q) => q.sql.includes('from in_request_attempt_messages'));
+    expect(messagesQuery).toBeDefined();
+    const loadedIds = messagesQuery!.params[0] as string[];
+    // Only the last 20 archives' IDs should have been queried.
+    expect(loadedIds).toHaveLength(20);
+    expect(loadedIds).toContain('archive_long_24');
+    expect(loadedIds).toContain('archive_long_5');
+    expect(loadedIds).not.toContain('archive_long_4');
+    expect(loadedIds).not.toContain('archive_long_0');
+
+    // Session metadata still covers the full 25-archive window.
+    const session = feed.sessions[0];
+    expect(session.sessionKey).toBe('sess_long');
+    expect(session.startedAt).toBe('2026-04-19T00:00:00.000Z');
+    expect(session.lastActivityAt).toBe('2026-04-19T00:24:05.000Z');
+    expect(session.turnCount).toBe(20);
+    expect(session.turns).toHaveLength(20);
+    expect(session.turns[0].archiveId).toBe('archive_long_5');
+    expect(session.turns[19].archiveId).toBe('archive_long_24');
+  });
+
   it('does not load messages when no archives match', async () => {
     const db = new MultiQueryClient(() => ({ rows: [], rowCount: 0 }));
     const svc = new MyLiveSessionsService({ sql: db });


### PR DESCRIPTION
## Summary
- Fix "no transcript rows yet" on long-running CLI sessions in the watch-me-work panel
- SQL \`DISTINCT ON\` was attributing every message to the earliest archive, which the 20-turn slice then dropped — leaving visible turns empty
- Now: slice per-session to last \`MAX_TURNS_PER_SESSION\` archives *before* calling \`loadMessages\`, so dedup lands within the displayed window
- Session headers (startedAt, lastActivityAt, provider/model sets) still cover the full bucket — no visible regression in metadata
- Bonus: message query shrinks further on heavy sessions

## Investigation
Observed two sessions stuck at "no transcript rows yet" in prod:

| session | total archives | deduped-owning archives | owning in last 20 |
|---|---|---|---|
| \`1af1424f\` | 346 | 127 | 0 |
| \`d73ca22f\` | 139 | 34 | 0 |

Hundreds of archives re-ship the same cumulative history, so every (side, ordinal) gets pinned to an archive outside the displayed window.

## Test plan
- [x] \`npx vitest run tests/myLiveSessionsService.test.ts\` — 12 passing (11 existing + 1 new slice-before-load case)
- [x] \`npx tsc --noEmit\` — no new errors
- [ ] After merge: confirm \`1af1424f\` and \`d73ca22f\` render real transcript rows in the watch-me-work panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)