### PR TITLE
fix(api): strip image blobs + CLI system prompts from public live-sessions feed

### DIFF
--- a/api/src/services/adminLive/myLiveSessionsService.ts
+++ b/api/src/services/adminLive/myLiveSessionsService.ts
@@ -61,6 +61,9 @@ function sessionKeyForArchive(row: ArchiveRow): string {
 // Strip content blocks the watch-me-work panel never renders:
 //   - anthropic thinking / redacted_thinking (opaque, often huge)
 //   - tool_use / tool_result (panel hides tool activity — SessionPanel.tsx)
+//   - image (base64 blobs — can be hundreds of KB each; panel doesn't render
+//     them. The `[Image #N]` reference text lives in a separate text part and
+//     is preserved.)
 // The archive normalizer either emits these at top level (`{type: "thinking"}`)
 // or wraps them (`{type: "json", value: {type: "thinking"}}`), so handle both.
 // Tool-use/result blocks are the dominant size driver — a single file-read
@@ -70,7 +73,8 @@ const HIDDEN_PART_TYPES = new Set([
   'thinking',
   'redacted_thinking',
   'tool_use',
-  'tool_result'
+  'tool_result',
+  'image'
 ]);
 
 function stripHiddenParts(payload: Record<string, unknown>): Record<string, unknown> {
@@ -306,12 +310,12 @@ export class MyLiveSessionsService {
                     with ordinality as t(part, idx)
                   where not (
                     part->>'type' in (
-                      'thinking','redacted_thinking','tool_use','tool_result'
+                      'thinking','redacted_thinking','tool_use','tool_result','image'
                     )
                     or (
                       part->>'type' = 'json'
                       and part->'value'->>'type' in (
-                        'thinking','redacted_thinking','tool_use','tool_result'
+                        'thinking','redacted_thinking','tool_use','tool_result','image'
                       )
                     )
                   )

--- a/api/src/services/publicInnies/publicTextSanitizer.ts
+++ b/api/src/services/publicInnies/publicTextSanitizer.ts
@@ -60,6 +60,20 @@ const SCAFFOLD_TAG_PATTERN = new RegExp(
 const EXTERNAL_UNTRUSTED_CONTENT_PATTERN =
   /<EXTERNAL_UNTRUSTED_CONTENT\b[^>]*>[\s\S]*?<<<END_EXTERNAL_UNTRUSTED_CONTENT[^>]*>>>\s*/gi;
 
+// Claude Code ships an `x-anthropic-billing-header: cc_version=...` line with
+// every turn. It's pure telemetry — strip it line-by-line.
+const BILLING_HEADER_PATTERN = /^x-anthropic-billing-header:[^\n]*\n?/gim;
+
+// When a coding-assistant CLI's system prompt bleeds into a visible message
+// (the archive normalizer flattens `system` + user turns together), strip from
+// the signature phrase to end-of-string. Over-strips if someone literally
+// pastes the CLI prompt into a conversation, but that's the right call for
+// a public feed. Tighten the codex signature when we have a real sample.
+const CLAUDE_CODE_SYSTEM_PROMPT_PATTERN =
+  /You are Claude Code, Anthropic's official CLI for Claude\.[\s\S]*/g;
+const CODEX_SYSTEM_PROMPT_PATTERN =
+  /You are a coding agent running in the Codex CLI[\s\S]*/gi;
+
 function capText(value: string, maxChars = TOOL_PAYLOAD_MAX_CHARS): string {
   const safeMaxChars = Number.isFinite(maxChars) ? Math.max(1, Math.floor(maxChars)) : TOOL_PAYLOAD_MAX_CHARS;
   if (value.length <= safeMaxChars) {
@@ -140,6 +154,9 @@ export function sanitizePublicText(input: string): string {
   // count drops before we run the rest of the regexes.
   text = text.replace(SCAFFOLD_TAG_PATTERN, '');
   text = text.replace(EXTERNAL_UNTRUSTED_CONTENT_PATTERN, '');
+  text = text.replace(BILLING_HEADER_PATTERN, '');
+  text = text.replace(CLAUDE_CODE_SYSTEM_PROMPT_PATTERN, '');
+  text = text.replace(CODEX_SYSTEM_PROMPT_PATTERN, '');
 
   text = text.replace(AUTH_HEADER_QUOTED_PATTERN, (_match, prefix: string, _value: string, suffix: string) =>
     `${prefix}${REDACTED_CREDENTIAL}${suffix}`

--- a/api/tests/publicTextSanitizer.test.ts
+++ b/api/tests/publicTextSanitizer.test.ts
@@ -166,6 +166,51 @@ describe('publicTextSanitizer', () => {
     expect(sanitizePublicText(input)).toBe('after');
   });
 
+  it('strips the Claude Code x-anthropic-billing-header telemetry line', () => {
+    const input = [
+      'hello',
+      'x-anthropic-billing-header: cc_version=2.1.114.eb4; cc_entrypoint=cli; cch=4b1b1;',
+      'world'
+    ].join('\n');
+
+    const result = sanitizePublicText(input);
+    expect(result).not.toContain('x-anthropic-billing-header');
+    expect(result).not.toContain('cc_version');
+    expect(result).toContain('hello');
+    expect(result).toContain('world');
+  });
+
+  it('strips the Claude Code system prompt when it leaks into a visible message', () => {
+    const input = [
+      'here is what i was asked:',
+      "You are Claude Code, Anthropic's official CLI for Claude.",
+      'You are an interactive agent that helps users with software engineering tasks.',
+      '# System',
+      '- All text you output outside of tool use is displayed to the user.',
+      '# Doing tasks',
+      'Do them carefully.'
+    ].join('\n');
+
+    const result = sanitizePublicText(input);
+    expect(result).not.toContain("You are Claude Code, Anthropic's official CLI");
+    expect(result).not.toContain('# System');
+    expect(result).not.toContain('# Doing tasks');
+    expect(result).toContain('here is what i was asked:');
+  });
+
+  it('strips a codex CLI system prompt when it leaks into a visible message', () => {
+    const input = [
+      'user ask:',
+      'You are a coding agent running in the Codex CLI.',
+      'Be terse, follow AGENTS.md, ask before running destructive commands.'
+    ].join('\n');
+
+    const result = sanitizePublicText(input);
+    expect(result).not.toContain('You are a coding agent running in the Codex CLI');
+    expect(result).not.toContain('AGENTS.md');
+    expect(result).toContain('user ask:');
+  });
+
   it('handles circular tool payloads without throwing', () => {
     const payload: Record<string, unknown> = {
       name: 'tool'


### PR DESCRIPTION
## Summary
- Add `image` to `HIDDEN_PART_TYPES` and the SQL `jsonb_agg` filter so base64 image blobs (hundreds of KB each) are dropped server-side before crossing the wire. Panel doesn't render them; `[Image #N]` text refs live in separate text parts and are preserved.
- Strip three scaffolding shapes that were leaking into visible messages when the archive normalizer flattened `system` + user turns:
  - `x-anthropic-billing-header:` telemetry line
  - Claude Code system prompt (signature `You are Claude Code, Anthropic's official CLI for Claude.` → end of text)
  - codex system prompt (signature `You are a coding agent running in the Codex CLI` → end of text; placeholder signature, tighten when we grab a real sample)

## Test plan
- [x] `npx vitest run tests/publicTextSanitizer.test.ts` — 18/18 green
- [x] `npx vitest run tests/myLiveSessionsService.test.ts` — 12/12 green
- [ ] Post-deploy: refresh innies.work watch-me-work panel, confirm image blobs + system prompt chunks are gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)