### PR TITLE
fix(api): recursive hidden-part strip + drop role=system messages

### DIFF
--- a/api/src/services/adminLive/myLiveSessionsService.ts
+++ b/api/src/services/adminLive/myLiveSessionsService.ts
@@ -77,27 +77,45 @@ const HIDDEN_PART_TYPES = new Set([
   'image'
 ]);
 
-function stripHiddenParts(payload: Record<string, unknown>): Record<string, unknown> {
-  const content = payload.content;
-  if (!Array.isArray(content)) return payload;
-
-  const filtered = content.filter((part) => {
-    if (!part || typeof part !== 'object') return true;
-    const record = part as Record<string, unknown>;
-    const type = record.type;
-    if (typeof type === 'string' && HIDDEN_PART_TYPES.has(type)) return false;
-    if (type === 'json') {
-      const inner = record.value;
-      if (inner && typeof inner === 'object') {
-        const innerType = (inner as Record<string, unknown>).type;
-        if (typeof innerType === 'string' && HIDDEN_PART_TYPES.has(innerType)) return false;
-      }
+function isHiddenPart(item: unknown): boolean {
+  if (!item || typeof item !== 'object') return false;
+  const record = item as Record<string, unknown>;
+  const type = record.type;
+  if (typeof type === 'string' && HIDDEN_PART_TYPES.has(type)) return true;
+  if (type === 'json') {
+    const inner = record.value;
+    if (inner && typeof inner === 'object') {
+      const innerType = (inner as Record<string, unknown>).type;
+      if (typeof innerType === 'string' && HIDDEN_PART_TYPES.has(innerType)) return true;
     }
-    return true;
-  });
+  }
+  return false;
+}
 
-  if (filtered.length === content.length) return payload;
-  return { ...payload, content: filtered };
+// Recursively walk the payload and drop hidden parts from ANY array, not just
+// the top-level `content`. Claude wraps image blobs inside `tool_result.content`
+// (and future providers may nest even deeper), so the filter has to be depth-
+// agnostic to actually kill the bytes.
+function stripHiddenPartsValue(value: unknown): unknown {
+  if (value == null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) {
+    const filtered: unknown[] = [];
+    for (const item of value) {
+      if (isHiddenPart(item)) continue;
+      filtered.push(stripHiddenPartsValue(item));
+    }
+    return filtered;
+  }
+  const record = value as Record<string, unknown>;
+  const result: Record<string, unknown> = {};
+  for (const [key, v] of Object.entries(record)) {
+    result[key] = stripHiddenPartsValue(v);
+  }
+  return result;
+}
+
+function stripHiddenParts(payload: Record<string, unknown>): Record<string, unknown> {
+  return stripHiddenPartsValue(payload) as Record<string, unknown>;
 }
 
 export class MyLiveSessionsService {
@@ -286,6 +304,7 @@ export class MyLiveSessionsService {
         inner join ${TABLES.requestAttemptArchives} ar
           on ar.id = rm.request_attempt_archive_id
         where rm.request_attempt_archive_id = any($1::uuid[])
+          and rm.role is distinct from 'system'
         order by
           coalesce(ar.openclaw_session_id::text, ar.id::text),
           rm.side,
@@ -337,7 +356,7 @@ export class MyLiveSessionsService {
 
   private buildTurn(archive: ArchiveRow, messageRows: MessageRow[]): MyLiveSessionTurn {
     const messages: MyLiveSessionTurnMessage[] = messageRows
-      .slice()
+      .filter((row) => row.role !== 'system')
       .sort((left, right) => {
         if (left.side !== right.side) return left.side === 'request' ? -1 : 1;
         return left.ordinal - right.ordinal;

--- a/api/tests/myLiveSessionsService.test.ts
+++ b/api/tests/myLiveSessionsService.test.ts
@@ -350,6 +350,79 @@ describe('MyLiveSessionsService.listFeed', () => {
     expect(parts[0]).toEqual({ type: 'text', text: 'hello world' });
   });
 
+  it('strips image parts nested inside tool_result content (claude shape)', async () => {
+    const archives = [makeArchiveRow({ id: 'archive_img', openclaw_session_id: 'sess_img' })];
+    const messages = [
+      makeMessageRow({
+        request_attempt_archive_id: 'archive_img',
+        side: 'request',
+        ordinal: 0,
+        role: 'user',
+        normalized_payload: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'call_img',
+              content: [
+                { type: 'image', source: { type: 'base64', data: 'iVBORw0KGgo' + 'A'.repeat(10_000) } },
+                { type: 'text', text: 'screenshot captured' }
+              ]
+            },
+            { type: 'image', source: { type: 'base64', data: 'iVBORw0KGgo' + 'B'.repeat(10_000) } },
+            { type: 'text', text: 'what do you see' }
+          ]
+        }
+      })
+    ];
+    const db = new MultiQueryClient((sql) => {
+      if (sql.includes('from in_request_attempt_archives')) return { rows: archives, rowCount: archives.length };
+      if (sql.includes('from in_request_attempt_messages')) return { rows: messages, rowCount: messages.length };
+      return { rows: [], rowCount: 0 };
+    });
+    const svc = new MyLiveSessionsService({ sql: db });
+
+    const feed = await svc.listFeed({ apiKeyIds: ['key_mine'] });
+
+    const parts = feed.sessions[0].turns[0].messages[0].normalizedPayload.content as Array<Record<string, unknown>>;
+    expect(parts).toHaveLength(1);
+    expect(parts[0]).toEqual({ type: 'text', text: 'what do you see' });
+    expect(JSON.stringify(feed)).not.toContain('iVBORw0KGgo');
+  });
+
+  it('drops messages with role=system (title generators, CLI system prompts)', async () => {
+    const archives = [makeArchiveRow({ id: 'archive_sys', openclaw_session_id: 'sess_sys' })];
+    const messages = [
+      makeMessageRow({
+        request_attempt_archive_id: 'archive_sys',
+        side: 'request',
+        ordinal: 0,
+        role: 'system',
+        normalized_payload: { role: 'system', content: [{ type: 'text', text: 'Generate a concise title...' }] }
+      }),
+      makeMessageRow({
+        request_attempt_archive_id: 'archive_sys',
+        side: 'request',
+        ordinal: 1,
+        role: 'user',
+        normalized_payload: { role: 'user', content: [{ type: 'text', text: 'the actual user question' }] }
+      })
+    ];
+    const db = new MultiQueryClient((sql) => {
+      if (sql.includes('from in_request_attempt_archives')) return { rows: archives, rowCount: archives.length };
+      if (sql.includes('from in_request_attempt_messages')) return { rows: messages, rowCount: messages.length };
+      return { rows: [], rowCount: 0 };
+    });
+    const svc = new MyLiveSessionsService({ sql: db });
+
+    const feed = await svc.listFeed({ apiKeyIds: ['key_mine'] });
+
+    const turnMessages = feed.sessions[0].turns[0].messages;
+    expect(turnMessages).toHaveLength(1);
+    expect(turnMessages[0].role).toBe('user');
+    expect(JSON.stringify(feed)).not.toContain('Generate a concise title');
+  });
+
   it('dedupes cumulative messages across turns by (side, ordinal)', async () => {
     // Claude/Codex sessions re-send the full history each turn. The panel
     // only renders newly-appended (side, ordinal) pairs, so the server


### PR DESCRIPTION
## Summary
- Images were nested inside `tool_result.content` (claude's tool-result-with-image shape), so the top-level `payload.content[]` filter never reached them. Made `stripHiddenParts` walk the whole value recursively — any array at any depth has its hidden parts dropped.
- Drop `role=system` messages entirely (SQL `is distinct from 'system'` + JS filter in `buildTurn`). Title-generator / CLI system prompts were showing up verbatim on the watch-me-work panel; signature-based regex only caught the main Claude Code prompt, not the title-gen one. Dropping the whole message at the source is clean and doesn't depend on knowing every possible system-prompt signature.

## Test plan
- [x] `npx vitest run tests/myLiveSessionsService.test.ts` — 14/14 green (2 new)
- [x] `npx vitest run tests/publicTextSanitizer.test.ts` — 18/18 green
- [ ] Post-deploy: refresh innies.work watch-me-work, confirm images + system prompt blocks are gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)