### PR TITLE
fix(api): auto-heal hung db transactions via SET LOCAL timeouts

### DIFF
--- a/api/src/repos/pgClient.ts
+++ b/api/src/repos/pgClient.ts
@@ -1,6 +1,17 @@
 import { Pool, type PoolClient } from 'pg';
 import type { SqlClient, SqlQueryResult, SqlValue, TransactionContext } from './sqlClient.js';
 
+const DEFAULT_IDLE_IN_TX_TIMEOUT_MS = 30_000;
+const DEFAULT_STATEMENT_TIMEOUT_MS = 180_000;
+
+function readPositiveIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return parsed;
+}
+
 class PgTransactionContext implements TransactionContext {
   constructor(private readonly client: PoolClient) {}
 
@@ -24,16 +35,49 @@ export class PgSqlClient implements SqlClient {
     return { rows: result.rows as T[], rowCount: result.rowCount ?? 0 };
   }
 
+  /**
+   * Run `run` inside a single BEGIN/COMMIT block, with server-side safety
+   * timeouts installed via SET LOCAL so that a hung callback cannot leak a
+   * connection from the pg pool or hold advisory locks indefinitely.
+   *
+   * - `idle_in_transaction_session_timeout` kills the backend if the tx is
+   *   idle (no query running) for longer than the configured window. This
+   *   covers the case where `run` hangs on non-db I/O (an HTTP fetch, a
+   *   promise that never settles, an orphaned request after client
+   *   disconnect).
+   * - `statement_timeout` caps any single query inside the tx.
+   *
+   * Both defaults can be overridden via env vars when a batch job legitimately
+   * needs longer (e.g. admin projectors running over large backfills).
+   */
   async transaction<T>(run: (tx: TransactionContext) => Promise<T>): Promise<T> {
+    const idleInTxTimeoutMs = readPositiveIntEnv(
+      'INNIES_DB_TX_IDLE_TIMEOUT_MS',
+      DEFAULT_IDLE_IN_TX_TIMEOUT_MS
+    );
+    const statementTimeoutMs = readPositiveIntEnv(
+      'INNIES_DB_TX_STATEMENT_TIMEOUT_MS',
+      DEFAULT_STATEMENT_TIMEOUT_MS
+    );
+
     const client = await this.pool.connect();
     try {
       await client.query('begin');
+      await client.query(`set local idle_in_transaction_session_timeout = ${idleInTxTimeoutMs}`);
+      await client.query(`set local statement_timeout = ${statementTimeoutMs}`);
       const tx = new PgTransactionContext(client);
       const result = await run(tx);
       await client.query('commit');
       return result;
     } catch (error) {
-      await client.query('rollback');
+      // Best-effort rollback; if the backend was terminated by one of the
+      // timeouts above, rollback itself may fail, and that's fine — the
+      // outer error still propagates and the client is released below.
+      try {
+        await client.query('rollback');
+      } catch {
+        // swallow; connection is about to be released / discarded
+      }
       throw error;
     } finally {
       client.release();

--- a/api/tests/pgClient.test.ts
+++ b/api/tests/pgClient.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PgSqlClient } from '../src/repos/pgClient.js';
+
+type ExecutedQuery = { sql: string; params?: unknown[] };
+
+function buildFakePool(options?: { runThrows?: unknown; connectRejects?: boolean }) {
+  const executed: ExecutedQuery[] = [];
+  const releases: Array<'release'> = [];
+
+  const client = {
+    query: vi.fn(async (sql: string, params?: unknown[]) => {
+      executed.push({ sql, params });
+      return { rows: [], rowCount: 0 };
+    }),
+    release: vi.fn(() => {
+      releases.push('release');
+    })
+  };
+
+  const pool = {
+    connect: vi.fn(async () => {
+      if (options?.connectRejects) {
+        throw new Error('connect failed');
+      }
+      return client;
+    }),
+    query: vi.fn(async (sql: string, params?: unknown[]) => {
+      executed.push({ sql, params });
+      return { rows: [], rowCount: 0 };
+    }),
+    end: vi.fn(async () => undefined)
+  };
+
+  return { pool, client, executed, releases };
+}
+
+describe('PgSqlClient.transaction', () => {
+  const originalIdle = process.env.INNIES_DB_TX_IDLE_TIMEOUT_MS;
+  const originalStmt = process.env.INNIES_DB_TX_STATEMENT_TIMEOUT_MS;
+
+  afterEach(() => {
+    if (originalIdle === undefined) {
+      delete process.env.INNIES_DB_TX_IDLE_TIMEOUT_MS;
+    } else {
+      process.env.INNIES_DB_TX_IDLE_TIMEOUT_MS = originalIdle;
+    }
+    if (originalStmt === undefined) {
+      delete process.env.INNIES_DB_TX_STATEMENT_TIMEOUT_MS;
+    } else {
+      process.env.INNIES_DB_TX_STATEMENT_TIMEOUT_MS = originalStmt;
+    }
+  });
+
+  it('installs SET LOCAL idle_in_transaction_session_timeout and statement_timeout after BEGIN', async () => {
+    delete process.env.INNIES_DB_TX_IDLE_TIMEOUT_MS;
+    delete process.env.INNIES_DB_TX_STATEMENT_TIMEOUT_MS;
+
+    const { pool, executed, releases } = buildFakePool();
+    const db = new PgSqlClient(pool as never);
+
+    await db.transaction(async () => 'ok');
+
+    expect(executed.map((q) => q.sql)).toEqual([
+      'begin',
+      'set local idle_in_transaction_session_timeout = 30000',
+      'set local statement_timeout = 180000',
+      'commit'
+    ]);
+    expect(releases).toEqual(['release']);
+  });
+
+  it('honors env overrides for both timeouts', async () => {
+    process.env.INNIES_DB_TX_IDLE_TIMEOUT_MS = '5000';
+    process.env.INNIES_DB_TX_STATEMENT_TIMEOUT_MS = '45000';
+
+    const { pool, executed } = buildFakePool();
+    const db = new PgSqlClient(pool as never);
+
+    await db.transaction(async () => 'ok');
+
+    expect(executed.map((q) => q.sql)).toContain('set local idle_in_transaction_session_timeout = 5000');
+    expect(executed.map((q) => q.sql)).toContain('set local statement_timeout = 45000');
+  });
+
+  it('falls back to defaults when env values are non-numeric or non-positive', async () => {
+    process.env.INNIES_DB_TX_IDLE_TIMEOUT_MS = 'banana';
+    process.env.INNIES_DB_TX_STATEMENT_TIMEOUT_MS = '0';
+
+    const { pool, executed } = buildFakePool();
+    const db = new PgSqlClient(pool as never);
+
+    await db.transaction(async () => 'ok');
+
+    expect(executed.map((q) => q.sql)).toContain('set local idle_in_transaction_session_timeout = 30000');
+    expect(executed.map((q) => q.sql)).toContain('set local statement_timeout = 180000');
+  });
+
+  it('rolls back and releases when the callback throws', async () => {
+    const { pool, executed, releases } = buildFakePool();
+    const db = new PgSqlClient(pool as never);
+
+    await expect(
+      db.transaction(async () => {
+        throw new Error('boom');
+      })
+    ).rejects.toThrow('boom');
+
+    expect(executed.map((q) => q.sql)).toContain('rollback');
+    expect(executed.map((q) => q.sql)).not.toContain('commit');
+    expect(releases).toEqual(['release']);
+  });
+
+  it('still releases the connection when rollback itself fails (e.g. backend already terminated by timeout)', async () => {
+    const { pool, client, releases } = buildFakePool();
+    client.query.mockImplementation(async (sql: string) => {
+      if (sql === 'rollback') {
+        throw new Error('connection terminated');
+      }
+      return { rows: [], rowCount: 0 };
+    });
+    const db = new PgSqlClient(pool as never);
+
+    await expect(
+      db.transaction(async () => {
+        throw new Error('tx body failed');
+      })
+    ).rejects.toThrow('tx body failed');
+
+    expect(releases).toEqual(['release']);
+  });
+});


### PR DESCRIPTION
## Summary
- root cause of the ~12h outage on \`innies-api.exe.xyz\`: \`PgSqlClient.transaction\` awaits \`run(tx)\` with no timeout, so a callback that never settles leaks the pg connection, holds advisory locks forever, and wedges every authed request path once the pool drains.
- this PR adds \`SET LOCAL idle_in_transaction_session_timeout\` + \`SET LOCAL statement_timeout\` to every transaction so Postgres kills its own backend on stall, which surfaces as an error, rolls back cleanly, and releases the pool connection.

## What happened in prod
Two \`refreshIfLockAvailable\` callers in \`AnalyticsDashboardSnapshotRepository\` got stuck inside \`await buildDashboardSnapshotPayload(...)\` at \`13:53 UTC\`. Evidence:
\`\`\`
pid    | state               | age             | query
-------+---------------------+-----------------+---------------------------------
386729 | idle in transaction | 12:18:02        | select pg_try_advisory_xact_lock($1, hashtext($2))
386751 | idle in transaction | 12:18:05        | select pg_try_advisory_xact_lock($1, hashtext($2))
\`\`\`
\`classid = 19772191\` = \`LOCK_NAMESPACE\` in [analyticsDashboardSnapshotRepository.ts](../blob/main/api/src/repos/analyticsDashboardSnapshotRepository.ts#L51). 12h age exactly matched the \`downstream_closed\` spate in the journal at \`Apr 23 13:53\`.

Unauthed POSTs returned fast 401 (never touch the pool); any bearer token hung indefinitely (auth path needed the pool). Mitigation was \`pg_terminate_backend(386729); pg_terminate_backend(386751);\` — traffic resumed within seconds.

## Fix
[api/src/repos/pgClient.ts](../blob/fix/pg-transaction-idle-timeout/api/src/repos/pgClient.ts):
- after \`BEGIN\`, run:
  \`\`\`sql
  SET LOCAL idle_in_transaction_session_timeout = <ms>
  SET LOCAL statement_timeout = <ms>
  \`\`\`
- defaults: 30s idle-in-tx, 180s statement. override via \`INNIES_DB_TX_IDLE_TIMEOUT_MS\` and \`INNIES_DB_TX_STATEMENT_TIMEOUT_MS\`.
- rollback is now wrapped so that if the backend was already terminated by a timeout, the rollback failure doesn't prevent \`client.release()\`.

The \`idle_in_transaction_session_timeout\` alone would have prevented this outage — it only fires when a tx is genuinely idle (no query running), so it doesn't affect healthy long-running queries.

## Why this won't break long batch jobs
- \`idle_in_transaction_session_timeout\` measures time between queries while inside a tx. Projectors that run back-to-back queries don't trip it.
- \`statement_timeout\` of 180s is higher than any query I see in the tree; batch jobs that need longer can raise it per-env.
- No caller signature changed.

## Test plan
- [x] new unit tests in [api/tests/pgClient.test.ts](../blob/fix/pg-transaction-idle-timeout/api/tests/pgClient.test.ts) — 5 cases cover: default SET LOCALs are issued after BEGIN, env overrides, bad env values fall back to defaults, rollback + release on throw, connection still released when rollback itself throws
- [x] all 75 existing tests in the six repo test files that use \`.transaction\` still pass
- [x] verified prod recovered after the \`pg_terminate_backend\` mitigation — e2e POST to \`innies-api.exe.xyz/v1/proxy/v1/responses\` now returns 200 in 1.4s

## Follow-ups (separate PRs)
- thread \`AbortSignal\` from the HTTP request through \`refreshIfLockAvailable\` → \`buildDashboardSnapshotPayload\` so client disconnect tears down background work instead of letting it run orphaned. That's the deeper fix for why \`buildPayload\` hung at all; this PR is the safety net so one hang can't ever wedge the service again.
- investigate what \`buildDashboardSnapshotPayload\` was actually waiting on at \`Apr 23 13:53\` (the Vercel UI 15s client timeout on \`/analytics\` looks related).

🤖 Generated with [Claude Code](https://claude.com/claude-code)