### PR TITLE
fix(api): apply statement_timeout + query_timeout at pg Pool level

### DIFF
--- a/api/src/repos/pgClient.ts
+++ b/api/src/repos/pgClient.ts
@@ -3,6 +3,10 @@ import type { SqlClient, SqlQueryResult, SqlValue, TransactionContext } from './
 
 const DEFAULT_IDLE_IN_TX_TIMEOUT_MS = 30_000;
 const DEFAULT_STATEMENT_TIMEOUT_MS = 180_000;
+const DEFAULT_POOL_STATEMENT_TIMEOUT_MS = 60_000;
+const DEFAULT_POOL_QUERY_TIMEOUT_MS = 65_000;
+const DEFAULT_POOL_IDLE_IN_TX_TIMEOUT_MS = 30_000;
+const DEFAULT_POOL_MAX = 20;
 
 function readPositiveIntEnv(name: string, fallback: number): number {
   const raw = process.env[name];
@@ -89,7 +93,50 @@ export class PgSqlClient implements SqlClient {
   }
 }
 
+/**
+ * Build a pg pool with safety timeouts applied at the connection level.
+ *
+ * Non-transactional queries (`pool.query` via `PgSqlClient.query`) do NOT go
+ * through `PgSqlClient.transaction`, so the SET LOCAL timeouts installed
+ * there don't protect them. Without a server-side `statement_timeout` on the
+ * pool, a single hung `pool.query()` waits forever — which is what wedged
+ * `buildDashboardSnapshotPayload` on 2026-04-23 when its 7 parallel
+ * `Promise.all` reads stalled on a saturated pool.
+ *
+ * Defaults:
+ * - `statement_timeout` 60s — caps any single query server-side. Bigger than
+ *   observed hot-window rollups (dashboard window=1m worst case ~8.5s) but
+ *   tight enough to kill true hangs.
+ * - `query_timeout` 65s — client-side cancel, 5s after statement_timeout so
+ *   pg-node aborts the query if the server somehow doesn't.
+ * - `idle_in_transaction_session_timeout` 30s — same scope and reasoning as
+ *   the SET LOCAL fallback in `transaction()`, applied here so it also
+ *   covers any caller that opens a tx without going through our wrapper
+ *   (e.g. direct `pool.connect()` use, should any ever appear).
+ *
+ * All three are overridable per-env so batch backfills can opt out.
+ */
 export function buildPgClient(connectionString: string): PgSqlClient {
-  const pool = new Pool({ connectionString, max: 20 });
+  const poolMax = readPositiveIntEnv('INNIES_DB_POOL_MAX', DEFAULT_POOL_MAX);
+  const statementTimeoutMs = readPositiveIntEnv(
+    'INNIES_DB_POOL_STATEMENT_TIMEOUT_MS',
+    DEFAULT_POOL_STATEMENT_TIMEOUT_MS
+  );
+  const queryTimeoutMs = readPositiveIntEnv(
+    'INNIES_DB_POOL_QUERY_TIMEOUT_MS',
+    DEFAULT_POOL_QUERY_TIMEOUT_MS
+  );
+  const idleInTxTimeoutMs = readPositiveIntEnv(
+    'INNIES_DB_POOL_IDLE_IN_TX_TIMEOUT_MS',
+    DEFAULT_POOL_IDLE_IN_TX_TIMEOUT_MS
+  );
+
+  const pool = new Pool({
+    connectionString,
+    max: poolMax,
+    statement_timeout: statementTimeoutMs,
+    query_timeout: queryTimeoutMs,
+    idle_in_transaction_session_timeout: idleInTxTimeoutMs
+  });
   return new PgSqlClient(pool);
 }

--- a/api/tests/pgClient.test.ts
+++ b/api/tests/pgClient.test.ts
@@ -1,5 +1,29 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { PgSqlClient } from '../src/repos/pgClient.js';
+import { PgSqlClient, buildPgClient } from '../src/repos/pgClient.js';
+
+const poolConstructorCalls: Array<Record<string, unknown>> = [];
+
+vi.mock('pg', () => {
+  class FakePool {
+    constructor(options: Record<string, unknown>) {
+      poolConstructorCalls.push(options);
+    }
+    async connect() {
+      return {
+        query: async () => ({ rows: [], rowCount: 0 }),
+        release: () => undefined
+      };
+    }
+    async query() {
+      return { rows: [], rowCount: 0 };
+    }
+    async end() {
+      return undefined;
+    }
+  }
+
+  return { Pool: FakePool };
+});
 
 type ExecutedQuery = { sql: string; params?: unknown[] };
 
@@ -127,5 +151,89 @@ describe('PgSqlClient.transaction', () => {
     ).rejects.toThrow('tx body failed');
 
     expect(releases).toEqual(['release']);
+  });
+});
+
+describe('buildPgClient', () => {
+  const envKeys = [
+    'INNIES_DB_POOL_MAX',
+    'INNIES_DB_POOL_STATEMENT_TIMEOUT_MS',
+    'INNIES_DB_POOL_QUERY_TIMEOUT_MS',
+    'INNIES_DB_POOL_IDLE_IN_TX_TIMEOUT_MS'
+  ] as const;
+  const originals: Partial<Record<(typeof envKeys)[number], string | undefined>> = {};
+
+  for (const key of envKeys) {
+    originals[key] = process.env[key];
+  }
+
+  afterEach(() => {
+    poolConstructorCalls.length = 0;
+    for (const key of envKeys) {
+      if (originals[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = originals[key];
+      }
+    }
+  });
+
+  it('constructs the Pool with server-side safety timeouts by default', () => {
+    for (const key of envKeys) delete process.env[key];
+
+    buildPgClient('postgres://example/db');
+
+    expect(poolConstructorCalls).toHaveLength(1);
+    expect(poolConstructorCalls[0]).toMatchObject({
+      connectionString: 'postgres://example/db',
+      max: 20,
+      statement_timeout: 60_000,
+      query_timeout: 65_000,
+      idle_in_transaction_session_timeout: 30_000
+    });
+  });
+
+  it('query_timeout is strictly greater than statement_timeout so the server-side cap fires first', () => {
+    for (const key of envKeys) delete process.env[key];
+
+    buildPgClient('postgres://example/db');
+
+    const opts = poolConstructorCalls[0] as {
+      statement_timeout: number;
+      query_timeout: number;
+    };
+    expect(opts.query_timeout).toBeGreaterThan(opts.statement_timeout);
+  });
+
+  it('honors env overrides for all four pool knobs', () => {
+    process.env.INNIES_DB_POOL_MAX = '7';
+    process.env.INNIES_DB_POOL_STATEMENT_TIMEOUT_MS = '15000';
+    process.env.INNIES_DB_POOL_QUERY_TIMEOUT_MS = '16000';
+    process.env.INNIES_DB_POOL_IDLE_IN_TX_TIMEOUT_MS = '9000';
+
+    buildPgClient('postgres://example/db');
+
+    expect(poolConstructorCalls[0]).toMatchObject({
+      max: 7,
+      statement_timeout: 15_000,
+      query_timeout: 16_000,
+      idle_in_transaction_session_timeout: 9_000
+    });
+  });
+
+  it('falls back to defaults when env values are non-positive or non-numeric', () => {
+    process.env.INNIES_DB_POOL_MAX = '-3';
+    process.env.INNIES_DB_POOL_STATEMENT_TIMEOUT_MS = 'banana';
+    process.env.INNIES_DB_POOL_QUERY_TIMEOUT_MS = '0';
+    process.env.INNIES_DB_POOL_IDLE_IN_TX_TIMEOUT_MS = '';
+
+    buildPgClient('postgres://example/db');
+
+    expect(poolConstructorCalls[0]).toMatchObject({
+      max: 20,
+      statement_timeout: 60_000,
+      query_timeout: 65_000,
+      idle_in_transaction_session_timeout: 30_000
+    });
   });
 });


### PR DESCRIPTION
**Re-opened from #216 — original PR was auto-closed when its base branch \`fix/pg-transaction-idle-timeout\` was deleted after #214 merged. Same code, rebased on main.**

---

## Summary
- stacks on now-merged #214. that PR protects queries inside \`PgSqlClient.transaction(...)\` with \`SET LOCAL\` timeouts. this PR extends the same self-healing guarantee to non-transactional \`pool.query()\` calls by installing timeouts on the pg Pool constructor itself.
- closes the third bug surfaced by the 2026-04-23 post-mortem: a stalled \`pool.query()\` inside \`buildDashboardSnapshotPayload\`'s \`Promise.all\` held the outer tx open for 12h even though #214 would have eventually killed the tx, because the tx's \`run(tx)\` was awaiting those pool.query promises indefinitely.

## Fix
\`\`\`ts
new Pool({
  connectionString,
  max: 20,
  statement_timeout: 60_000,          // server-side cap
  query_timeout: 65_000,              // client-side cancel, fires 5s after server
  idle_in_transaction_session_timeout: 30_000
})
\`\`\`
Env overrides: \`INNIES_DB_POOL_MAX\`, \`INNIES_DB_POOL_STATEMENT_TIMEOUT_MS\`, \`INNIES_DB_POOL_QUERY_TIMEOUT_MS\`, \`INNIES_DB_POOL_IDLE_IN_TX_TIMEOUT_MS\`.

## Why 60s is safe as a default
Measured worst-case rollups:

| endpoint | window=1m |
|---|---|
| \`/v1/admin/analytics/system\` | **8.5s** |
| \`/v1/admin/analytics/tokens/health\` | 5.3s |
| \`/v1/admin/analytics/buyers\` | 3.2s |

60s gives 7x headroom. Batch backfill jobs can raise per-env.

## Test plan
- [x] 4 new unit tests cover: defaults, \`query_timeout > statement_timeout\` invariant, env overrides, bad env values fall back
- [x] 9/9 tests pass; 67 adjacent tests unchanged
- [x] no new tsc errors vs main baseline

## Follow-ups
- #215 (AbortSignal plumbing)
- #217 (window=1m query perf)

🤖 Generated with [Claude Code](https://claude.com/claude-code)